### PR TITLE
ENG-14

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -48,6 +48,7 @@ import type * as documentEngine_templateVersions from "../documentEngine/templat
 import type * as documentEngine_templates from "../documentEngine/templates.js";
 import type * as documentEngine_validators from "../documentEngine/validators.js";
 import type * as engine_auditJournal from "../engine/auditJournal.js";
+import type * as engine_effects_obligation from "../engine/effects/obligation.js";
 import type * as engine_effects_onboarding from "../engine/effects/onboarding.js";
 import type * as engine_effects_registry from "../engine/effects/registry.js";
 import type * as engine_effects_workosProvisioning from "../engine/effects/workosProvisioning.js";
@@ -124,6 +125,7 @@ declare const fullApi: ApiFromModules<{
   "documentEngine/templates": typeof documentEngine_templates;
   "documentEngine/validators": typeof documentEngine_validators;
   "engine/auditJournal": typeof engine_auditJournal;
+  "engine/effects/obligation": typeof engine_effects_obligation;
   "engine/effects/onboarding": typeof engine_effects_onboarding;
   "engine/effects/registry": typeof engine_effects_registry;
   "engine/effects/workosProvisioning": typeof engine_effects_workosProvisioning;

--- a/convex/engine/effects/obligation.ts
+++ b/convex/engine/effects/obligation.ts
@@ -1,0 +1,28 @@
+import { internalMutation } from "../../_generated/server";
+import { effectPayloadValidator } from "../validators";
+
+/**
+ * Stub: emits an event when an obligation becomes overdue.
+ * Will be replaced with cross-entity dispatch logic in a future milestone.
+ */
+export const emitObligationOverdue = internalMutation({
+	args: effectPayloadValidator,
+	handler: async (_ctx, args) => {
+		console.info(
+			`[stub] emitObligationOverdue: entity=${args.entityId}, event=${args.eventType}`
+		);
+	},
+});
+
+/**
+ * Stub: emits an event when an obligation is settled.
+ * Will be replaced with cross-entity dispatch logic in a future milestone.
+ */
+export const emitObligationSettled = internalMutation({
+	args: effectPayloadValidator,
+	handler: async (_ctx, args) => {
+		console.info(
+			`[stub] emitObligationSettled: entity=${args.entityId}, event=${args.eventType}`
+		);
+	},
+});

--- a/convex/engine/effects/onboarding.ts
+++ b/convex/engine/effects/onboarding.ts
@@ -1,8 +1,8 @@
-import { v } from "convex/values";
 import { internal } from "../../_generated/api";
 import type { Id } from "../../_generated/dataModel";
 import { type ActionCtx, internalAction } from "../../_generated/server";
 import { auditLog } from "../../auditLog";
+import { effectPayloadValidator } from "../validators";
 import { getWorkosProvisioning } from "./workosProvisioning";
 
 async function completeRoleAssignmentProcessing(
@@ -42,7 +42,7 @@ async function resolveTargetOrganizationId(
 	if (requestedRole === "broker" && !resolvedTargetOrganizationId) {
 		if (processingStatus === "in_progress") {
 			throw new Error(
-				`[assignRoleToUser] Broker provisioning already started for request ${requestId}`
+				`[assignRole] Broker provisioning already started for request ${requestId}`
 			);
 		}
 		const orgName = `${user.firstName} ${user.lastName}'s Brokerage`;
@@ -59,7 +59,7 @@ async function resolveTargetOrganizationId(
 
 	if (!resolvedTargetOrganizationId) {
 		throw new Error(
-			`[assignRoleToUser] No target org for request ${requestId} (role: ${requestedRole}, journal: ${journalEntryId})`
+			`[assignRole] No target org for request ${requestId} (role: ${requestedRole}, journal: ${journalEntryId})`
 		);
 	}
 
@@ -92,10 +92,49 @@ async function ensureOrganizationMembership(
 			throw membershipError;
 		}
 		console.info(
-			`[assignRoleToUser] Membership already exists for ${user.authId} in ${targetOrganizationId}`
+			`[assignRole] Membership already exists for ${user.authId} in ${targetOrganizationId}`
 		);
 	}
 }
+
+/**
+ * Stub: notifies the applicant that their onboarding request was approved.
+ * Will be replaced with real email/notification logic in a future milestone.
+ */
+export const notifyApplicantApproved = internalAction({
+	args: effectPayloadValidator,
+	handler: async (_ctx, args) => {
+		console.info(
+			`[stub] notifyApplicantApproved: entity=${args.entityId}, event=${args.eventType}`
+		);
+	},
+});
+
+/**
+ * Stub: notifies the applicant that their onboarding request was rejected.
+ * Will be replaced with real email/notification logic in a future milestone.
+ */
+export const notifyApplicantRejected = internalAction({
+	args: effectPayloadValidator,
+	handler: async (_ctx, args) => {
+		console.info(
+			`[stub] notifyApplicantRejected: entity=${args.entityId}, event=${args.eventType}`
+		);
+	},
+});
+
+/**
+ * Stub: notifies admins that a new onboarding request has been submitted.
+ * Will be replaced with real email/notification logic in a future milestone.
+ */
+export const notifyAdminNewRequest = internalAction({
+	args: effectPayloadValidator,
+	handler: async (_ctx, args) => {
+		console.info(
+			`[stub] notifyAdminNewRequest: entity=${args.entityId}, event=${args.eventType}`
+		);
+	},
+});
 
 /**
  * Side effect triggered by the APPROVE transition.
@@ -103,13 +142,8 @@ async function ensureOrganizationMembership(
  * On success, sends ASSIGN_ROLE to complete the lifecycle.
  * On failure, request stays in `approved` — Convex retries automatically.
  */
-export const assignRoleToUser = internalAction({
-	args: {
-		entityId: v.string(),
-		journalEntryId: v.string(),
-		effectName: v.string(),
-		params: v.optional(v.object({})),
-	},
+export const assignRole = internalAction({
+	args: effectPayloadValidator,
 	handler: async (ctx, args) => {
 		// 1. Load the request
 		const request = await ctx.runQuery(
@@ -117,7 +151,7 @@ export const assignRoleToUser = internalAction({
 			{ id: args.entityId as Id<"onboardingRequests"> }
 		);
 		if (!request) {
-			throw new Error(`[assignRoleToUser] Request not found: ${args.entityId}`);
+			throw new Error(`[assignRole] Request not found: ${args.entityId}`);
 		}
 
 		// 2. Load the user
@@ -126,7 +160,7 @@ export const assignRoleToUser = internalAction({
 		});
 		if (!user) {
 			throw new Error(
-				`[assignRoleToUser] User not found for request ${args.entityId}: ${request.userId}`
+				`[assignRole] User not found for request ${args.entityId}: ${request.userId}`
 			);
 		}
 
@@ -203,7 +237,7 @@ export const assignRoleToUser = internalAction({
 
 			if (!transitionResult.success) {
 				throw new Error(
-					`[assignRoleToUser] ASSIGN_ROLE transition failed for ${args.entityId}: ${transitionResult.reason}`
+					`[assignRole] ASSIGN_ROLE transition failed for ${args.entityId}: ${transitionResult.reason}`
 				);
 			}
 
@@ -213,13 +247,13 @@ export const assignRoleToUser = internalAction({
 				args.journalEntryId
 			);
 			console.info(
-				`[assignRoleToUser] Assigned ${request.requestedRole} to ${user.authId} in ${targetOrgId}`
+				`[assignRole] Assigned ${request.requestedRole} to ${user.authId} in ${targetOrgId}`
 			);
 		} catch (error) {
 			// On failure — log but do NOT transition.
 			// Request stays in `approved`. Convex retries automatically.
 			console.error(
-				`[assignRoleToUser] Failed for request ${args.entityId}: ${
+				`[assignRole] Failed for request ${args.entityId}: ${
 					error instanceof Error ? error.message : String(error)
 				}`
 			);

--- a/convex/engine/effects/registry.ts
+++ b/convex/engine/effects/registry.ts
@@ -7,10 +7,17 @@ import { internal } from "../../_generated/api";
  */
 export const effectRegistry: Record<
 	string,
-	FunctionReference<"action", "internal">
+	FunctionReference<"mutation" | "action", "internal">
 > = {
-	// onboardingRequest machine effects
-	assignRole: internal.engine.effects.onboarding.assignRoleToUser,
-	// notifyApplicantApproved — TODO: implement notification effect
-	// notifyApplicantRejected — TODO: implement notification effect
+	assignRole: internal.engine.effects.onboarding.assignRole,
+	notifyApplicantApproved:
+		internal.engine.effects.onboarding.notifyApplicantApproved,
+	notifyApplicantRejected:
+		internal.engine.effects.onboarding.notifyApplicantRejected,
+	notifyAdminNewRequest:
+		internal.engine.effects.onboarding.notifyAdminNewRequest,
+	emitObligationOverdue:
+		internal.engine.effects.obligation.emitObligationOverdue,
+	emitObligationSettled:
+		internal.engine.effects.obligation.emitObligationSettled,
 };

--- a/convex/engine/machines/onboardingRequest.machine.ts
+++ b/convex/engine/machines/onboardingRequest.machine.ts
@@ -9,8 +9,8 @@ export const onboardingRequestMachine = setup({
 			| { type: "ASSIGN_ROLE" },
 	},
 	actions: {
-		// No-op stubs: the Transition Engine reads action names from the machine
-		// config and schedules the matching effect from the Effect Registry.
+		// No-op: the transition engine reads the action name from the machine config
+		// and schedules the matching effect from the effect registry.
 		notifyApplicantApproved: () => {
 			/* resolved by GT effect registry */
 		},

--- a/convex/engine/transition.ts
+++ b/convex/engine/transition.ts
@@ -80,7 +80,11 @@ function extractScheduledEffects(
 async function scheduleEffects(
 	ctx: MutationCtx,
 	entityId: string,
+	entityType: EntityType,
+	eventType: string,
 	journalEntryId: string,
+	source: CommandSource,
+	payload: Record<string, unknown> | undefined,
 	scheduledEffects: ScheduledEffectDescriptor[]
 ): Promise<string[]> {
 	const effectNames: string[] = [];
@@ -92,11 +96,18 @@ async function scheduleEffects(
 		if (handler) {
 			await ctx.scheduler.runAfter(0, handler, {
 				entityId,
+				entityType,
+				eventType,
 				journalEntryId,
 				effectName: actionDescriptor.actionType,
-				params: actionDescriptor.params,
+				payload: actionDescriptor.params ?? payload,
+				source,
 			});
 			effectNames.push(actionDescriptor.actionType);
+		} else {
+			console.warn(
+				`[GT Effect Scheduler] No handler registered for effect "${actionDescriptor.actionType}". Skipping.`
+			);
 		}
 	}
 	return effectNames;
@@ -237,7 +248,11 @@ export async function transitionEntity(
 		const effectNames = await scheduleEffects(
 			ctx,
 			entityId,
+			entityType,
+			eventType,
 			journalEntryId,
+			resolvedSource,
+			payload,
 			scheduledEffects
 		);
 		await auditLog.log(ctx, {
@@ -315,7 +330,11 @@ export async function transitionEntity(
 	const effectNames = await scheduleEffects(
 		ctx,
 		entityId,
+		entityType,
+		eventType,
 		journalEntryId,
+		resolvedSource,
+		payload,
 		scheduledEffects
 	);
 

--- a/convex/engine/types.ts
+++ b/convex/engine/types.ts
@@ -52,6 +52,17 @@ export interface TransitionResult {
 	success: boolean;
 }
 
+// ── Effect Payload ──────────────────────────────────────────────────
+export interface EffectPayload {
+	effectName: string;
+	entityId: string;
+	entityType: EntityType;
+	eventType: string;
+	journalEntryId: string;
+	payload?: Record<string, unknown>;
+	source: CommandSource;
+}
+
 // ── Audit Journal Entry ─────────────────────────────────────────────
 // Mirrors the auditJournal table in schema.ts — source fields flattened for indexability
 export interface AuditJournalEntry {

--- a/convex/engine/validators.ts
+++ b/convex/engine/validators.ts
@@ -47,3 +47,13 @@ export const commandArgsValidator = {
 	payload: v.optional(v.any()),
 	source: sourceValidator,
 };
+
+export const effectPayloadValidator = {
+	entityId: v.string(),
+	entityType: entityTypeValidator,
+	eventType: v.string(),
+	journalEntryId: v.string(),
+	effectName: v.string(),
+	payload: v.optional(v.any()),
+	source: sourceValidator,
+};

--- a/specs/ENG-14/chunks/chunk-01-types-and-effects/context.md
+++ b/specs/ENG-14/chunks/chunk-01-types-and-effects/context.md
@@ -1,0 +1,253 @@
+# Chunk 1 Context: Types, Effects & Registry
+
+## Goal
+Define the `EffectPayload` interface and validators, rename onboarding machine actions to match spec, create all effect stubs, and populate the effect registry.
+
+## Resolved Design Decisions
+1. **Rename `assignRoleToUser` → `assignRole`** and add `notifyApplicantApproved`/`notifyApplicantRejected`/`notifyAdminNewRequest` as separate stubs.
+2. **`emitObligationOverdue`** — obligation domain only, no mortgage registry entry.
+3. **`EffectPayload`** lives in `convex/engine/types.ts` with all other GT types.
+
+---
+
+## T-001: EffectPayload Interface
+
+Add this interface to `convex/engine/types.ts` after the `TransitionResult` interface:
+
+```typescript
+export interface EffectPayload {
+  entityId: string;
+  entityType: EntityType;
+  eventType: string;
+  journalEntryId: string;
+  effectName: string;
+  payload?: Record<string, unknown>;
+  source: CommandSource;
+}
+```
+
+This uses the existing `EntityType` and `CommandSource` types already defined in that file.
+
+## T-002: effectPayloadValidator
+
+Add to `convex/engine/validators.ts`:
+
+```typescript
+export const effectPayloadValidator = {
+  entityId: v.string(),
+  entityType: entityTypeValidator,
+  eventType: v.string(),
+  journalEntryId: v.string(),
+  effectName: v.string(),
+  payload: v.optional(v.any()),
+  source: sourceValidator,
+};
+```
+
+Both `entityTypeValidator` and `sourceValidator` already exist in this file.
+
+## T-003: Update Onboarding Machine Action Names
+
+File: `convex/engine/machines/onboardingRequest.machine.ts`
+
+The current machine declares `assignRoleToUser` on APPROVE. The spec declares different actions:
+
+**Current machine (WRONG):**
+```typescript
+states: {
+  pending_review: {
+    on: {
+      APPROVE: {
+        target: "approved",
+        actions: ["assignRoleToUser"],
+      },
+      REJECT: { target: "rejected" },
+    },
+  },
+  approved: {
+    on: { ASSIGN_ROLE: { target: "role_assigned" } },
+  },
+  // ...
+}
+```
+
+**Spec machine (TARGET):**
+```typescript
+states: {
+  pending_review: {
+    on: {
+      APPROVE: {
+        target: "approved",
+        actions: ["notifyApplicantApproved"],
+      },
+      REJECT: {
+        target: "rejected",
+        actions: ["notifyApplicantRejected"],
+      },
+    },
+  },
+  approved: {
+    on: {
+      ASSIGN_ROLE: {
+        target: "role_assigned",
+        actions: ["assignRole"],
+      },
+    },
+  },
+  rejected: { type: "final" },
+  role_assigned: { type: "final" },
+}
+```
+
+Key changes:
+- APPROVE action: `assignRoleToUser` → `notifyApplicantApproved`
+- REJECT: add `actions: ["notifyApplicantRejected"]`
+- ASSIGN_ROLE: add `actions: ["assignRole"]`
+
+Also update the `actions` map in the `setup()` call to declare all three:
+```typescript
+actions: {
+  notifyApplicantApproved: () => { /* resolved by GT effect registry */ },
+  notifyApplicantRejected: () => { /* resolved by GT effect registry */ },
+  assignRole: () => { /* resolved by GT effect registry */ },
+},
+```
+
+## T-004: Rename assignRoleToUser → assignRole
+
+File: `convex/engine/effects/onboarding.ts`
+
+The existing `assignRoleToUser` export must be renamed to `assignRole`. This is a substantial internalAction with real WorkOS provisioning logic — preserve all handler logic, only change:
+
+1. Export name: `assignRoleToUser` → `assignRole`
+2. Args: replace current ad-hoc args with `effectPayloadValidator`
+   - Current: `{ entityId: v.string(), journalEntryId: v.string(), effectName: v.string(), params: v.optional(v.object({})) }`
+   - New: uses `effectPayloadValidator` (which has entityId, entityType, eventType, journalEntryId, effectName, payload, source)
+3. Internal references to `args.entityId` and `args.journalEntryId` stay the same since those fields are in both schemas.
+4. `args.params` references should become `args.payload` (but the current handler doesn't actually use params, so this is a no-op for the handler logic).
+
+**CRITICAL:** The handler logic (WorkOS provisioning, audit logging, transition calling) must be completely preserved. Only the function name and args schema change.
+
+Also update all console.log/error messages that reference `[assignRoleToUser]` to `[assignRole]`.
+
+## T-005: Add Notification Stub Effects
+
+Add to `convex/engine/effects/onboarding.ts` (same file as assignRole):
+
+```typescript
+export const notifyApplicantApproved = internalAction({
+  args: effectPayloadValidator,
+  handler: async (_ctx, args) => {
+    console.info(
+      `[stub] notifyApplicantApproved: entity=${args.entityId}, event=${args.eventType}`
+    );
+  },
+});
+
+export const notifyApplicantRejected = internalAction({
+  args: effectPayloadValidator,
+  handler: async (_ctx, args) => {
+    console.info(
+      `[stub] notifyApplicantRejected: entity=${args.entityId}, event=${args.eventType}`
+    );
+  },
+});
+
+export const notifyAdminNewRequest = internalAction({
+  args: effectPayloadValidator,
+  handler: async (_ctx, args) => {
+    console.info(
+      `[stub] notifyAdminNewRequest: entity=${args.entityId}, event=${args.eventType}`
+    );
+  },
+});
+```
+
+Import `effectPayloadValidator` from `../validators`.
+
+## T-006: Create Obligation Stub Effects
+
+Create new file: `convex/engine/effects/obligation.ts`
+
+```typescript
+import { internalMutation } from "../../_generated/server";
+import { effectPayloadValidator } from "../validators";
+
+/**
+ * Fires OBLIGATION_OVERDUE event at the parent mortgage.
+ * Stub: logs intent. ENG-19 replaces with real cross-entity dispatch.
+ */
+export const emitObligationOverdue = internalMutation({
+  args: effectPayloadValidator,
+  handler: async (_ctx, args) => {
+    console.info(
+      `[stub] emitObligationOverdue: entity=${args.entityId}, event=${args.eventType}`
+    );
+  },
+});
+
+/**
+ * Fires PAYMENT_CONFIRMED event at the parent mortgage.
+ * Stub: logs intent. ENG-19 replaces with real cross-entity dispatch.
+ */
+export const emitObligationSettled = internalMutation({
+  args: effectPayloadValidator,
+  handler: async (_ctx, args) => {
+    console.info(
+      `[stub] emitObligationSettled: entity=${args.entityId}, event=${args.eventType}`
+    );
+  },
+});
+```
+
+Note: These are `internalMutation` (not `internalAction`) because cross-entity effects will need to read/write the database when dispatching commands to the transition engine.
+
+## T-007: Update Effect Registry
+
+File: `convex/engine/effects/registry.ts`
+
+Replace the entire file content:
+
+```typescript
+import type { FunctionReference } from "convex/server";
+import { internal } from "../../_generated/api";
+
+/**
+ * Maps action names declared in XState machines to Convex internal function references.
+ * Phase 1: static registry. Runtime registration is a future concern.
+ */
+export const effectRegistry: Record<
+  string,
+  FunctionReference<"mutation" | "action", "internal">
+> = {
+  // Onboarding effects
+  assignRole: internal.engine.effects.onboarding.assignRole,
+  notifyApplicantApproved: internal.engine.effects.onboarding.notifyApplicantApproved,
+  notifyApplicantRejected: internal.engine.effects.onboarding.notifyApplicantRejected,
+  notifyAdminNewRequest: internal.engine.effects.onboarding.notifyAdminNewRequest,
+  // Obligation effects
+  emitObligationOverdue: internal.engine.effects.obligation.emitObligationOverdue,
+  emitObligationSettled: internal.engine.effects.obligation.emitObligationSettled,
+};
+```
+
+Key changes from current:
+- Type widened from `FunctionReference<"action", "internal">` to `FunctionReference<"mutation" | "action", "internal">`
+- `assignRoleToUser` renamed to `assignRole`
+- Added 5 new entries (3 onboarding notifications + 2 obligation stubs)
+
+---
+
+## Files to Read Before Starting
+- `convex/engine/types.ts` — where EffectPayload goes
+- `convex/engine/validators.ts` — where effectPayloadValidator goes
+- `convex/engine/machines/onboardingRequest.machine.ts` — machine to update
+- `convex/engine/effects/onboarding.ts` — effect to rename + stubs to add
+- `convex/engine/effects/registry.ts` — registry to update
+
+## Files to Create
+- `convex/engine/effects/obligation.ts` — new stub effects
+
+## Cross-References
+- The `transitionMutation` at `convex/engine/transitionMutation.ts` calls `internal.engine.transitionMutation.transitionMutation` — the existing `assignRoleToUser` handler calls this. After rename to `assignRole`, ensure that import still resolves.
+- The test at `convex/engine/machines/__tests__/onboardingRequest.machine.test.ts` may reference `assignRoleToUser` — update references if found.

--- a/specs/ENG-14/chunks/chunk-01-types-and-effects/tasks.md
+++ b/specs/ENG-14/chunks/chunk-01-types-and-effects/tasks.md
@@ -1,0 +1,9 @@
+# Chunk 1: Types, Effects & Registry
+
+- [ ] T-001: Add `EffectPayload` interface to `convex/engine/types.ts`
+- [ ] T-002: Add `effectPayloadValidator` to `convex/engine/validators.ts`
+- [ ] T-003: Update onboarding machine action names to match spec (`notifyApplicantApproved`, `notifyApplicantRejected`, `assignRole`)
+- [ ] T-004: Rename existing `assignRoleToUser` effect to `assignRole` and update args to use `effectPayloadValidator`
+- [ ] T-005: Add notification stub effects (`notifyApplicantApproved`, `notifyApplicantRejected`, `notifyAdminNewRequest`) to `convex/engine/effects/onboarding.ts`
+- [ ] T-006: Create `convex/engine/effects/obligation.ts` with stub effects (`emitObligationOverdue`, `emitObligationSettled`)
+- [ ] T-007: Widen registry type to `"mutation" | "action"` and add all effect entries to `convex/engine/effects/registry.ts`

--- a/specs/ENG-14/chunks/chunk-02-engine-integration/context.md
+++ b/specs/ENG-14/chunks/chunk-02-engine-integration/context.md
@@ -1,0 +1,135 @@
+# Chunk 2 Context: Engine Integration & Quality Gate
+
+## Goal
+Wire the updated effect registry into the transition engine by adding `console.warn` for missing effects, passing the full `EffectPayload` to scheduled effects, updating tests, and ensuring all quality checks pass.
+
+## Prerequisites (completed by Chunk 1)
+- `EffectPayload` interface exists in `convex/engine/types.ts`
+- `effectPayloadValidator` exists in `convex/engine/validators.ts`
+- `effectRegistry` updated with all entries and widened type
+- Onboarding machine actions renamed (notifyApplicantApproved, notifyApplicantRejected, assignRole)
+- `assignRole` effect exists (renamed from assignRoleToUser)
+- Notification stubs exist in onboarding.ts
+- Obligation stubs exist in obligation.ts
+
+---
+
+## T-008: Add console.warn for Missing Effects
+
+File: `convex/engine/transition.ts`
+
+The current `scheduleEffects` function silently skips missing effects. Add a `console.warn`:
+
+**Current code (in `scheduleEffects`):**
+```typescript
+const handler = effectRegistry[actionDescriptor.actionType];
+if (handler) {
+  await ctx.scheduler.runAfter(0, handler, {
+    entityId,
+    journalEntryId,
+    effectName: actionDescriptor.actionType,
+    params: actionDescriptor.params,
+  });
+  effectNames.push(actionDescriptor.actionType);
+}
+```
+
+**Updated code:**
+```typescript
+const handler = effectRegistry[actionDescriptor.actionType];
+if (handler) {
+  await ctx.scheduler.runAfter(0, handler, {
+    entityId,
+    journalEntryId,
+    effectName: actionDescriptor.actionType,
+    // ... (full EffectPayload — see T-009)
+  });
+  effectNames.push(actionDescriptor.actionType);
+} else {
+  console.warn(
+    `[GT Effect Scheduler] No handler registered for effect "${actionDescriptor.actionType}". Skipping.`
+  );
+}
+```
+
+This is an acceptance criterion: "Missing effect in registry → `console.warn` + continue (never crash the engine)".
+
+## T-009: Pass Full EffectPayload to Scheduled Effects
+
+File: `convex/engine/transition.ts`
+
+The `scheduleEffects` function currently only passes `entityId`, `journalEntryId`, `effectName`, and `params`. It needs to pass the full `EffectPayload` shape:
+
+```typescript
+{
+  entityId,
+  entityType,
+  eventType,
+  journalEntryId,
+  effectName: actionDescriptor.actionType,
+  payload: actionDescriptor.params,
+  source: resolvedSource,
+}
+```
+
+This means the `scheduleEffects` function signature needs additional parameters: `entityType`, `eventType`, and `source`.
+
+**Updated function signature:**
+```typescript
+async function scheduleEffects(
+  ctx: MutationCtx,
+  entityId: string,
+  entityType: EntityType,
+  eventType: string,
+  journalEntryId: string,
+  source: CommandSource,
+  scheduledEffects: ScheduledEffectDescriptor[]
+): Promise<string[]>
+```
+
+**Update all call sites** of `scheduleEffects` within `transitionEntity` to pass the new params. There are 2 call sites:
+1. The "same state but has effects" path (around line 223)
+2. The "state changed" path (around line 301)
+
+Both already have access to `entityType`, `eventType`, and `resolvedSource` in the enclosing scope.
+
+Import `EffectPayload` type from `./types` if useful for documentation, but the actual payload is constructed inline as an object literal.
+
+Also rename `params` → `payload` in the scheduler call to match the EffectPayload interface.
+
+## T-010: Update Onboarding Machine Test
+
+File: `convex/engine/machines/__tests__/onboardingRequest.machine.test.ts`
+
+This test likely references the old action name `assignRoleToUser`. Update all references to the new names:
+- `assignRoleToUser` → `notifyApplicantApproved` (on APPROVE transition)
+- New: `notifyApplicantRejected` (on REJECT transition)
+- New: `assignRole` (on ASSIGN_ROLE transition)
+
+If the test checks that specific actions are produced by transitions, update those assertions. The machine behavior (states, transitions) is unchanged — only the action names are different.
+
+## T-011: Quality Gate
+
+Run these commands in order:
+```bash
+bun check          # Auto-formats + lints (run FIRST per CLAUDE.md)
+bun typecheck      # TypeScript type checking
+bunx convex codegen  # Regenerate Convex types (needed after adding new functions)
+```
+
+Fix any errors. Common issues to watch for:
+- `internal.engine.effects.onboarding.assignRoleToUser` references may still exist in generated code — run `bunx convex codegen` to regenerate
+- The widened registry type `FunctionReference<"mutation" | "action", "internal">` may cause type errors if Convex's type system doesn't support the union — if so, use a type assertion or `FunctionReference<"mutation", "internal"> | FunctionReference<"action", "internal">`
+- Any file that imports `assignRoleToUser` by name needs updating
+
+After fixing, re-run all three commands to confirm clean output.
+
+---
+
+## Key Constraint
+**From Spec Rule 5:** Effects are fire-and-forget. The transition is committed before effects run. The `scheduleEffects` function runs within the mutation but schedules effects via `ctx.scheduler.runAfter(0, ...)` which runs them asynchronously after the mutation commits.
+
+## Files to Read Before Starting
+- `convex/engine/transition.ts` — main file to modify
+- `convex/engine/machines/__tests__/onboardingRequest.machine.test.ts` — test to update
+- `convex/engine/types.ts` — to import EffectPayload/EntityType/CommandSource if needed

--- a/specs/ENG-14/chunks/chunk-02-engine-integration/tasks.md
+++ b/specs/ENG-14/chunks/chunk-02-engine-integration/tasks.md
@@ -1,0 +1,6 @@
+# Chunk 2: Engine Integration & Quality Gate
+
+- [ ] T-008: Add `console.warn` for missing effects in `scheduleEffects` in `convex/engine/transition.ts`
+- [ ] T-009: Update `scheduleEffects` to pass full `EffectPayload` (add entityType, eventType, source params)
+- [ ] T-010: Update onboarding machine test to reflect renamed actions
+- [ ] T-011: Run `bun check`, `bun typecheck`, `bunx convex codegen` — fix all errors

--- a/specs/ENG-14/chunks/manifest.md
+++ b/specs/ENG-14/chunks/manifest.md
@@ -1,0 +1,6 @@
+# ENG-14 Chunk Manifest
+
+| Chunk | Tasks | Status |
+|-------|-------|--------|
+| chunk-01-types-and-effects | T-001 through T-007 | pending |
+| chunk-02-engine-integration | T-008 through T-011 | pending |

--- a/specs/ENG-14/tasks.md
+++ b/specs/ENG-14/tasks.md
@@ -1,0 +1,18 @@
+# ENG-14: Implement Effect Registry and Effect Dispatch Pattern
+
+## Master Task List
+
+### Chunk 1: Types, Effects & Registry
+- [x] T-001: Add `EffectPayload` interface to `convex/engine/types.ts`
+- [x] T-002: Add `effectPayloadValidator` to `convex/engine/validators.ts`
+- [x] T-003: Update onboarding machine action names to match spec (`notifyApplicantApproved`, `notifyApplicantRejected`, `assignRole`)
+- [x] T-004: Rename existing `assignRoleToUser` effect to `assignRole` and update args to use `effectPayloadValidator`
+- [x] T-005: Add notification stub effects (`notifyApplicantApproved`, `notifyApplicantRejected`, `notifyAdminNewRequest`) to `convex/engine/effects/onboarding.ts`
+- [x] T-006: Create `convex/engine/effects/obligation.ts` with stub effects (`emitObligationOverdue`, `emitObligationSettled`)
+- [x] T-007: Widen registry type to `"mutation" | "action"` and add all effect entries to `convex/engine/effects/registry.ts`
+
+### Chunk 2: Engine Integration & Quality Gate
+- [x] T-008: Add `console.warn` for missing effects in `scheduleEffects` in `convex/engine/transition.ts`
+- [x] T-009: Update `scheduleEffects` to pass full `EffectPayload` (add entityType, eventType, source params)
+- [x] T-010: Update onboarding machine test to reflect renamed actions (no changes needed — tests already use new names)
+- [x] T-011: Run `bun check`, `bun typecheck`, `bunx convex codegen` — all passing

--- a/src/test/convex/engine/transition.test.ts
+++ b/src/test/convex/engine/transition.test.ts
@@ -65,9 +65,8 @@ describe("transition engine", () => {
 			success: true,
 			previousState: "pending_review",
 			newState: "approved",
+			effectsScheduled: ["notifyApplicantApproved"],
 		});
-		// notifyApplicantApproved is declared but not yet in effectRegistry (TODO)
-		expect(result.effectsScheduled).toEqual([]);
 
 		const request = await getRequest(t, requestId);
 		expect(request?.status).toBe("approved");
@@ -97,7 +96,7 @@ describe("transition engine", () => {
 			success: true,
 			previousState: "pending_review",
 			newState: "rejected",
-			effectsScheduled: [],
+			effectsScheduled: ["notifyApplicantRejected"],
 		});
 
 		const request = await getRequest(t, requestId);
@@ -223,7 +222,7 @@ describe("transition engine", () => {
 				events: {} as { type: "RETRY_ASSIGN" },
 			},
 			actions: {
-				assignRoleToUser: () => {
+				assignRole: () => {
 					// noop test action
 				},
 				testEffect: () => {
@@ -240,7 +239,7 @@ describe("transition engine", () => {
 						RETRY_ASSIGN: {
 							actions: [
 								{ type: "xstate.raise" },
-								"assignRoleToUser",
+								"assignRole",
 								{ type: "testEffect", params: { attempt: "retry" } },
 							] as unknown as never,
 						},
@@ -251,10 +250,7 @@ describe("transition engine", () => {
 
 		machineRegistry.onboardingRequest =
 			retryMachine as unknown as typeof originalMachine;
-		effectRegistry.assignRoleToUser =
-			internal.engine.effects.onboarding.assignRoleToUser;
-		effectRegistry.testEffect =
-			internal.engine.effects.onboarding.assignRoleToUser;
+		effectRegistry.testEffect = internal.engine.effects.onboarding.assignRole;
 
 		const journalCountBefore = (await getAuditJournalRows(t, requestId)).length;
 		const result = await t.mutation(
@@ -275,7 +271,7 @@ describe("transition engine", () => {
 			success: true,
 			previousState: "approved",
 			newState: "approved",
-			effectsScheduled: ["assignRoleToUser", "testEffect"],
+			effectsScheduled: ["assignRole", "testEffect"],
 		});
 		// Same-state-with-effects still writes a journal entry for traceability
 		expect((await getAuditJournalRows(t, requestId)).length).toBe(
@@ -426,8 +422,7 @@ describe("transition engine", () => {
 
 		machineRegistry.onboardingRequest =
 			singleActionMachine as unknown as typeof originalMachine;
-		effectRegistry.testEffect =
-			internal.engine.effects.onboarding.assignRoleToUser;
+		effectRegistry.testEffect = internal.engine.effects.onboarding.assignRole;
 
 		const result = await t.mutation(
 			internal.engine.transitionMutation.transitionMutation,

--- a/src/test/convex/onboarding/helpers.ts
+++ b/src/test/convex/onboarding/helpers.ts
@@ -187,10 +187,13 @@ export async function runAssignRoleAction(
 		journalEntryId: string;
 	}
 ) {
-	return t.action(internal.engine.effects.onboarding.assignRoleToUser, {
+	return t.action(internal.engine.effects.onboarding.assignRole, {
 		entityId: args.entityId,
+		entityType: "onboardingRequest",
+		eventType: "ASSIGN_ROLE",
 		journalEntryId: args.journalEntryId,
-		effectName: args.effectName ?? "assignRoleToUser",
+		effectName: args.effectName ?? "assignRole",
+		source: { channel: "scheduler", actorType: "system" },
 	});
 }
 


### PR DESCRIPTION


ft. ENG-14 Implement Effect Registry and effect dispatch pattern

Define EffectPayload interface and validators as the standard contract
for all GT side effects. Align onboarding machine action names to spec
(assignRoleToUser → assignRole, add notifyApplicantApproved/Rejected).
Create obligation effect stubs for cross-entity coordination. Populate
registry with all six entries and widen type to support both mutations
and actions. Add console.warn for missing effects so the engine never
crashes on unregistered handlers.

Co-Authored-By: Claude Opus 4.6 (1M context) [noreply@anthropic.com](mailto:noreply@anthropic.com)