### PR TITLE
ft. ENG-11

### DIFF
--- a/convex/engine/machines/__tests__/registry.test.ts
+++ b/convex/engine/machines/__tests__/registry.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import type { GovernedEntityType } from "../../types";
+import { getMachineVersion, machineRegistry } from "../registry";
+
+// Derive governed entity types from the registry — single source of truth
+const GOVERNED_ENTITY_TYPES = Object.keys(
+	machineRegistry
+) as GovernedEntityType[];
+const VERSION_FORMAT = /^.+@.+$/;
+
+describe("machineRegistry", () => {
+	it("has a machine for every GovernedEntityType", () => {
+		for (const entityType of GOVERNED_ENTITY_TYPES) {
+			expect(machineRegistry[entityType]).toBeDefined();
+		}
+	});
+
+	it("contains exactly the governed entity types as keys", () => {
+		const registryKeys = Object.keys(machineRegistry).sort();
+		const expectedKeys = [...GOVERNED_ENTITY_TYPES].sort();
+		expect(registryKeys).toEqual(expectedKeys);
+	});
+
+	it("every registered machine has a non-empty id", () => {
+		for (const entityType of GOVERNED_ENTITY_TYPES) {
+			const machine = machineRegistry[entityType];
+			expect(machine.id).toBeTruthy();
+			expect(typeof machine.id).toBe("string");
+		}
+	});
+
+	it("machine ids match their entity type keys", () => {
+		for (const entityType of GOVERNED_ENTITY_TYPES) {
+			const machine = machineRegistry[entityType];
+			expect(machine.id).toBe(entityType);
+		}
+	});
+});
+
+describe("getMachineVersion", () => {
+	it('returns "{machineId}@{version}" format', () => {
+		for (const entityType of GOVERNED_ENTITY_TYPES) {
+			const version = getMachineVersion(entityType);
+			expect(version).toMatch(VERSION_FORMAT);
+		}
+	});
+
+	it("defaults to 1.0.0 when machine has no version", () => {
+		let unversionedCount = 0;
+
+		for (const entityType of GOVERNED_ENTITY_TYPES) {
+			const machine = machineRegistry[entityType];
+			if (!machine.version) {
+				unversionedCount += 1;
+				expect(getMachineVersion(entityType)).toBe(`${machine.id}@1.0.0`);
+			}
+		}
+
+		expect(unversionedCount).toBeGreaterThan(0);
+	});
+
+	it("returns consistent format for all registered machines", () => {
+		expect(getMachineVersion("onboardingRequest")).toBe(
+			"onboardingRequest@1.0.0"
+		);
+		expect(getMachineVersion("mortgage")).toBe("mortgage@1.0.0");
+		expect(getMachineVersion("obligation")).toBe("obligation@1.0.0");
+	});
+});

--- a/convex/engine/machines/registry.ts
+++ b/convex/engine/machines/registry.ts
@@ -1,9 +1,25 @@
 import type { AnyStateMachine } from "xstate";
-import type { EntityType } from "../types";
+import type { GovernedEntityType } from "../types";
 import { mortgageMachine } from "./mortgage.machine";
+import { obligationMachine } from "./obligation.machine";
 import { onboardingRequestMachine } from "./onboardingRequest.machine";
 
-export const machineRegistry: Partial<Record<EntityType, AnyStateMachine>> = {
+/**
+ * Type-safe registry mapping every GovernedEntityType to its XState machine.
+ * Adding a new governed entity requires a one-line addition here — TypeScript
+ * enforces completeness via the Record key type.
+ */
+export const machineRegistry: Record<GovernedEntityType, AnyStateMachine> = {
 	mortgage: mortgageMachine,
+	obligation: obligationMachine,
 	onboardingRequest: onboardingRequestMachine,
 } as const;
+
+/**
+ * Returns a version string for audit journal entries.
+ * Format: "{machineId}@{version}" (defaults to "1.0.0" if no version is set).
+ */
+export function getMachineVersion(entityType: GovernedEntityType): string {
+	const machine = machineRegistry[entityType];
+	return `${machine.id}@${machine.version ?? "1.0.0"}`;
+}

--- a/convex/engine/transition.ts
+++ b/convex/engine/transition.ts
@@ -1,11 +1,18 @@
+import type { AnyStateMachine } from "xstate";
 import { getNextSnapshot } from "xstate";
 import type { Id } from "../_generated/dataModel";
 import type { MutationCtx } from "../_generated/server";
 import { auditLog } from "../auditLog";
 import { appendAuditJournalEntry } from "./auditJournal";
 import { effectRegistry } from "./effects/registry";
-import { machineRegistry } from "./machines/registry";
+import { getMachineVersion, machineRegistry } from "./machines/registry";
 import type { CommandSource, EntityType, TransitionResult } from "./types";
+
+function isGovernedEntityType(
+	entityType: EntityType
+): entityType is EntityType & keyof typeof machineRegistry {
+	return entityType in machineRegistry;
+}
 
 interface ScheduledEffectDescriptor {
 	actionType: string;
@@ -47,7 +54,7 @@ function normalizeActionDescriptors(
 }
 
 function extractScheduledEffects(
-	machine: NonNullable<(typeof machineRegistry)[keyof typeof machineRegistry]>,
+	machine: AnyStateMachine,
 	previousState: string,
 	eventType: string
 ): ScheduledEffectDescriptor[] {
@@ -142,10 +149,11 @@ export async function transitionEntity(
 	}
 
 	// 2. Get machine
-	const machine = machineRegistry[entityType];
-	if (!machine) {
+	if (!isGovernedEntityType(entityType)) {
 		throw new Error(`No machine registered for entity type: ${entityType}`);
 	}
+	const machine = machineRegistry[entityType];
+	const machineVersion = getMachineVersion(entityType);
 
 	// 3. Hydrate current state
 	const previousState = entity.status as string;
@@ -195,7 +203,7 @@ export async function transitionEntity(
 				newState,
 				outcome: "rejected",
 				reason: `Event "${eventType}" not valid in state "${previousState}"`,
-				machineVersion: machine.id,
+				machineVersion,
 				timestamp: Date.now(),
 			});
 
@@ -216,7 +224,7 @@ export async function transitionEntity(
 					outcome: "rejected",
 					reason: `Event "${eventType}" not valid in state "${previousState}"`,
 					source: resolvedSource,
-					machineVersion: machine.id,
+					machineVersion,
 				},
 			});
 			return {
@@ -242,7 +250,7 @@ export async function transitionEntity(
 			newState,
 			outcome: "transitioned",
 			reason: "same_state_with_effects",
-			machineVersion: machine.id,
+			machineVersion,
 			timestamp: Date.now(),
 		});
 		const effectNames = await scheduleEffects(
@@ -271,7 +279,7 @@ export async function transitionEntity(
 				outcome: "same_state_with_effects",
 				effectsScheduled: effectNames,
 				source: resolvedSource,
-				machineVersion: machine.id,
+				machineVersion,
 			},
 		});
 		return {
@@ -302,7 +310,7 @@ export async function transitionEntity(
 		previousState,
 		newState,
 		outcome: "transitioned",
-		machineVersion: machine.id,
+		machineVersion,
 		timestamp: Date.now(),
 	});
 
@@ -322,7 +330,7 @@ export async function transitionEntity(
 			newState,
 			outcome: "transitioned",
 			source: resolvedSource,
-			machineVersion: machine.id,
+			machineVersion,
 		},
 	});
 

--- a/convex/engine/types.ts
+++ b/convex/engine/types.ts
@@ -14,6 +14,14 @@ export type EntityType =
 	| "offerCondition"
 	| "lenderRenewalIntent";
 
+// ── Governed Entity Types ──────────────────────────────────────────
+// Subset of EntityType that have XState machine definitions.
+// TypeScript enforces completeness — machineRegistry must map every GovernedEntityType.
+export type GovernedEntityType =
+	| "onboardingRequest"
+	| "mortgage"
+	| "obligation";
+
 // ── Command Source ──────────────────────────────────────────────────
 export type CommandChannel =
 	| "borrower_portal"

--- a/specs/ENG-11/chunks/chunk-01-registry/context.md
+++ b/specs/ENG-11/chunks/chunk-01-registry/context.md
@@ -1,0 +1,126 @@
+# Context: ENG-11 Machine Registry
+
+## Linear Issue
+
+Create the type-safe registry mapping `EntityType` → XState machine definition, plus a `getMachineVersion()` helper for audit trail versioning.
+
+**Files:** `convex/machines/registry.ts` (note: actual path is `convex/engine/machines/registry.ts`)
+
+### Acceptance Criteria
+- `machineRegistry: Record<GovernedEntityType, AnyStateMachine>` maps all three Phase 1 entity types to their machines
+- `getMachineVersion(entityType)` returns `"{machineId}@{version}"` string for audit journal
+- Adding a new machine is a one-line addition to the registry
+- TypeScript enforces completeness — missing a machine for a GovernedEntityType is a compile error
+- `bun check` and `bun typecheck` pass
+
+### Technical Notes
+- ENG-17 (obligation machine) is NOT merged yet. Create a minimal stub.
+- ENG-15 (onboardingRequest) and ENG-16 (mortgage) ARE merged and their machines exist.
+
+## Spec: §3.4 Machine Registry (from SPEC 1.2)
+
+The spec defines the registry as:
+
+```typescript
+export const machineRegistry: Record<EntityType, AnyStateMachine> = {
+  onboardingRequest: onboardingRequestMachine,
+  mortgage: mortgageMachine,
+  obligation: obligationMachine,
+};
+
+// Helper: get machine version (hash of definition for audit trail)
+export function getMachineVersion(entityType: EntityType): string {
+  const machine = machineRegistry[entityType];
+  return `${machine.id}@${machine.version ?? "1.0.0"}`;
+}
+```
+
+## Architecture Context (from Governed Transitions doc)
+
+The Machine Registry is Component 1 of 5 in the Governed Transitions architecture:
+- The transition engine looks up machines via `machineRegistry[entityType]`
+- The audit journal records `machineVersion` from `getMachineVersion()`
+- Machines are pure XState v5 definitions — no Convex imports, no I/O, no async
+
+## Current Codebase State
+
+### `convex/engine/types.ts` — EntityType (CURRENT)
+```typescript
+export type EntityType =
+  | "onboardingRequest"
+  | "mortgage"
+  | "obligation"
+  | "deal"
+  | "provisionalApplication"
+  | "applicationPackage"
+  | "broker"
+  | "borrower"
+  | "lenderOnboarding"
+  | "provisionalOffer"
+  | "offerCondition"
+  | "lenderRenewalIntent";
+```
+
+Note: EntityType has many more types than have machines. We need a `GovernedEntityType` subset for the Phase 1 machine types only. This subset must be a proper subtype of `EntityType`.
+
+### `convex/engine/machines/registry.ts` — CURRENT (to be replaced)
+```typescript
+import type { AnyStateMachine } from "xstate";
+import type { EntityType } from "../types";
+import { mortgageMachine } from "./mortgage.machine";
+import { onboardingRequestMachine } from "./onboardingRequest.machine";
+
+export const machineRegistry: Partial<Record<EntityType, AnyStateMachine>> = {
+  mortgage: mortgageMachine,
+  onboardingRequest: onboardingRequestMachine,
+} as const;
+```
+
+Problems:
+1. Uses `Partial` — no compile-time completeness check
+2. Missing obligation machine
+3. No `getMachineVersion()` helper
+4. `as const` is unnecessary with explicit type annotation
+
+### `convex/engine/machines/onboardingRequest.machine.ts` — EXISTS
+- Machine id: `"onboardingRequest"`
+- States: pending_review → approved → role_assigned | rejected
+- No machineContext
+
+### `convex/engine/machines/mortgage.machine.ts` — EXISTS
+- Machine id: `"mortgage"`
+- States: active → delinquent → defaulted → collections → written_off | matured
+- Has MortgageMachineContext with missedPayments, lastPaymentAt
+
+### Obligation machine — DOES NOT EXIST (ENG-17 not merged)
+From ENG-17 spec:
+- Machine id should be: `"obligation"`
+- States: upcoming → due → overdue → settled
+- No machineContext needed for thin slice
+- Effect marker actions: emitObligationOverdue (on GRACE_PERIOD_EXPIRED), emitObligationSettled (on PAYMENT_APPLIED)
+- Terminal: settled is final
+
+Create a **stub** that matches this spec so the registry compiles. The real machine will replace it when ENG-17 merges.
+
+### `convex/engine/transition.ts` — USES the registry
+- Line 7: `import { machineRegistry } from "./machines/registry";`
+- Line 50: `extractScheduledEffects` uses `NonNullable<(typeof machineRegistry)[keyof typeof machineRegistry]>` — this will simplify when registry is no longer Partial
+- Line 145: `const machine = machineRegistry[entityType];` then null-checks — the null check won't be needed for GovernedEntityType
+- Line 198: Uses `machine.id` directly for machineVersion — should use `getMachineVersion()` instead
+
+## Developer Checklist (from spec)
+Adding a new governed entity:
+1. Define the machine — `convex/engine/machines/{entityType}.machine.ts`
+2. Add the entity type — Update `GovernedEntityType` union in `engine/types.ts`
+3. Register the machine — Add to `machineRegistry` in `machines/registry.ts` (one line)
+4. (remaining steps are for other issues)
+
+## Design Decisions
+
+1. **`GovernedEntityType` vs narrowing `EntityType`**: Introduce a new type `GovernedEntityType` as a subset. Keep `EntityType` broad (it's used elsewhere for table mappings etc). The registry maps `GovernedEntityType → AnyStateMachine`.
+
+2. **Obligation stub**: Create a minimal working XState machine matching the ENG-17 spec. Include a `// TODO(ENG-17): Replace with real machine when merged` comment.
+
+3. **`getMachineVersion()` format**: `"{machineId}@{version}"` where version comes from `machine.version ?? "1.0.0"`. The transition engine already uses `machine.id` in audit entries — update those to use `getMachineVersion()`.
+
+4. **Export pattern**: Export both `machineRegistry` and `getMachineVersion()` from registry.ts. The registry const + helper function is the full public API.

--- a/specs/ENG-11/chunks/chunk-01-registry/tasks.md
+++ b/specs/ENG-11/chunks/chunk-01-registry/tasks.md
@@ -1,0 +1,8 @@
+# Chunk 01: Machine Registry Implementation
+
+- [ ] T-001: Define `GovernedEntityType` subset in `convex/engine/types.ts`
+- [ ] T-002: Create obligation machine stub in `convex/engine/machines/obligation.machine.ts`
+- [ ] T-003: Update `convex/engine/machines/registry.ts` — full Record, getMachineVersion(), all 3 machines
+- [ ] T-004: Update `convex/engine/transition.ts` to use `GovernedEntityType` where appropriate
+- [ ] T-005: Write tests for registry completeness and getMachineVersion()
+- [ ] T-006: Quality gate — `bun check`, `bun typecheck`, `bunx convex codegen`

--- a/specs/ENG-11/chunks/manifest.md
+++ b/specs/ENG-11/chunks/manifest.md
@@ -1,0 +1,5 @@
+# ENG-11 Chunk Manifest
+
+| Chunk | Tasks | Status |
+|-------|-------|--------|
+| chunk-01-registry | T-001 through T-006 | pending |

--- a/specs/ENG-11/tasks.md
+++ b/specs/ENG-11/tasks.md
@@ -1,0 +1,10 @@
+# ENG-11: Machine Registry & getMachineVersion()
+
+## Tasks
+
+- [x] T-001: Define `GovernedEntityType` subset in `convex/engine/types.ts`
+- [x] T-002: Create obligation machine stub in `convex/engine/machines/obligation.machine.ts`
+- [x] T-003: Update `convex/engine/machines/registry.ts` — full Record, getMachineVersion(), all 3 machines
+- [x] T-004: Update `convex/engine/transition.ts` to use `GovernedEntityType` where appropriate
+- [x] T-005: Write tests for registry completeness and getMachineVersion()
+- [x] T-006: Quality gate — `bun check`, `bun typecheck` pass; 7/7 tests pass


### PR DESCRIPTION
## Summary by Sourcery

Introduce a type-safe state machine registry for governed entity types and wire machine versioning into the transition engine and audit trail.

New Features:
- Add a GovernedEntityType subset and a complete machine registry mapping each governed entity to its XState machine, including a stub obligation machine.
- Expose a getMachineVersion helper that returns a stable "{machineId}@{version}" identifier for use in audit logging.

Enhancements:
- Update the transition engine to use GovernedEntityType, the central machine registry, and getMachineVersion for recording machine versions in audit journal entries.

Documentation:
- Add ENG-11 specification and task documents describing the machine registry design, governed entity types, and implementation tasks.

Tests:
- Add unit tests to verify registry completeness, machine id consistency, and getMachineVersion behavior and formatting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Strengthened internal state machine registry with enhanced type validation and completeness checks.
  * Added versioning support for improved audit trail consistency.
  * Improved system reliability through stricter governance type constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->