### PR TITLE
ENG - 21 Feedback 

### DIFF
--- a/convex/seed/seedObligation.ts
+++ b/convex/seed/seedObligation.ts
@@ -54,6 +54,12 @@ async function resolveMortgageBorrowerPairs(
 		);
 	}
 
+	if (borrowerPool.length === 0) {
+		throw new ConvexError(
+			"No borrowers available. Seed borrowers first or pass borrowerIds / mortgageBorrowers."
+		);
+	}
+
 	const pairs: MortgageBorrowerPair[] = [];
 	for (let index = 0; index < mortgages.length; index += 1) {
 		const mortgage = mortgages[index];
@@ -148,6 +154,32 @@ function obligationDates(
 		default:
 			throw new ConvexError(`Unsupported obligation date state: ${state}`);
 	}
+}
+
+/**
+ * Sync parent mortgage machineContext.missedPayments with seeded overdue obligations.
+ * Only patches delinquent mortgages — other statuses don't track missedPayments.
+ */
+async function syncMortgageMissedPayments(
+	ctx: Pick<MutationCtx, "db">,
+	mortgage: Doc<"mortgages">,
+	states: readonly ObligationState[]
+) {
+	const overdueCount = states.filter((s) => s === "overdue").length;
+	if (overdueCount === 0 || mortgage.status !== "delinquent") {
+		return;
+	}
+
+	const existingContext = (mortgage.machineContext ?? {
+		missedPayments: 0,
+		lastPaymentAt: 0,
+	}) as { missedPayments: number; lastPaymentAt: number };
+	await ctx.db.patch(mortgage._id, {
+		machineContext: {
+			...existingContext,
+			missedPayments: Math.max(existingContext.missedPayments, overdueCount),
+		},
+	});
 }
 
 export const seedObligation = adminMutation
@@ -269,6 +301,8 @@ export const seedObligation = adminMutation
 				createdObligations += 1;
 				obligationIds.push(obligationId);
 			}
+
+			await syncMortgageMissedPayments(ctx, mortgage, states);
 		}
 
 		return {

--- a/convex/seed/seedOnboardingRequest.ts
+++ b/convex/seed/seedOnboardingRequest.ts
@@ -135,6 +135,9 @@ export const seedOnboardingRequest = adminMutation
 				fixture.request.status === "pending_review"
 					? undefined
 					: createdAt + 60_000;
+			const reviewedBy = reviewTimestamp
+				? (fixture.request.reviewedBy ?? args.reviewerId)
+				: undefined;
 			const requestId = await ctx.db.insert("onboardingRequests", {
 				userId,
 				requestedRole: fixture.request.requestedRole,
@@ -143,7 +146,7 @@ export const seedOnboardingRequest = adminMutation
 				lastTransitionAt: reviewTimestamp ?? createdAt,
 				referralSource: fixture.request.referralSource,
 				targetOrganizationId: fixture.request.targetOrganizationId,
-				reviewedBy: fixture.request.reviewedBy ?? args.reviewerId,
+				reviewedBy,
 				reviewedAt: reviewTimestamp,
 				rejectionReason: fixture.request.rejectionReason,
 				createdAt,


### PR DESCRIPTION
## Summary by Sourcery

Improve seeding behavior for obligations and onboarding requests by tightening validation and keeping related entities in sync.

Bug Fixes:
- Prevent seeding obligations when no borrowers are available by throwing an explicit error.
- Ensure seeded onboarding requests only set a reviewer when the request has been reviewed, avoiding incorrect reviewedBy data.

Enhancements:
- Synchronize delinquent mortgages' missedPayments counts with the number of seeded overdue obligations during obligation seeding.