### PR TITLE
ft. ENG-39

### DIFF
--- a/convex/ledger/__tests__/ledger.test.ts
+++ b/convex/ledger/__tests__/ledger.test.ts
@@ -1317,6 +1317,45 @@ describe("Point-in-Time & History", () => {
 		expect(filtered).toHaveLength(1);
 		expect(filtered[0].entryType).toBe("SHARES_TRANSFERRED");
 	});
+
+	it("T-070c: history queries default to limit=100 when omitted", async () => {
+		const t = createTestHarness();
+		await initCounter(t);
+		const auth = asLedgerUser(t);
+		const { issueResult } = await mintAndIssue(t, "m1", "lender-a");
+
+		for (let i = 0; i < 101; i++) {
+			const sellerLenderId = i % 2 === 0 ? "lender-a" : "lender-b";
+			const buyerLenderId = i % 2 === 0 ? "lender-b" : "lender-a";
+
+			await auth.mutation(api.ledger.mutations.transferShares, {
+				mortgageId: "m1",
+				sellerLenderId,
+				buyerLenderId,
+				amount: 5_000,
+				effectiveDate: "2026-01-02",
+				idempotencyKey: `transfer-default-limit-${i}`,
+				source: SYS_SOURCE,
+			});
+		}
+
+		const mortgageHistory = await auth.query(
+			api.ledger.queries.getMortgageHistory,
+			{
+				mortgageId: "m1",
+			}
+		);
+		expect(mortgageHistory).toHaveLength(100);
+		expect(mortgageHistory[0].sequenceNumber).toBe(1n);
+		expect(mortgageHistory[99].sequenceNumber).toBe(100n);
+
+		const accountHistory = await auth.query(api.ledger.queries.getAccountHistory, {
+			accountId: issueResult.positionAccountId,
+		});
+		expect(accountHistory).toHaveLength(100);
+		expect(accountHistory[0].sequenceNumber).toBe(2n);
+		expect(accountHistory[99].sequenceNumber).toBe(101n);
+	});
 });
 
 // ── Validation & Cursor tests ─────────────────────────────────────

--- a/convex/ledger/queries.ts
+++ b/convex/ledger/queries.ts
@@ -255,6 +255,7 @@ export const getAccountHistory = ledgerQuery
 	.handler(async (ctx, args) => {
 		const lo = args.from ?? 0;
 		const hi = args.to ?? Number.MAX_SAFE_INTEGER;
+		const effectiveLimit = args.limit ?? 100;
 
 		const debits = await ctx.db
 			.query("ledger_journal_entries")
@@ -287,10 +288,7 @@ export const getAccountHistory = ledgerQuery
 		});
 		unique.sort(compareSequenceNumbers);
 
-		if (args.limit) {
-			return unique.slice(0, args.limit);
-		}
-		return unique;
+		return unique.slice(0, effectiveLimit);
 	})
 	.public();
 
@@ -304,6 +302,7 @@ export const getMortgageHistory = ledgerQuery
 	.handler(async (ctx, args) => {
 		const lo = args.from ?? 0;
 		const hi = args.to ?? Number.MAX_SAFE_INTEGER;
+		const effectiveLimit = args.limit ?? 100;
 
 		const entries = await ctx.db
 			.query("ledger_journal_entries")
@@ -316,9 +315,6 @@ export const getMortgageHistory = ledgerQuery
 			.collect();
 
 		entries.sort(compareSequenceNumbers);
-		if (args.limit) {
-			return entries.slice(0, args.limit);
-		}
-		return entries;
+		return entries.slice(0, effectiveLimit);
 	})
 	.public();

--- a/specs/ENG-39/chunks/chunk-01-history-queries/context.md
+++ b/specs/ENG-39/chunks/chunk-01-history-queries/context.md
@@ -1,0 +1,173 @@
+# Chunk 1 Context: History Queries Hardening & Verification
+
+Source: Linear `ENG-39`, linked Notion implementation plan, `SPEC 1.3 — Mortgage Ownership Ledger`, `REQ-72`, upstream `ENG-24`, downstream `ENG-42`, and current repo inspection.
+
+## Goal
+
+Finish the actual remaining work for `ENG-39` on this branch. The key repo drift is that both history queries and several history-query tests already exist, but the default-limit requirement from the Linear issue is still not implemented.
+
+## Linear Issue Excerpt
+
+```md
+Implement paginated history queries as `authedQuery` functions:
+
+### getAccountHistory(accountId, opts)
+
+* Journal entries where debitAccountId or creditAccountId = accountId
+* Optional from/to timestamp filters
+* Paginated with limit (default 100)
+* Ordered by timestamp ascending
+
+### getMortgageHistory(mortgageId, opts)
+
+* Journal entries for a mortgage
+* Optional from/to timestamp filters
+* Paginated with limit (default 100)
+* Ordered by timestamp ascending
+```
+
+```md
+## Acceptance Criteria
+
+- [ ] getAccountHistory: returns paginated entries for an account, filtered by time range
+- [ ] getMortgageHistory: returns paginated entries for a mortgage, filtered by time range
+- [ ] Both support from/to timestamp filtering
+- [ ] Both default to limit=100 with pagination support
+- [ ] Both use appropriate indexes (by_debit_account, by_credit_account, by_mortgage_and_time)
+- [ ] Both are authedQuery (require authentication)
+- [ ] Tests: pagination, time range filtering, ordering
+```
+
+## Notion Implementation Plan Excerpt
+
+```md
+## 1. Status Assessment
+**Both queries are already implemented** in `convex/ledger/queries.ts` (lines 248–324). The implementation uses `ledgerQuery` middleware (requires auth + `ledger:view` permission) and queries appropriate indexes. The remaining work is:
+1. **Fix default limit** — AC requires `limit=100` default; current code has no default
+2. **Write test suite** — No tests exist for either history query
+```
+
+```md
+### 3a. Default Limit — NEEDS FIX
+**Current code:** No default — if `limit` is omitted, all entries are returned
+**Action:** Apply `args.limit ?? 100` as the effective limit. This is critical for REQ-72 compliance — 6-year retention means unbounded queries could return massive result sets.
+```
+
+## Repo Drift That Must Override the Stale Plan
+
+- `convex/ledger/queries.ts` already exports both `getAccountHistory` and `getMortgageHistory`.
+- `convex/ledger/__tests__/ledger.test.ts` already contains history-query coverage:
+  - `T-069: getMortgageHistory returns entries in sequence order`
+  - `T-070: getAccountHistory returns entries touching an account`
+  - `T-069b: getMortgageHistory filters by from/to date range`
+  - `T-069c: getMortgageHistory respects limit`
+  - `T-070b: getAccountHistory filters by from/to date range`
+- The Notion plan says the tests are missing and should be added to `queries.test.ts`; that is stale. Work against `ledger.test.ts` unless repo inspection shows a better local convention while implementing.
+
+## Current Repo Facts
+
+### `convex/ledger/queries.ts`
+
+```ts
+export const getAccountHistory = ledgerQuery
+  .input({
+    accountId: v.id("ledger_accounts"),
+    from: v.optional(v.number()),
+    to: v.optional(v.number()),
+    limit: v.optional(v.number()),
+  })
+  .handler(async (ctx, args) => {
+    const lo = args.from ?? 0;
+    const hi = args.to ?? Number.MAX_SAFE_INTEGER;
+    // query by_debit_account and by_credit_account
+    // merge + deduplicate + sort by sequenceNumber
+    if (args.limit) {
+      return unique.slice(0, args.limit);
+    }
+    return unique;
+  })
+  .public();
+```
+
+```ts
+export const getMortgageHistory = ledgerQuery
+  .input({
+    mortgageId: v.string(),
+    from: v.optional(v.number()),
+    to: v.optional(v.number()),
+    limit: v.optional(v.number()),
+  })
+  .handler(async (ctx, args) => {
+    const lo = args.from ?? 0;
+    const hi = args.to ?? Number.MAX_SAFE_INTEGER;
+    // query by_mortgage_and_time
+    // sort by sequenceNumber
+    if (args.limit) {
+      return entries.slice(0, args.limit);
+    }
+    return entries;
+  })
+  .public();
+```
+
+### Existing History Tests in `convex/ledger/__tests__/ledger.test.ts`
+
+```ts
+it("T-069: getMortgageHistory returns entries in sequence order", async () => { ... });
+it("T-070: getAccountHistory returns entries touching an account", async () => { ... });
+it("T-069b: getMortgageHistory filters by from/to date range", async () => { ... });
+it("T-069c: getMortgageHistory respects limit", async () => { ... });
+it("T-070b: getAccountHistory filters by from/to date range", async () => { ... });
+```
+
+## Relevant Spec / Goal Excerpts
+
+```md
+getAccountHistory(accountId: string, opts?: { from?, to?, limit? }): JournalEntry[]
+getMortgageHistory(mortgageId: string, opts?: { from?, to?, limit? }): JournalEntry[]
+```
+
+```md
+The mortgage ownership ledger is a pure primitive: tracks who owns what fraction of each mortgage, and when that changed.
+...
+Records retained 6 years after agreement expiry
+Electronic records permitted if promptly retrievable in legible format
+```
+
+## Integration Points
+
+### Upstream `ENG-24` (Done)
+
+```md
+`journalEntries` table ... Indexes: by_idempotency, by_mortgage_and_time, by_sequence, by_debit_account, by_credit_account, by_entry_type
+```
+
+These indexes are already present and are the required contract for this issue.
+
+### Downstream `ENG-42`
+
+```md
+Working history queries for full Definition of Done checklist
+Contract: Both queries return paginated, time-filtered, sequence-ordered journal entries
+```
+
+`ENG-39` should leave those query contracts stable for the downstream verification pass.
+
+## Constraints
+
+- Run `bun check` before hand-fixing lint or formatting issues.
+- `bun check`, `bun typecheck`, and `bunx convex codegen` must pass before considering the issue complete.
+- Do not introduce `any`.
+- Preserve `ledgerQuery` auth/permission middleware; the issue contract requires authenticated access.
+- Keep the existing index-backed query strategy:
+  - `getAccountHistory` merges `by_debit_account` and `by_credit_account`
+  - `getMortgageHistory` uses `by_mortgage_and_time`
+- Preserve deterministic ascending `sequenceNumber` ordering after collection.
+
+## Implementation Bias
+
+The smallest coherent implementation is:
+
+1. Add `const effectiveLimit = args.limit ?? 100` in both history queries.
+2. Return sliced results using that default.
+3. Extend the current `ledger.test.ts` coverage just enough to lock the default-limit behavior in place and close any remaining acceptance-criteria gaps without moving tests to a new file unless there is a strong repo-local reason.

--- a/specs/ENG-39/chunks/chunk-01-history-queries/status.md
+++ b/specs/ENG-39/chunks/chunk-01-history-queries/status.md
@@ -1,0 +1,21 @@
+# Chunk 1: History Queries Hardening & Verification — Status
+
+Completed: 2026-03-16 21:50 EDT
+
+## Tasks Completed
+- [x] T-001: Added `limit ?? 100` default handling to `getAccountHistory` in `convex/ledger/queries.ts`
+- [x] T-002: Added `limit ?? 100` default handling to `getMortgageHistory` in `convex/ledger/queries.ts`
+- [x] T-003: Added `T-070c` coverage in `convex/ledger/__tests__/ledger.test.ts` to verify both history queries cap omitted-limit responses at 100 entries
+
+## Tasks Incomplete
+- [ ] T-004: `bunx convex codegen` could not be executed in this worktree because `CONVEX_DEPLOYMENT` is not configured locally
+
+## Quality Gate
+- `bun check`: pass
+- `bun typecheck`: pass
+- `bun run test -- convex/ledger/__tests__/ledger.test.ts`: pass
+- `bunx convex codegen`: blocked by missing `CONVEX_DEPLOYMENT`
+
+## Notes
+- The linked Notion implementation plan was stale relative to the repo: both history queries and their core ordering/filtering tests already existed.
+- The remaining code change for `ENG-39` was the default-limit behavior required by the Linear issue and REQ-72 retention constraints.

--- a/specs/ENG-39/chunks/chunk-01-history-queries/tasks.md
+++ b/specs/ENG-39/chunks/chunk-01-history-queries/tasks.md
@@ -1,0 +1,6 @@
+# Chunk 1: History Queries Hardening & Verification
+
+- [x] T-001: Update `convex/ledger/queries.ts` so `getAccountHistory` enforces a default `limit=100` when omitted, while preserving `from`/`to` filtering, debit+credit merge behavior, deduplication, and ascending `sequenceNumber` ordering.
+- [x] T-002: Update `convex/ledger/queries.ts` so `getMortgageHistory` enforces a default `limit=100` when omitted, while preserving `from`/`to` filtering, the `by_mortgage_and_time` index scan, and ascending `sequenceNumber` ordering.
+- [x] T-003: Align and extend `convex/ledger/__tests__/ledger.test.ts` with the current repo state: keep the existing ordering, time-range, and explicit-limit coverage, and add focused assertions for the new default-limit behavior and any remaining acceptance-criteria gaps.
+- [ ] T-004: Run `bun check`, `bunx convex codegen`, `bun typecheck`, and the relevant ledger test suite(s); resolve any fallout before closing the issue.

--- a/specs/ENG-39/chunks/manifest.md
+++ b/specs/ENG-39/chunks/manifest.md
@@ -1,0 +1,5 @@
+# ENG-39 Chunk Manifest
+
+| Chunk | Tasks | Status |
+|-------|-------|--------|
+| chunk-01-history-queries | T-001 through T-004 | partial |

--- a/specs/ENG-39/tasks.md
+++ b/specs/ENG-39/tasks.md
@@ -1,0 +1,9 @@
+# ENG-39 — Implement history queries (`getAccountHistory`, `getMortgageHistory`)
+
+## Master Task List
+
+### Chunk 1: History Queries Hardening & Verification
+- [x] T-001: Update `convex/ledger/queries.ts` so `getAccountHistory` enforces a default `limit=100` when omitted, while preserving `from`/`to` filtering, debit+credit merge behavior, deduplication, and ascending `sequenceNumber` ordering.
+- [x] T-002: Update `convex/ledger/queries.ts` so `getMortgageHistory` enforces a default `limit=100` when omitted, while preserving `from`/`to` filtering, the `by_mortgage_and_time` index scan, and ascending `sequenceNumber` ordering.
+- [x] T-003: Align and extend `convex/ledger/__tests__/ledger.test.ts` with the current repo state: keep the existing ordering, time-range, and explicit-limit coverage, and add focused assertions for the new default-limit behavior and any remaining acceptance-criteria gaps.
+- [ ] T-004: Run `bun check`, `bunx convex codegen`, `bun typecheck`, and the relevant ledger test suite(s); resolve any fallout before closing the issue.


### PR DESCRIPTION
### TL;DR

Added default limit of 100 entries to ledger history queries when no limit is specified.

### What changed?

- Modified `getAccountHistory` and `getMortgageHistory` queries in `convex/ledger/queries.ts` to default to a limit of 100 entries when the `limit` parameter is omitted
- Replaced conditional limit application with consistent use of `effectiveLimit = args.limit ?? 100`
- Added test case `T-070c` to verify both history queries respect the 100-entry default limit by creating 101 transactions and confirming only the first 100 are returned

### How to test?

Run the ledger test suite:
```bash
bun run test -- convex/ledger/__tests__/ledger.test.ts
```

The new test `T-070c` creates 101 share transfer transactions and verifies that:
- `getMortgageHistory` without a limit parameter returns exactly 100 entries (sequence numbers 1-100)
- `getAccountHistory` without a limit parameter returns exactly 100 entries (sequence numbers 2-101)

### Why make this change?

This addresses a critical performance and compliance requirement where unbounded history queries could return massive result sets, especially given the 6-year data retention policy. The default limit prevents potential performance issues while maintaining backward compatibility for queries that explicitly specify a limit.