### PR TITLE
feat: implement commitReservation/voidReservation mutations and reservation+concurrency test suites (ENG-33, ENG-36)

### DIFF
--- a/convex/ledger/mutations.ts
+++ b/convex/ledger/mutations.ts
@@ -587,6 +587,18 @@ export const commitReservation = internalMutation({
 			)
 			.first();
 		if (existingEntry) {
+			if (existingEntry.entryType !== "SHARES_COMMITTED") {
+				throw new ConvexError({
+					code: "IDEMPOTENT_REPLAY_FAILED" as const,
+					message: `Idempotent commitReservation replay: existing entry ${existingEntry._id} has entryType ${existingEntry.entryType}, expected SHARES_COMMITTED`,
+				});
+			}
+			if (existingEntry.reservationId !== args.reservationId) {
+				throw new ConvexError({
+					code: "IDEMPOTENT_REPLAY_FAILED" as const,
+					message: `Idempotent commitReservation replay: existing entry ${existingEntry._id} has reservationId ${existingEntry.reservationId}, expected ${args.reservationId}`,
+				});
+			}
 			return { journalEntry: existingEntry };
 		}
 
@@ -660,6 +672,18 @@ export const voidReservation = internalMutation({
 			)
 			.first();
 		if (existingEntry) {
+			if (existingEntry.entryType !== "SHARES_VOIDED") {
+				throw new ConvexError({
+					code: "IDEMPOTENT_REPLAY_FAILED" as const,
+					message: `Idempotent voidReservation replay: existing entry ${existingEntry._id} has entryType ${existingEntry.entryType}, expected SHARES_VOIDED`,
+				});
+			}
+			if (existingEntry.reservationId !== args.reservationId) {
+				throw new ConvexError({
+					code: "IDEMPOTENT_REPLAY_FAILED" as const,
+					message: `Idempotent voidReservation replay: existing entry ${existingEntry._id} has reservationId ${existingEntry.reservationId}, expected ${args.reservationId}`,
+				});
+			}
 			return { journalEntry: existingEntry };
 		}
 


### PR DESCRIPTION
- Add commitReservation internalMutation: finalizes pending reservation by
  posting SHARES_COMMITTED entry, clearing pending fields, and updating
  reservation status to "committed"
- Add voidReservation internalMutation: cancels pending reservation by
  posting SHARES_VOIDED entry (audit-only), releasing pending holds, and
  updating reservation status to "voided"
- Fix balanceCheck ordering: clear pending fields before postEntry so
  available balance reflects the units being committed
- Add 7 reservation lifecycle tests: commit/void happy paths,
  double-commit/void prevention, cross-state rejection, mutex lifecycle
- Add 6 concurrency tests: min-fraction transfer enforcement, double-mint
  OCC, sequence number gap-freedom, supply invariant under mixed scenarios

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved idempotency behavior and stronger consistency for reservation commits/voids.
  * Ensured pending balances are cleared and reflected correctly when reservations finalize.
  * Tightened error reporting and validation for reservation and account states.

* **Tests**
  * Added extensive concurrency and lifecycle tests covering transfers, minting, sequencing, and supply invariants.
  * Added utilities to extract and validate error codes in tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->