### PR TITLE
feat(ENG-79): add dispersal validators, types, and extract reusable schema validators

### DIFF
--- a/convex/dispersal/types.ts
+++ b/convex/dispersal/types.ts
@@ -1,0 +1,41 @@
+import type { Id } from "../_generated/dataModel";
+
+// ── Calculation details (mirrors calculationDetailsValidator) ────
+export type CalculationDetails = {
+	settledAmount: number;
+	servicingFee: number;
+	distributableAmount: number;
+	ownershipUnits: number;
+	totalUnits: number;
+	ownershipFraction: number;
+	rawAmount: number;
+	roundedAmount: number;
+};
+
+// ── Dispersal entry (per-lender per-obligation) ─────────────────
+export type DispersalEntry = {
+	_id: Id<"dispersalEntries">;
+	mortgageId: Id<"mortgages">;
+	lenderId: Id<"lenders">;
+	lenderAccountId: Id<"ledger_accounts">;
+	amount: number;
+	dispersalDate: string;
+	obligationId: Id<"obligations">;
+	servicingFeeDeducted: number;
+	status: "pending";
+	idempotencyKey: string;
+	calculationDetails: CalculationDetails;
+	createdAt: number;
+};
+
+// ── Servicing fee entry (FairLend revenue per payment) ──────────
+export type ServicingFeeEntry = {
+	_id: Id<"servicingFeeEntries">;
+	mortgageId: Id<"mortgages">;
+	obligationId: Id<"obligations">;
+	amount: number;
+	annualRate: number;
+	principalBalance: number;
+	date: string;
+	createdAt: number;
+};

--- a/convex/dispersal/validators.ts
+++ b/convex/dispersal/validators.ts
@@ -1,0 +1,19 @@
+import { v } from "convex/values";
+
+// ── Dispersal entry status ──────────────────────────────────────
+// Phase 1: always "pending". Phase 2 will add "disbursed" | "failed".
+export const dispersalStatusValidator = v.literal("pending");
+
+// ── Calculation audit trail ─────────────────────────────────────
+// Every input to the pro-rata computation is preserved for
+// independent verification (SPEC §5.3).
+export const calculationDetailsValidator = v.object({
+	settledAmount: v.number(),
+	servicingFee: v.number(),
+	distributableAmount: v.number(),
+	ownershipUnits: v.number(),
+	totalUnits: v.number(),
+	ownershipFraction: v.number(),
+	rawAmount: v.number(),
+	roundedAmount: v.number(),
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -14,6 +14,10 @@ import {
 	channelValidator,
 	entityTypeValidator,
 } from "./engine/validators";
+import {
+	calculationDetailsValidator,
+	dispersalStatusValidator,
+} from "./dispersal/validators";
 
 export default defineSchema({
 	// ══════════════════════════════════════════════════════════
@@ -873,18 +877,9 @@ export default defineSchema({
 		dispersalDate: v.string(),
 		obligationId: v.id("obligations"),
 		servicingFeeDeducted: v.number(),
-		status: v.literal("pending"),
+		status: dispersalStatusValidator,
 		idempotencyKey: v.string(),
-		calculationDetails: v.object({
-			settledAmount: v.number(),
-			servicingFee: v.number(),
-			distributableAmount: v.number(),
-			ownershipUnits: v.number(),
-			totalUnits: v.number(),
-			ownershipFraction: v.number(),
-			rawAmount: v.number(),
-			roundedAmount: v.number(),
-		}),
+		calculationDetails: calculationDetailsValidator,
 		createdAt: v.number(),
 	})
 		.index("by_lender", ["lenderId", "dispersalDate"])


### PR DESCRIPTION
## Create dispersal domain types and validators

Create `convex/dispersal/validators.ts` with `dispersalStatusValidator` and `calculationDetailsValidator`, and `convex/dispersal/types.ts` with `CalculationDetails`, `DispersalEntry`, and `ServicingFeeEntry` types for the dispersal accounting domain. Refactor `schema.ts` to import these validators instead of using inline definitions for dispersal entries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized dispersal system infrastructure with dedicated type and validator modules for improved code maintainability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->