### PR TITLE
feat ENG70: derive ownership periods from ledger journal

### DIFF
--- a/convex/accrual/__tests__/ownershipPeriods.test.ts
+++ b/convex/accrual/__tests__/ownershipPeriods.test.ts
@@ -1,6 +1,7 @@
 import { convexTest } from "convex-test";
 import { describe, expect, it } from "vitest";
 import { api, internal } from "../../_generated/api";
+import type { Id } from "../../_generated/dataModel";
 import { FAIRLEND_STAFF_ORG_ID } from "../../constants";
 import schema from "../../schema";
 import { getOwnershipPeriods } from "../ownershipPeriods";
@@ -8,15 +9,15 @@ import { getOwnershipPeriods } from "../ownershipPeriods";
 const modules = import.meta.glob("/convex/**/*.ts");
 
 const LEDGER_TEST_IDENTITY = {
-	subject: "test-ledger-user",
+	subject: "test-accrual-user",
 	issuer: "https://api.workos.com",
 	org_id: FAIRLEND_STAFF_ORG_ID,
 	organization_name: "FairLend Staff",
 	role: "admin",
 	roles: JSON.stringify(["admin"]),
 	permissions: JSON.stringify(["ledger:view", "ledger:correct"]),
-	user_email: "ledger-test@fairlend.ca",
-	user_first_name: "Ledger",
+	user_email: "accrual-test@fairlend.ca",
+	user_first_name: "Accrual",
 	user_last_name: "Tester",
 };
 
@@ -30,50 +31,137 @@ function asLedgerUser(t: ReturnType<typeof createTestHarness>) {
 	return t.withIdentity(LEDGER_TEST_IDENTITY);
 }
 
-async function initCounter(t: ReturnType<typeof createTestHarness>) {
-	await asLedgerUser(t).mutation(
-		api.ledger.sequenceCounter.initializeSequenceCounter,
-		{}
-	);
+async function initLedger(t: ReturnType<typeof createTestHarness>) {
+	const auth = asLedgerUser(t);
+	await auth.mutation(api.ledger.sequenceCounter.initializeSequenceCounter, {});
+	return auth;
 }
 
-async function mintAndIssue(
-	t: ReturnType<typeof createTestHarness>,
+async function mintMortgage(
+	auth: ReturnType<typeof asLedgerUser>,
 	mortgageId: string,
-	lenderId: string,
-	amount = 10_000
+	idempotencyKey: string
 ) {
-	const auth = asLedgerUser(t);
-	await auth.mutation(api.ledger.mutations.mintMortgage, {
+	return auth.mutation(api.ledger.mutations.mintMortgage, {
 		mortgageId,
 		effectiveDate: "2026-01-01",
-		idempotencyKey: `mint-${mortgageId}`,
+		idempotencyKey,
 		source: SYS_SOURCE,
 	});
+}
+
+async function issueShares(
+	auth: ReturnType<typeof asLedgerUser>,
+	mortgageId: string,
+	lenderId: string,
+	amount: number,
+	effectiveDate: string,
+	idempotencyKey: string
+) {
 	return auth.mutation(internal.ledger.mutations.issueShares, {
 		mortgageId,
 		lenderId,
 		amount,
-		effectiveDate: "2026-01-01",
-		idempotencyKey: `issue-${mortgageId}-${lenderId}`,
+		effectiveDate,
+		idempotencyKey,
 		source: SYS_SOURCE,
 	});
 }
 
-describe("getOwnershipPeriods", () => {
-	it("returns a single open period for an untouched position", async () => {
-		const t = createTestHarness();
-		await initCounter(t);
-		await mintAndIssue(t, "m-single", "lender-a");
+async function transferShares(
+	auth: ReturnType<typeof asLedgerUser>,
+	args: {
+		amount: number;
+		buyerLenderId: string;
+		effectiveDate: string;
+		idempotencyKey: string;
+		mortgageId: string;
+		sellerLenderId: string;
+	}
+) {
+	return auth.mutation(internal.ledger.mutations.transferSharesInternal, {
+		...args,
+		source: SYS_SOURCE,
+	});
+}
 
-		const periods = await t.run(async (ctx) =>
-			getOwnershipPeriods(ctx, "m-single", "lender-a")
+async function redeemShares(
+	auth: ReturnType<typeof asLedgerUser>,
+	args: {
+		amount: number;
+		effectiveDate: string;
+		idempotencyKey: string;
+		mortgageId: string;
+		lenderId: string;
+	}
+) {
+	return auth.mutation(internal.ledger.mutations.redeemSharesInternal, {
+		...args,
+		source: SYS_SOURCE,
+	});
+}
+
+async function reserveShares(
+	auth: ReturnType<typeof asLedgerUser>,
+	args: {
+		amount: number;
+		buyerLenderId: string;
+		effectiveDate: string;
+		idempotencyKey: string;
+		mortgageId: string;
+		sellerLenderId: string;
+	}
+) {
+	return auth.mutation(internal.ledger.mutations.reserveShares, {
+		...args,
+		source: SYS_SOURCE,
+	});
+}
+
+async function commitReservation(
+	auth: ReturnType<typeof asLedgerUser>,
+	args: {
+		effectiveDate: string;
+		idempotencyKey: string;
+		reservationId: Id<"ledger_reservations">;
+	}
+) {
+	return auth.mutation(internal.ledger.mutations.commitReservation, {
+		...args,
+		source: SYS_SOURCE,
+	});
+}
+
+async function getPeriods(
+	t: ReturnType<typeof createTestHarness>,
+	mortgageId: string,
+	lenderId: string
+) {
+	return t.run(async (ctx) =>
+		getOwnershipPeriods({ db: ctx.db }, mortgageId, lenderId)
+	);
+}
+
+describe("getOwnershipPeriods", () => {
+	it("returns one open period for a single owner", async () => {
+		const t = createTestHarness();
+		const auth = await initLedger(t);
+
+		await mintMortgage(auth, "m-period-single", "mint-single");
+		await issueShares(
+			auth,
+			"m-period-single",
+			"lender-a",
+			10_000,
+			"2026-01-01",
+			"issue-single"
 		);
 
+		const periods = await getPeriods(t, "m-period-single", "lender-a");
 		expect(periods).toEqual([
 			{
 				lenderId: "lender-a",
-				mortgageId: "m-single",
+				mortgageId: "m-period-single",
 				fraction: 1,
 				fromDate: "2026-01-01",
 				toDate: null,
@@ -81,49 +169,59 @@ describe("getOwnershipPeriods", () => {
 		]);
 	});
 
-	it("splits periods on transfer and gives the closing date to the seller", async () => {
+	it("keeps the closing date with the seller and starts the buyer the day after on SHARES_COMMITTED", async () => {
 		const t = createTestHarness();
-		await initCounter(t);
-		const auth = asLedgerUser(t);
+		const auth = await initLedger(t);
 
-		await mintAndIssue(t, "m-transfer", "seller");
-		await auth.mutation(api.ledger.mutations.transferShares, {
-			mortgageId: "m-transfer",
+		await mintMortgage(auth, "m-period-commit", "mint-commit");
+		await issueShares(
+			auth,
+			"m-period-commit",
+			"seller",
+			10_000,
+			"2026-01-01",
+			"issue-commit-seller"
+		);
+
+		const reservation = await reserveShares(auth, {
+			mortgageId: "m-period-commit",
 			sellerLenderId: "seller",
 			buyerLenderId: "buyer",
 			amount: 5000,
 			effectiveDate: "2026-01-15",
-			idempotencyKey: "transfer-m-transfer",
-			source: SYS_SOURCE,
+			idempotencyKey: "reserve-commit",
 		});
 
-		const sellerPeriods = await t.run(async (ctx) =>
-			getOwnershipPeriods(ctx, "m-transfer", "seller")
-		);
-		const buyerPeriods = await t.run(async (ctx) =>
-			getOwnershipPeriods(ctx, "m-transfer", "buyer")
-		);
+		await commitReservation(auth, {
+			reservationId: reservation.reservationId,
+			effectiveDate: "2026-01-15",
+			idempotencyKey: "commit-commit",
+		});
+
+		const sellerPeriods = await getPeriods(t, "m-period-commit", "seller");
+		const buyerPeriods = await getPeriods(t, "m-period-commit", "buyer");
 
 		expect(sellerPeriods).toEqual([
 			{
 				lenderId: "seller",
-				mortgageId: "m-transfer",
+				mortgageId: "m-period-commit",
 				fraction: 1,
 				fromDate: "2026-01-01",
 				toDate: "2026-01-15",
 			},
 			{
 				lenderId: "seller",
-				mortgageId: "m-transfer",
+				mortgageId: "m-period-commit",
 				fraction: 0.5,
 				fromDate: "2026-01-16",
 				toDate: null,
 			},
 		]);
+
 		expect(buyerPeriods).toEqual([
 			{
 				lenderId: "buyer",
-				mortgageId: "m-transfer",
+				mortgageId: "m-period-commit",
 				fraction: 0.5,
 				fromDate: "2026-01-16",
 				toDate: null,
@@ -131,106 +229,152 @@ describe("getOwnershipPeriods", () => {
 		]);
 	});
 
-	it("reconstructs multiple periods deterministically from real ledger rows", async () => {
+	it("returns a correct period chain for multiple sequential transfers", async () => {
 		const t = createTestHarness();
-		await initCounter(t);
-		const auth = asLedgerUser(t);
+		const auth = await initLedger(t);
 
-		await mintAndIssue(t, "m-multi", "seller");
-		await auth.mutation(api.ledger.mutations.transferShares, {
-			mortgageId: "m-multi",
-			sellerLenderId: "seller",
-			buyerLenderId: "buyer-1",
-			amount: 2000,
-			effectiveDate: "2026-02-01",
-			idempotencyKey: "transfer-1",
-			source: SYS_SOURCE,
-		});
-		await auth.mutation(api.ledger.mutations.transferShares, {
-			mortgageId: "m-multi",
-			sellerLenderId: "seller",
-			buyerLenderId: "buyer-2",
-			amount: 2000,
-			effectiveDate: "2026-03-01",
-			idempotencyKey: "transfer-2",
-			source: SYS_SOURCE,
-		});
-
-		const first = await t.run(async (ctx) =>
-			getOwnershipPeriods(ctx, "m-multi", "seller")
+		await mintMortgage(auth, "m-period-chain", "mint-chain");
+		await issueShares(
+			auth,
+			"m-period-chain",
+			"lender-a",
+			10_000,
+			"2026-01-01",
+			"issue-chain"
 		);
-		const second = await t.run(async (ctx) =>
-			getOwnershipPeriods(ctx, "m-multi", "seller")
-		);
+		await transferShares(auth, {
+			mortgageId: "m-period-chain",
+			sellerLenderId: "lender-a",
+			buyerLenderId: "lender-b",
+			amount: 3000,
+			effectiveDate: "2026-01-10",
+			idempotencyKey: "transfer-chain-1",
+		});
+		await transferShares(auth, {
+			mortgageId: "m-period-chain",
+			sellerLenderId: "lender-a",
+			buyerLenderId: "lender-c",
+			amount: 3000,
+			effectiveDate: "2026-01-20",
+			idempotencyKey: "transfer-chain-2",
+		});
 
-		expect(first).toEqual(second);
-		expect(first).toEqual([
+		await expect(getPeriods(t, "m-period-chain", "lender-a")).resolves.toEqual([
 			{
-				lenderId: "seller",
-				mortgageId: "m-multi",
+				lenderId: "lender-a",
+				mortgageId: "m-period-chain",
 				fraction: 1,
 				fromDate: "2026-01-01",
-				toDate: "2026-02-01",
+				toDate: "2026-01-10",
 			},
 			{
-				lenderId: "seller",
-				mortgageId: "m-multi",
-				fraction: 0.8,
-				fromDate: "2026-02-02",
-				toDate: "2026-03-01",
+				lenderId: "lender-a",
+				mortgageId: "m-period-chain",
+				fraction: 0.7,
+				fromDate: "2026-01-11",
+				toDate: "2026-01-20",
 			},
 			{
-				lenderId: "seller",
-				mortgageId: "m-multi",
-				fraction: 0.6,
-				fromDate: "2026-03-02",
+				lenderId: "lender-a",
+				mortgageId: "m-period-chain",
+				fraction: 0.4,
+				fromDate: "2026-01-21",
+				toDate: null,
+			},
+		]);
+
+		await expect(getPeriods(t, "m-period-chain", "lender-b")).resolves.toEqual([
+			{
+				lenderId: "lender-b",
+				mortgageId: "m-period-chain",
+				fraction: 0.3,
+				fromDate: "2026-01-11",
+				toDate: null,
+			},
+		]);
+
+		await expect(getPeriods(t, "m-period-chain", "lender-c")).resolves.toEqual([
+			{
+				lenderId: "lender-c",
+				mortgageId: "m-period-chain",
+				fraction: 0.3,
+				fromDate: "2026-01-21",
 				toDate: null,
 			},
 		]);
 	});
 
-	it("ignores audit-only reserve and void entries", async () => {
+	it("closes the final period on full exit", async () => {
 		const t = createTestHarness();
-		await initCounter(t);
-		const auth = asLedgerUser(t);
+		const auth = await initLedger(t);
 
-		await mintAndIssue(t, "m-audit", "seller");
-		await auth.mutation(internal.ledger.mutations.reserveShares, {
-			mortgageId: "m-audit",
+		await mintMortgage(auth, "m-period-exit", "mint-exit");
+		await issueShares(
+			auth,
+			"m-period-exit",
+			"lender-a",
+			10_000,
+			"2026-01-01",
+			"issue-exit"
+		);
+		await redeemShares(auth, {
+			mortgageId: "m-period-exit",
+			lenderId: "lender-a",
+			amount: 10_000,
+			effectiveDate: "2026-01-15",
+			idempotencyKey: "redeem-exit",
+		});
+
+		const periods = await getPeriods(t, "m-period-exit", "lender-a");
+		expect(periods).toEqual([
+			{
+				lenderId: "lender-a",
+				mortgageId: "m-period-exit",
+				fraction: 1,
+				fromDate: "2026-01-01",
+				toDate: "2026-01-15",
+			},
+		]);
+	});
+
+	it("ignores SHARES_RESERVED and SHARES_VOIDED entries", async () => {
+		const t = createTestHarness();
+		const auth = await initLedger(t);
+
+		await mintMortgage(auth, "m-period-audit", "mint-audit");
+		await issueShares(
+			auth,
+			"m-period-audit",
+			"seller",
+			10_000,
+			"2026-01-01",
+			"issue-audit"
+		);
+
+		const reservation = await reserveShares(auth, {
+			mortgageId: "m-period-audit",
 			sellerLenderId: "seller",
 			buyerLenderId: "buyer",
-			amount: 2000,
-			effectiveDate: "2026-01-15",
+			amount: 3000,
+			effectiveDate: "2026-01-10",
 			idempotencyKey: "reserve-audit",
-			source: SYS_SOURCE,
 		});
-		const reservation = await t.run(async (ctx) => {
-			const reservations = await ctx.db.query("ledger_reservations").collect();
-			return reservations.find((row) => row.mortgageId === "m-audit");
-		});
-		expect(reservation).toBeDefined();
-		if (!reservation) {
-			return;
-		}
+
 		await auth.mutation(internal.ledger.mutations.voidReservation, {
-			reservationId: reservation._id,
-			reason: "test void",
-			effectiveDate: "2026-01-16",
+			reservationId: reservation.reservationId,
+			reason: "cancelled",
+			effectiveDate: "2026-01-11",
 			idempotencyKey: "void-audit",
 			source: SYS_SOURCE,
 		});
 
-		const sellerPeriods = await t.run(async (ctx) =>
-			getOwnershipPeriods(ctx, "m-audit", "seller")
-		);
-		const buyerPeriods = await t.run(async (ctx) =>
-			getOwnershipPeriods(ctx, "m-audit", "buyer")
-		);
+		const sellerPeriods = await getPeriods(t, "m-period-audit", "seller");
+		const buyerPeriods = await getPeriods(t, "m-period-audit", "buyer");
 
 		expect(sellerPeriods).toEqual([
 			{
 				lenderId: "seller",
-				mortgageId: "m-audit",
+				mortgageId: "m-period-audit",
 				fraction: 1,
 				fromDate: "2026-01-01",
 				toDate: null,

--- a/convex/accrual/ownershipPeriods.ts
+++ b/convex/accrual/ownershipPeriods.ts
@@ -2,34 +2,29 @@ import type { Doc } from "../_generated/dataModel";
 import type { QueryCtx } from "../_generated/server";
 import { getAccountLenderId } from "../ledger/accountOwnership";
 import { AUDIT_ONLY_ENTRY_TYPES, TOTAL_SUPPLY } from "../ledger/constants";
-import { getPositionAccount } from "../ledger/accounts";
 import { dayAfter, dayBefore } from "./interestMath";
 import type { OwnershipPeriod } from "./types";
 
-type LedgerJournalEntry = Pick<
-	Doc<"ledger_journal_entries">,
-	| "_id"
-	| "amount"
-	| "creditAccountId"
-	| "debitAccountId"
-	| "effectiveDate"
-	| "entryType"
-	| "sequenceNumber"
->;
-
-const TRANSFER_LIKE_ENTRY_TYPES = new Set([
-	"SHARES_TRANSFERRED",
-	"SHARES_COMMITTED",
-]);
-
-function amountToNumber(amount: number | bigint): number {
-	return typeof amount === "bigint" ? Number(amount) : amount;
+interface DbCtx {
+	db: QueryCtx["db"];
 }
 
-function compareBySequence(
-	left: LedgerJournalEntry,
-	right: LedgerJournalEntry
-) {
+type LedgerAccount = Doc<"ledger_accounts">;
+type LedgerEntry = Doc<"ledger_journal_entries">;
+
+function toBigIntAmount(amount: number | bigint, entryId: string): bigint {
+	if (typeof amount === "bigint") {
+		return amount;
+	}
+	if (!Number.isSafeInteger(amount)) {
+		throw new Error(
+			`Journal entry ${entryId} has an unsafe amount (${amount})`
+		);
+	}
+	return BigInt(amount);
+}
+
+function compareSequenceNumbers(left: LedgerEntry, right: LedgerEntry): number {
 	if (left.sequenceNumber < right.sequenceNumber) {
 		return -1;
 	}
@@ -39,169 +34,154 @@ function compareBySequence(
 	return 0;
 }
 
-async function getPositionHistory(
-	ctx: { db: QueryCtx["db"] },
-	accountId: Doc<"ledger_accounts">["_id"]
-) {
-	const [debits, credits] = await Promise.all([
-		ctx.db
-			.query("ledger_journal_entries")
-			.withIndex("by_debit_account", (q) => q.eq("debitAccountId", accountId))
-			.collect(),
-		ctx.db
-			.query("ledger_journal_entries")
-			.withIndex("by_credit_account", (q) => q.eq("creditAccountId", accountId))
-			.collect(),
-	]);
+async function findPositionAccount(
+	ctx: DbCtx,
+	mortgageId: string,
+	lenderId: string
+): Promise<LedgerAccount | null> {
+	const indexed = await ctx.db
+		.query("ledger_accounts")
+		.withIndex("by_mortgage_and_lender", (q) =>
+			q.eq("mortgageId", mortgageId).eq("lenderId", lenderId)
+		)
+		.first();
 
-	const seen = new Set<string>();
-	const merged = [...debits, ...credits].filter((entry) => {
-		if (seen.has(entry._id)) {
-			return false;
-		}
-		seen.add(entry._id);
-		return true;
-	});
-
-	merged.sort(compareBySequence);
-	return merged as LedgerJournalEntry[];
-}
-
-function getPeriodStartDate(entry: LedgerJournalEntry, isDebitSide: boolean) {
-	if (!isDebitSide) {
-		return entry.effectiveDate;
+	if (indexed && indexed.type === "POSITION") {
+		return indexed;
 	}
 
-	if (TRANSFER_LIKE_ENTRY_TYPES.has(entry.entryType)) {
+	const fallback = await ctx.db
+		.query("ledger_accounts")
+		.withIndex("by_mortgage", (q) => q.eq("mortgageId", mortgageId))
+		.collect();
+
+	return (
+		fallback.find(
+			(account) =>
+				account.type === "POSITION" && getAccountLenderId(account) === lenderId
+		) ?? null
+	);
+}
+
+function getStartDate(entry: LedgerEntry, isDebitSide: boolean): string {
+	if (isDebitSide) {
+		if (entry.entryType === "SHARES_ISSUED") {
+			return entry.effectiveDate;
+		}
 		return dayAfter(entry.effectiveDate);
 	}
 
 	return entry.effectiveDate;
 }
 
-function getPeriodEndDate(entry: LedgerJournalEntry, isCreditSide: boolean) {
-	if (!isCreditSide) {
-		return null;
-	}
-
-	if (AUDIT_ONLY_ENTRY_TYPES.has(entry.entryType)) {
-		return null;
-	}
-
-	return entry.effectiveDate;
-}
-
-function getNextBalance(
-	currentBalance: bigint,
-	entry: LedgerJournalEntry,
-	positionAccountId: Doc<"ledger_accounts">["_id"]
-) {
-	const delta = BigInt(amountToNumber(entry.amount));
-	return entry.debitAccountId === positionAccountId
-		? currentBalance + delta
-		: currentBalance - delta;
-}
-
-function closeOpenPeriod(
+function closeCurrentPeriod(
 	periods: OwnershipPeriod[],
-	openPeriod: OwnershipPeriod | null,
-	currentBalance: bigint,
-	currentEndDate: string | null
-) {
-	if (!openPeriod || currentBalance <= 0n) {
-		return null;
+	closingDate: string
+): void {
+	const current = periods.at(-1);
+	if (!current || current.toDate !== null) {
+		throw new Error("Invalid ownership timeline: no open period to close");
 	}
-
-	openPeriod.toDate = currentEndDate ?? openPeriod.toDate;
-	periods.push(openPeriod);
-	return null;
+	current.toDate = closingDate;
 }
 
-/**
- * Reconstructs a lender's ownership periods for a mortgage from ledger history.
- * The ledger uses date-level business events, so transfers/commits close on the
- * effective date for the seller and reopen the buyer on the next day.
- */
 export async function getOwnershipPeriods(
 	ctx: { db: QueryCtx["db"] },
 	mortgageId: string,
 	lenderId: string
 ): Promise<OwnershipPeriod[]> {
-	const positionAccount = await getPositionAccount(ctx, mortgageId, lenderId);
+	const positionAccount = await findPositionAccount(ctx, mortgageId, lenderId);
 	if (!positionAccount) {
 		return [];
 	}
 
-	const history = await getPositionHistory(ctx, positionAccount._id);
-	const periods: OwnershipPeriod[] = [];
-	let currentBalance = 0n;
-	let openPeriod: OwnershipPeriod | null = null;
+	const [debitEntries, creditEntries] = await Promise.all([
+		ctx.db
+			.query("ledger_journal_entries")
+			.withIndex("by_debit_account", (q) =>
+				q.eq("debitAccountId", positionAccount._id)
+			)
+			.collect(),
+		ctx.db
+			.query("ledger_journal_entries")
+			.withIndex("by_credit_account", (q) =>
+				q.eq("creditAccountId", positionAccount._id)
+			)
+			.collect(),
+	]);
 
-	for (const entry of history) {
-		if (AUDIT_ONLY_ENTRY_TYPES.has(entry.entryType)) {
-			continue;
-		}
-
-		const isDebitSide = entry.debitAccountId === positionAccount._id;
-		const isCreditSide = entry.creditAccountId === positionAccount._id;
-		if (!(isDebitSide || isCreditSide)) {
-			continue;
-		}
-
-		const nextBalance = getNextBalance(
-			currentBalance,
-			entry,
-			positionAccount._id
-		);
-
-		if (nextBalance === currentBalance) {
-			continue;
-		}
-
-		const isIncrease = nextBalance > currentBalance;
-		const nextStartDate = isIncrease
-			? getPeriodStartDate(entry, isDebitSide)
-			: dayAfter(entry.effectiveDate);
-		const currentEndDate = isIncrease
-			? dayBefore(nextStartDate)
-			: getPeriodEndDate(entry, isCreditSide);
-
-		// If this change affects the same future start date as the currently open
-		// period, merge it into that period instead of closing and reopening.
-		if (openPeriod && openPeriod.fromDate === nextStartDate) {
-			if (nextBalance > 0n) {
-				openPeriod = {
-					...openPeriod,
-					fraction: Number(nextBalance) / Number(TOTAL_SUPPLY),
-				};
-			} else {
-				// Net effect is that there should be no ownership starting at this date.
-				openPeriod = null;
+	const seen = new Set<string>();
+	const entries = [...debitEntries, ...creditEntries]
+		.filter((entry) => {
+			if (seen.has(entry._id)) {
+				return false;
 			}
-		} else {
-			openPeriod = closeOpenPeriod(
-				periods,
-				openPeriod,
-				currentBalance,
-				currentEndDate
-			);
+			seen.add(entry._id);
+			return !AUDIT_ONLY_ENTRY_TYPES.has(entry.entryType);
+		})
+		.sort(compareSequenceNumbers);
 
-			if (nextBalance > 0n) {
-				openPeriod = {
-					lenderId,
-					mortgageId,
-					fraction: Number(nextBalance) / Number(TOTAL_SUPPLY),
-					fromDate: nextStartDate,
-					toDate: null,
-				};
-			}
-		}
-
-		currentBalance = nextBalance;
+	if (entries.length === 0) {
+		return [];
 	}
 
-	if (openPeriod) {
-		periods.push(openPeriod);
+	const periods: OwnershipPeriod[] = [];
+	let runningBalance = 0n;
+
+	for (const entry of entries) {
+		const amount = toBigIntAmount(entry.amount, entry._id);
+		const isDebitSide = entry.debitAccountId === positionAccount._id;
+		const startDate = getStartDate(entry, isDebitSide);
+		const previousBalance = runningBalance;
+
+		if (isDebitSide) {
+			runningBalance += amount;
+			if (runningBalance > TOTAL_SUPPLY) {
+				throw new Error(
+					`Invalid ownership timeline: balance for ${positionAccount._id} exceeds total supply`
+				);
+			}
+
+			if (previousBalance > 0n) {
+				closeCurrentPeriod(periods, dayBefore(startDate));
+			}
+
+			if (runningBalance > 0n) {
+				periods.push({
+					lenderId: lenderId as OwnershipPeriod["lenderId"],
+					mortgageId: mortgageId as OwnershipPeriod["mortgageId"],
+					fraction: Number(runningBalance) / Number(TOTAL_SUPPLY),
+					fromDate: startDate,
+					toDate: null,
+				});
+			}
+			continue;
+		}
+
+		runningBalance -= amount;
+		if (runningBalance < 0n) {
+			throw new Error(
+				`Invalid ownership timeline: negative balance for ${positionAccount._id}`
+			);
+		}
+
+		if (previousBalance <= 0n) {
+			throw new Error(
+				`Invalid ownership timeline: credit entry ${entry._id} closes a zero-balance position`
+			);
+		}
+
+		closeCurrentPeriod(periods, entry.effectiveDate);
+
+		if (runningBalance > 0n) {
+			periods.push({
+				lenderId: lenderId as OwnershipPeriod["lenderId"],
+				mortgageId: mortgageId as OwnershipPeriod["mortgageId"],
+				fraction: Number(runningBalance) / Number(TOTAL_SUPPLY),
+				fromDate: dayAfter(entry.effectiveDate),
+				toDate: null,
+			});
+		}
 	}
 
 	return periods;

--- a/specs/ENG-70/chunks/chunk-01-ownership-period-derivation/context.md
+++ b/specs/ENG-70/chunks/chunk-01-ownership-period-derivation/context.md
@@ -1,0 +1,252 @@
+# Chunk Context: ownership-period-derivation
+
+Source: Linear ENG-70, Notion requirement/spec/feature pages, and local ledger/accrual code.
+This file and the accompanying tasks.md contain everything needed to implement this chunk.
+
+## Implementation Plan Excerpt
+
+From `Ownership period derivation from ledger journal entries`:
+
+> `getOwnershipPeriods` must reconstruct an investor's ownership timeline by scanning ledger journal entries. The algorithm queries `SHARES_ISSUED`, `SHARES_TRANSFERRED`, `SHARES_COMMITTED`, and `SHARES_REDEEMED` entries, filters out `SHARES_RESERVED` and `SHARES_VOIDED`, and builds a chronological list of `{fraction, fromDate, toDate}` periods.
+
+Acceptance Criteria:
+
+> 1. Single owner: one open period with fraction 1.0
+> 2. Deal close: seller period includes closing date, buyer starts day after
+> 3. Multiple transfers: correct period chain with no gaps/overlaps
+> 4. Full exit: closed period with correct toDate
+> 5. SHARES_RESERVED/VOIDED excluded from derivation
+
+Rationale:
+
+> Ownership period derivation is the bridge between the ownership ledger (Project 3) and the accrual computation engine. Every accrual calculation depends on correct period reconstruction.
+
+From `Interest Accrual Computation Engine`:
+
+> Reconstructs ownership periods from ledger journal entries (`SHARES_ISSUED`, `SHARES_COMMITTED`, `SHARES_REDEEMED`). For a given mortgage and investor, builds a timeline of `{ fraction, fromDate, toDate }` periods. Each period's accrual is `rate × fraction × days / 365 × principal`.
+
+> Closing date accrues to the seller. Buyer's accrual starts the day after closing. This is derived naturally from ownership periods — no special proration logic needed.
+
+## SPEC 1.6 Excerpt
+
+From `SPEC 1.6 — Accrual & Dispersal Engine`, section `3.1 Ownership Period Derivation`:
+
+```typescript
+export type OwnershipPeriod = {
+  lenderId: Id<"lenders">;
+  mortgageId: Id<"mortgages">;
+  fraction: number;           // 0-1 (units / 10000)
+  fromDate: string;           // YYYY-MM-DD, inclusive
+  toDate: string | null;      // YYYY-MM-DD, inclusive. null = still active
+};
+
+/**
+ * Derives ownership periods for a single investor on a single mortgage.
+ * Reads ledger journal entries and builds a timeline of { fraction, fromDate, toDate }.
+ *
+ * Algorithm:
+ * 1. Query all journal entries for this mortgage, ordered by sequenceNumber
+ * 2. Filter to entries involving this investor's POSITION account
+ * 3. Walk entries chronologically, tracking running balance
+ * 4. Each balance change creates a new period (close previous, open new)
+ *
+ * The effectiveDate on journal entries is the business date of the ownership change.
+ * Closing date accrues to the SELLER — meaning the seller's last period includes
+ * the closing date, and the buyer's first period starts the day after.
+ */
+```
+
+## Corrected Drift from Current Codebase
+
+From `ENG-67 — Interest Accrual Computation Engine (Replanned)`:
+
+> `investorId: v.id("investors")` on ledger accounts → `lenderId: v.optional(v.string())` on `ledger_accounts`
+
+> `accounts` table → `ledger_accounts` table
+
+> `journalEntries` table → `ledger_journal_entries` table
+
+> `by_mortgage_and_investor` → `by_mortgage_and_lender`
+
+> `mortgage.principalBalance` → `mortgage.principal`
+
+> `mortgage.annualRate` → `mortgage.interestRate`
+
+Verified implementation guidance:
+
+```typescript
+const AUDIT_ONLY_TYPES = new Set(["SHARES_RESERVED", "SHARES_VOIDED"]);
+
+export async function getOwnershipPeriods(
+  ctx: { db: QueryCtx["db"] },
+  mortgageId: Id<"mortgages">,
+  lenderId: string,
+): Promise<OwnershipPeriod[]> {
+  const positionAccount = await ctx.db
+    .query("ledger_accounts")
+    .withIndex("by_mortgage_and_lender", q =>
+      q.eq("mortgageId", mortgageId as string).eq("lenderId", lenderId)
+    )
+    .filter(q => q.eq(q.field("type"), "POSITION"))
+    .first();
+
+  if (!positionAccount) return [];
+}
+```
+
+## Test Expectations
+
+From `ENG-76 — Tests: Ownership Period Derivation`:
+
+> - Single owner, no transfers → one open period
+> - Deal close (seller + buyer periods, closing date in seller's period)
+> - Multiple sequential transfers → correct period chain
+> - Full exit (sell all) → closed period
+> - SHARES_RESERVED/VOIDED excluded from derivation
+
+Data seeding notes:
+
+> Seed data uses actual schema field names (`ledger_accounts`, `ledger_journal_entries`, `lenderId`).
+
+> `sequenceNumber` is `int64` — use `1n`, `2n`, etc.
+
+> Closing date logic is subtle — seller's period includes `effectiveDate` for `SHARES_COMMITTED`; buyer starts day after.
+
+## Local Types & Helpers
+
+From `convex/accrual/types.ts`:
+
+```typescript
+export interface OwnershipPeriod {
+  fraction: number;
+  fromDate: string;
+  lenderId: Id<"lenders">;
+  mortgageId: Id<"mortgages">;
+  toDate: string | null;
+}
+```
+
+From `convex/ledger/constants.ts`:
+
+```typescript
+export const TOTAL_SUPPLY = 10_000n;
+
+export const AUDIT_ONLY_ENTRY_TYPES: ReadonlySet<string> = new Set([
+  "SHARES_RESERVED",
+  "SHARES_VOIDED",
+]);
+```
+
+From `convex/ledger/accountOwnership.ts`:
+
+```typescript
+export function getAccountLenderId(
+  account: LegacyOwnedLedgerAccount
+): string | undefined {
+  return account.lenderId ?? account.investorId;
+}
+```
+
+From `convex/ledger/accounts.ts`:
+
+```typescript
+export function getPostedBalance(
+  account: Pick<Doc<"ledger_accounts">, "cumulativeDebits" | "cumulativeCredits">
+): bigint {
+  return account.cumulativeDebits - account.cumulativeCredits;
+}
+```
+
+From `convex/ledger/queries.ts`:
+
+```typescript
+function compareSequenceNumbers(
+  left: { sequenceNumber: bigint },
+  right: { sequenceNumber: bigint }
+) {
+  if (left.sequenceNumber < right.sequenceNumber) {
+    return -1;
+  }
+  if (left.sequenceNumber > right.sequenceNumber) {
+    return 1;
+  }
+  return 0;
+}
+```
+
+```typescript
+export const getPositions = ledgerQuery
+  .input({ mortgageId: v.string() })
+  .handler(async (ctx, args) => {
+    const accounts = await ctx.db
+      .query("ledger_accounts")
+      .withIndex("by_type_and_mortgage", (q) =>
+        q.eq("type", "POSITION").eq("mortgageId", args.mortgageId)
+      )
+      .collect();
+
+    const nonZero = accounts.filter((a) => getPostedBalance(a) > 0n);
+```
+
+From `convex/schema.ts`:
+
+```typescript
+ledger_accounts: defineTable({
+  type: v.union(
+    v.literal("WORLD"),
+    v.literal("TREASURY"),
+    v.literal("POSITION")
+  ),
+  mortgageId: v.optional(v.string()),
+  lenderId: v.optional(v.string()),
+  cumulativeDebits: v.int64(),
+  cumulativeCredits: v.int64(),
+  pendingDebits: v.optional(v.int64()),
+  pendingCredits: v.optional(v.int64()),
+  createdAt: v.number(),
+  metadata: v.optional(v.any()),
+})
+  .index("by_mortgage", ["mortgageId"])
+  .index("by_lender", ["lenderId"])
+  .index("by_mortgage_and_lender", ["mortgageId", "lenderId"])
+  .index("by_type_and_mortgage", ["type", "mortgageId"]),
+```
+
+```typescript
+ledger_journal_entries: defineTable({
+  sequenceNumber: v.int64(),
+  entryType: v.union(
+    v.literal("MORTGAGE_MINTED"),
+    v.literal("SHARES_ISSUED"),
+    v.literal("SHARES_TRANSFERRED"),
+    v.literal("SHARES_REDEEMED"),
+    v.literal("MORTGAGE_BURNED"),
+    v.literal("SHARES_RESERVED"),
+    v.literal("SHARES_COMMITTED"),
+    v.literal("SHARES_VOIDED"),
+    v.literal("CORRECTION")
+  ),
+  reservationId: v.optional(v.id("ledger_reservations")),
+  mortgageId: v.string(),
+  effectiveDate: v.string(),
+  timestamp: v.number(),
+  debitAccountId: v.id("ledger_accounts"),
+  creditAccountId: v.id("ledger_accounts"),
+  amount: v.union(v.number(), v.int64()),
+  idempotencyKey: v.string(),
+```
+
+## Constraints & Rules
+
+- No new tables. `ENG-70` is pure read-side derivation.
+- Keep the helper dependency-injected. Do not bind it to full Convex runtime state when `{ db }` is sufficient.
+- Use repo terminology: `lender`, not `investor`, in all new code.
+- Preserve full precision. No rounding belongs in ownership-period derivation.
+- Respect the repo quality gate: `bun check`, `bun typecheck`, `bunx convex codegen`.
+
+## File Structure
+
+Target files for this chunk:
+
+- `convex/accrual/ownershipPeriods.ts`
+- `convex/accrual/__tests__/ownershipPeriods.test.ts`

--- a/specs/ENG-70/chunks/chunk-01-ownership-period-derivation/status.md
+++ b/specs/ENG-70/chunks/chunk-01-ownership-period-derivation/status.md
@@ -1,0 +1,25 @@
+# Chunk 01: ownership-period-derivation — Status
+
+Completed: 2026-03-19
+
+## Tasks Completed
+- [x] T-001: Create `convex/accrual/ownershipPeriods.ts` exporting `getOwnershipPeriods(ctx, mortgageId, lenderId): Promise<OwnershipPeriod[]>` as a pure read helper with injected `{ db }` access only.
+- [x] T-002: Resolve the lender's `POSITION` account using the actual ledger schema and compatibility helpers: query `ledger_accounts` via `by_mortgage_and_lender`, tolerate legacy ownership rows through `getAccountLenderId`, and return `[]` when the lender has no position for the mortgage.
+- [x] T-003: Query debit and credit journal entries from `ledger_journal_entries`, merge and deduplicate them, exclude audit-only entries (`SHARES_RESERVED`, `SHARES_VOIDED`), and sort deterministically by `sequenceNumber`.
+- [x] T-004: Build ownership periods from running balance changes using `dayAfter()` and `dayBefore()`, with the closing-date rule preserved: seller keeps `SHARES_COMMITTED.effectiveDate`, buyer starts the next day, full exits close the previous period, and each period fraction is `Number(balance) / Number(TOTAL_SUPPLY)`.
+- [x] T-005: Create `convex/accrual/__tests__/ownershipPeriods.test.ts` with `convex-test` coverage for single-owner issuance, deal-close transfer proration boundaries, multiple sequential transfers, full exit, and ignored audit-only entries.
+
+## Tasks Incomplete
+- [ ] T-006: Run the quality gate required by repo policy: `bun check`, `bun typecheck`, and `bunx convex codegen`. `bun check` now passes, but the remaining gate is blocked by unrelated pre-existing repo type errors and missing Convex deployment configuration.
+
+## Quality Gate
+- `bun check`: pass
+- `bun typecheck`: fail
+- `bunx convex codegen`: fail
+- Targeted verification: `bunx vitest run convex/accrual/__tests__/ownershipPeriods.test.ts` passed
+
+## Notes
+- The helper and tests are implemented against the repo's actual ledger schema and mutation names.
+- `bun test` is not a valid runner for these test files here because `import.meta.glob` is only supported under the Vite/Vitest toolchain used by this repo.
+- `bun typecheck` currently fails outside ENG-70 in existing files including `convex/deals/__tests__/access.test.ts`, `convex/deals/__tests__/dealClosing.test.ts`, `convex/deals/__tests__/effects.test.ts`, `convex/ledger/__tests__/ledger.test.ts`, `src/components/admin/deal-card.tsx`, `src/routes/demo/convex-ledger.tsx`, and `src/routes/demo/prod-ledger.tsx`.
+- `bunx convex codegen` currently fails with `No CONVEX_DEPLOYMENT set, run "npx convex dev" to configure a Convex project`.

--- a/specs/ENG-70/chunks/chunk-01-ownership-period-derivation/tasks.md
+++ b/specs/ENG-70/chunks/chunk-01-ownership-period-derivation/tasks.md
@@ -1,0 +1,8 @@
+# Chunk 01: ownership-period-derivation
+
+- [x] T-001: Create `convex/accrual/ownershipPeriods.ts` exporting `getOwnershipPeriods(ctx, mortgageId, lenderId): Promise<OwnershipPeriod[]>` as a pure read helper with injected `{ db }` access only.
+- [x] T-002: Resolve the lender's `POSITION` account using the actual ledger schema and compatibility helpers: query `ledger_accounts` via `by_mortgage_and_lender`, tolerate legacy ownership rows through `getAccountLenderId`, and return `[]` when the lender has no position for the mortgage.
+- [x] T-003: Query debit and credit journal entries from `ledger_journal_entries`, merge and deduplicate them, exclude audit-only entries (`SHARES_RESERVED`, `SHARES_VOIDED`), and sort deterministically by `sequenceNumber`.
+- [x] T-004: Build ownership periods from running balance changes using `dayAfter()` and `dayBefore()`, with the closing-date rule preserved: seller keeps `SHARES_COMMITTED.effectiveDate`, buyer starts the next day, full exits close the previous period, and each period fraction is `Number(balance) / Number(TOTAL_SUPPLY)`.
+- [x] T-005: Create `convex/accrual/__tests__/ownershipPeriods.test.ts` with `convex-test` coverage for single-owner issuance, deal-close transfer proration boundaries, multiple sequential transfers, full exit, and ignored audit-only entries.
+- [ ] T-006: Run the quality gate required by repo policy: `bun check`, `bun typecheck`, and `bunx convex codegen`. `bun check` passes; `bun typecheck` currently fails on unrelated pre-existing repo errors, and `bunx convex codegen` is blocked because `CONVEX_DEPLOYMENT` is not configured in this environment.

--- a/specs/ENG-70/chunks/manifest.md
+++ b/specs/ENG-70/chunks/manifest.md
@@ -1,0 +1,24 @@
+# Implementation Manifest: ENG-70 — Ownership Period Derivation from Ledger Journal
+
+Generated: 2026-03-19
+Source: Linear ENG-70, Notion requirement page, `SPEC 1.6`, ENG-67 replanned implementation doc
+
+| Chunk | Label | Tasks | Status |
+| ----- | ----- | ----- | ------ |
+| 01 | ownership-period-derivation | T-001, T-002, T-003, T-004, T-005, T-006 | partial |
+
+Status values: `pending` | `in-progress` | `complete` | `partial` | `blocked`
+
+## Execution Order
+1. `chunk-01-ownership-period-derivation` — the issue scope is narrow enough to keep implementation, tests, and the quality gate together.
+
+## Context Sources
+- Notion requirement: `Ownership period derivation from ledger journal entries` (`327fc1b4-4024-81d9-b71a-fb3470b3490a`)
+- Notion feature: `Interest Accrual Computation Engine` (`323fc1b4-4024-8193-8978-e3c68cb722e8`)
+- Notion spec: `SPEC 1.6 — Accrual & Dispersal Engine` (`323fc1b4-4024-8153-889d-d0d242c243c4`)
+- Notion implementation plan: `ENG-67 — Interest Accrual Computation Engine (Replanned)` (`328fc1b4-4024-8178-8cff-f6cd8c888eb6`)
+- Notion test plan: `ENG-76 — Tests: Ownership Period Derivation` (`327fc1b4-4024-81e0-88f5-e1dedfb8ec4d`)
+- Local code: `convex/accrual/types.ts`, `convex/ledger/constants.ts`, `convex/ledger/queries.ts`, `convex/ledger/accountOwnership.ts`, `convex/ledger/accounts.ts`, `convex/schema.ts`
+
+## Context Gap
+- Direct Linear attachments/relations were not available from the local fetch script because `LINEAR_API_KEY` is unset. No blocking issue descriptions were imported from Linear for this plan.

--- a/specs/ENG-70/tasks.md
+++ b/specs/ENG-70/tasks.md
@@ -1,0 +1,18 @@
+# Tasks: ENG-70 — Ownership Period Derivation from Ledger Journal
+
+Source: Linear ENG-70, Notion requirement page, `SPEC 1.6`, and the current accrual/ledger code in this repo.
+Generated: 2026-03-19
+
+## Notes
+- Linear issue attachments/relations could not be fetched via the local script because `LINEAR_API_KEY` is not set in this environment.
+- This plan is grounded in the linked Notion requirement page (`327fc1b4-4024-81d9-b71a-fb3470b3490a`), the current ENG-67 accrual-engine plan, `SPEC 1.6`, and the repo's actual schema/helpers.
+
+## Phase 1: Ownership Period Helper
+- [x] T-001: Create `convex/accrual/ownershipPeriods.ts` exporting `getOwnershipPeriods(ctx, mortgageId, lenderId): Promise<OwnershipPeriod[]>` as a pure read helper with injected `{ db }` access only.
+- [x] T-002: Resolve the lender's `POSITION` account using the actual ledger schema and compatibility helpers: query `ledger_accounts` via `by_mortgage_and_lender`, tolerate legacy ownership rows through `getAccountLenderId`, and return `[]` when the lender has no position for the mortgage.
+- [x] T-003: Query debit and credit journal entries from `ledger_journal_entries`, merge and deduplicate them, exclude audit-only entries (`SHARES_RESERVED`, `SHARES_VOIDED`), and sort deterministically by `sequenceNumber`.
+- [x] T-004: Build ownership periods from running balance changes using `dayAfter()` and `dayBefore()`, with the closing-date rule preserved: seller keeps `SHARES_COMMITTED.effectiveDate`, buyer starts the next day, full exits close the previous period, and each period fraction is `Number(balance) / Number(TOTAL_SUPPLY)`.
+
+## Phase 2: Tests and Verification
+- [x] T-005: Create `convex/accrual/__tests__/ownershipPeriods.test.ts` with `convex-test` coverage for single-owner issuance, deal-close transfer proration boundaries, multiple sequential transfers, full exit, and ignored audit-only entries.
+- [ ] T-006: Run the quality gate required by repo policy: `bun check`, `bun typecheck`, and `bunx convex codegen`. `bun check` passes; `bun typecheck` currently fails on unrelated pre-existing repo errors, and `bunx convex codegen` is blocked because `CONVEX_DEPLOYMENT` is not configured in this environment.


### PR DESCRIPTION
### TL;DR

Implements ownership period derivation from ledger journal entries to reconstruct investor ownership timelines for accrual calculations.

### What changed?

Added `getOwnershipPeriods` function in `convex/accrual/ownershipPeriods.ts` that reconstructs ownership periods by:
- Querying ledger journal entries for a specific mortgage and lender
- Filtering out audit-only entries (`SHARES_RESERVED`, `SHARES_VOIDED`) 
- Building chronological ownership periods with fraction, start date, and end date
- Handling ownership transitions where sellers keep the closing date and buyers start the next day

The implementation includes comprehensive test coverage for single ownership, deal closings, sequential transfers, full exits, and audit entry exclusion.

### How to test?

Run the test suite:
```bash
bunx vitest run convex/accrual/__tests__/ownershipPeriods.test.ts
```

The tests cover:
- Single owner scenarios returning one open period
- Deal closing logic with proper date boundaries between seller and buyer
- Multiple sequential transfers creating correct period chains
- Full exit scenarios that properly close periods
- Exclusion of reserved and voided share entries

### Why make this change?

This establishes the foundation for the interest accrual computation engine by providing accurate ownership period reconstruction from the ledger. The ownership periods are essential for calculating how much interest each lender should accrue based on their ownership fraction and time periods, enabling proper revenue distribution in the mortgage lending platform.

## Summary by Sourcery

Implement ownership period derivation for lenders from ledger journal entries and add supporting docs and tests for the accrual engine.

New Features:
- Add getOwnershipPeriods helper to derive lender ownership timelines for a mortgage based on ledger journal entries.

Enhancements:
- Refine dispersal-related TypeScript types to use interfaces and align field ordering.
- Document ENG-70 ownership period derivation scope, tasks, and implementation status under specs.

Tests:
- Introduce convex-test/Vitest suite covering ownership period derivation scenarios including single owner, deal closings, sequential transfers, full exits, and exclusion of audit-only entries.