### PR TITLE
fix: resolve PR #234 review feedback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -316,5 +316,5 @@ When spawning subagents (Agent/Task tool), the routing block is automatically in
 | Command | Action |
 |---------|--------|
 | `ctx stats` | Call the `ctx_stats` MCP tool and display the full output verbatim |
-| `ctx doctor` | Call the `ctx_doctor` MCP tool, run the returned shell command, display as checklist |
-| `ctx upgrade` | Call the `ctx_upgrade` MCP tool, run the returned shell command, display as checklist |
+| `ctx doctor` | Call the `ctx_doctor` MCP tool, display the returned shell command for user confirmation, then run it and display results as checklist |
+| `ctx upgrade` | Call the `ctx_upgrade` MCP tool, display the returned shell command for user confirmation, then run it and display results as checklist |

--- a/convex/dispersal/__tests__/createDispersalEntries.test.ts
+++ b/convex/dispersal/__tests__/createDispersalEntries.test.ts
@@ -272,13 +272,13 @@ describe("createDispersalEntries", () => {
 		const persistedEntries = (
 			await t.run(async (ctx) =>
 				Promise.all(
-					result.entries.map((entry) => ctx.db.get(entry.id as never))
+					result.entries.map((entry) => ctx.db.get(entry.id))
 				)
 			)
 		).filter((entry) => entry !== null);
 		const feeEntry = await t.run(async (ctx) =>
 			result.servicingFeeEntryId
-				? ctx.db.get(result.servicingFeeEntryId as never)
+				? ctx.db.get(result.servicingFeeEntryId)
 				: null
 		);
 
@@ -315,7 +315,7 @@ describe("createDispersalEntries", () => {
 
 		const feeEntry = await t.run(async (ctx) =>
 			result.servicingFeeEntryId
-				? ctx.db.get(result.servicingFeeEntryId as never)
+				? ctx.db.get(result.servicingFeeEntryId)
 				: null
 		);
 
@@ -350,7 +350,7 @@ describe("createDispersalEntries", () => {
 		const persistedEntries = (
 			await t.run(async (ctx) =>
 				Promise.all(
-					result.entries.map((entry) => ctx.db.get(entry.id as never))
+					result.entries.map((entry) => ctx.db.get(entry.id))
 				)
 			)
 		).filter((entry) => entry !== null);

--- a/convex/dispersal/__tests__/integration.test.ts
+++ b/convex/dispersal/__tests__/integration.test.ts
@@ -74,25 +74,42 @@ interface DispersalSummaryByLender {
 
 interface DispersalHistoryEntry {
 	amount: number;
+	calculationDetails: {
+		distributableAmount: number;
+		ownershipFraction: number;
+		ownershipUnits: number;
+		rawAmount: number;
+		roundedAmount: number;
+		servicingFee: number;
+		settledAmount: number;
+		totalUnits: number;
+	};
+	createdAt: number;
 	dispersalDate: string;
+	id: Id<"dispersalEntries">;
+	idempotencyKey: string;
+	lenderAccountId: Id<"ledger_accounts">;
 	lenderId: Id<"lenders">;
+	mortgageId: Id<"mortgages">;
+	obligationId: Id<"obligations">;
 	runningTotal: number;
+	servicingFeeDeducted: number;
+	status: "pending";
 }
 
 interface DispersalsByObligationResult {
 	byLender: DispersalSummaryByLender[];
-	entries: Array<{
-		amount: number;
-		lenderId: Id<"lenders">;
-	}>;
+	entries: DispersalHistoryEntry[];
 	entryCount: number;
+	obligationId: Id<"obligations">;
 	total: number;
 }
 
 interface DisbursementHistoryResult {
 	entries: DispersalHistoryEntry[];
 	entryCount: number;
-	pageTotal?: number;
+	lenderId: Id<"lenders">;
+	pageTotal: number;
 	total: number;
 }
 

--- a/convex/mortgages/paymentFrequency.ts
+++ b/convex/mortgages/paymentFrequency.ts
@@ -9,10 +9,15 @@ export const PERIODS_PER_YEAR: Record<PaymentFrequency, number> = {
 	weekly: 52,
 };
 
-export function getPeriodsPerYear(paymentFrequency: string): number {
-	const periodsPerYear = PERIODS_PER_YEAR[paymentFrequency as PaymentFrequency];
-	if (!periodsPerYear) {
+export function isPaymentFrequency(value: string): value is PaymentFrequency {
+	return value in PERIODS_PER_YEAR;
+}
+
+export function getPeriodsPerYear(
+	paymentFrequency: PaymentFrequency | string,
+): number {
+	if (!isPaymentFrequency(paymentFrequency)) {
 		throw new Error(`Unknown payment frequency: ${paymentFrequency}`);
 	}
-	return periodsPerYear;
+	return PERIODS_PER_YEAR[paymentFrequency];
 }

--- a/convex/payments/obligations/generateImpl.ts
+++ b/convex/payments/obligations/generateImpl.ts
@@ -1,7 +1,10 @@
 import { ConvexError } from "convex/values";
 import type { Id } from "../../_generated/dataModel";
 import type { MutationCtx } from "../../_generated/server";
-import { getPeriodsPerYear } from "../../mortgages/paymentFrequency";
+import {
+	type PaymentFrequency,
+	getPeriodsPerYear,
+} from "../../mortgages/paymentFrequency";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -41,7 +44,7 @@ export interface GenerateObligationsParams {
 	interestRate: number;
 	maturityDate: string; // ISO date string
 	mortgageId: Id<"mortgages">;
-	paymentFrequency: string;
+	paymentFrequency: PaymentFrequency;
 	principal: number;
 }
 


### PR DESCRIPTION
## Summary
- Addresses all 6 unresolved review threads from PR #234 (ENG-152) that were left open when the PR was merged
- Adds `isPaymentFrequency` type guard and replaces unsafe `as PaymentFrequency` casts with runtime validation
- Changes `GenerateObligationsParams.paymentFrequency` from `string` to `PaymentFrequency` union type
- Removes all `as never` casts in dispersal test — IDs are already properly typed
- Updates `DispersalHistoryEntry` and `DispersalsByObligationResult` test interfaces to match actual query return shapes
- Adds safety gate for `ctx_doctor`/`ctx_upgrade` commands in CLAUDE.md

## Test plan
- [x] `bun check` passes (lint + format)
- [x] `tsc --noEmit` passes (0 type errors)
- [ ] `bun run test` — unit tests pass
- [ ] Verify no regressions in dispersal test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)