### PR TITLE
ENG-181: Deal-related and fee-related cash event integration (#253)

### DIFF
--- a/convex/dispersal/createDispersalEntries.ts
+++ b/convex/dispersal/createDispersalEntries.ts
@@ -138,7 +138,8 @@ async function calculateServicingSplit(
 			? 0
 			: calculateServicingFee(
 					servicingConfig.annualRate,
-					args.mortgage.principal
+					args.mortgage.principal,
+					args.mortgage.paymentFrequency
 				);
 	const feeCashApplied = Math.min(args.settledAmount, feeDue);
 	return {


### PR DESCRIPTION
ENG-181: Deal-related and fee-related cash event integration (#253)

## Wire 4 deal/fee cash events through the posting pipeline

- postDealBuyerFundsReceived (CASH_RECEIVED → TRUST_CASH/CASH_CLEARING)
- postDealSellerPayout (LENDER_PAYOUT_SENT → LENDER_PAYABLE/TRUST_CASH)
- postLockingFeeReceived (CASH_RECEIVED → TRUST_CASH/UNAPPLIED_CASH)
- postCommitmentDepositReceived (CASH_RECEIVED → TRUST_CASH/UNAPPLIED_CASH)

Also fixes CREDIT_NORMAL_FAMILIES to include CASH_CLEARING and UNAPPLIED_CASH — these are liabilities (credit-normal) not assets, which corrects balance computation polarity for all future entries.

### Changes

- Adds 4 new integration functions in `integrations.ts` with proper idempotency keys and metadata
- Expands CASH_RECEIVED family map to accept CASH_CLEARING and UNAPPLIED_CASH as credit accounts
- Adds dealId field to journal entries schema with corresponding index
- Includes comprehensive test coverage for all functions including idempotency and error handling
- Corrects account normal balance classifications for proper accounting semantics

## Summary by Sourcery

Bug Fixes:
- Fix runtime crash in obligation settlement dispersal caused by missing paymentFrequency argument in servicing fee calculation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cash posting functions for deal-related transactions: buyer funds received, seller payouts, locking fees, and commitment deposits.
  * Added support for associating cash ledger entries with specific deals for better transaction tracking.

* **Tests**
  * Comprehensive test coverage for new cash posting functions, including idempotency and error handling scenarios.

* **Bug Fixes**
  * Corrected cash account balance preconditions in existing tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

ENG-224: Pass paymentFrequency to calculateServicingFee

ENG-152 added paymentFrequency as a required third parameter but the
caller in calculateServicingSplit was not updated, causing a runtime
crash on any obligation settlement triggering dispersal.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>