### PR TITLE
ENG-223: Flag CASH_APPLIED family map constraint for Phase 2+ sweep

### DIFF
--- a/convex/payments/cashLedger/types.ts
+++ b/convex/payments/cashLedger/types.ts
@@ -57,6 +57,9 @@ export const CASH_ENTRY_TYPE_FAMILY_MAP: Record<
 		debit: ["TRUST_CASH", "CASH_CLEARING", "UNAPPLIED_CASH"],
 		credit: ["BORROWER_RECEIVABLE", "CASH_CLEARING", "UNAPPLIED_CASH"],
 	},
+	// ENG-223: Phase 2+ sweep (sweepCashClearingToTrust) will need TRUST_CASH
+	// in debit and CASH_CLEARING in credit here. Current constraints only cover
+	// the obligation-applied path. Update when async providers are integrated.
 	CASH_APPLIED: {
 		debit: ["CONTROL", "UNAPPLIED_CASH"],
 		credit: ["CONTROL", "BORROWER_RECEIVABLE"],


### PR DESCRIPTION
The CASH_APPLIED entry type will need TRUST_CASH in debit and
CASH_CLEARING in credit when the async provider sweep mechanism
(sweepCashClearingToTrust) is implemented. Comment documents
this constraint so Phase 2+ work doesn't discover it late.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

## Summary by Sourcery

Enhancements:
- Add inline commentary to CASH_ENTRY_TYPE_FAMILY_MAP explaining the planned TRUST_CASH and CASH_CLEARING constraints for CASH_APPLIED in a future sweep implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added internal documentation for upcoming payment constraint updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->