### PR TITLE
ENG-222: Add unified idempotency key convention for cash ledger

### DIFF
--- a/convex/payments/cashLedger/integrations.ts
+++ b/convex/payments/cashLedger/integrations.ts
@@ -5,6 +5,7 @@ import { auditLog } from "../../auditLog";
 import type { CommandSource } from "../../engine/types";
 import { findCashAccount, getOrCreateCashAccount } from "./accounts";
 import { postCashEntryInternal } from "./postEntry";
+import { buildIdempotencyKey } from "./types";
 
 interface LegacySource {
 	actor?: string;
@@ -85,7 +86,7 @@ export async function postObligationAccrued(
 		amount: obligation.amount,
 		debitAccountId: receivableAccount._id,
 		creditAccountId: accrualControlAccount._id,
-		idempotencyKey: `cash-ledger:obligation-accrued:${obligation._id}`,
+		idempotencyKey: buildIdempotencyKey("obligation-accrued", obligation._id),
 		mortgageId: obligation.mortgageId,
 		obligationId: obligation._id,
 		borrowerId: obligation.borrowerId,
@@ -185,7 +186,7 @@ export async function postDealBuyerFundsReceived(
 		debitAccountId: trustCashAccount._id,
 		creditAccountId: cashClearingAccount._id,
 		// One buyer-funds entry per deal — idempotency key intentionally scoped to dealId only
-		idempotencyKey: `cash-ledger:deal-buyer-funds:${args.dealId}`,
+		idempotencyKey: buildIdempotencyKey("deal-buyer-funds", args.dealId),
 		mortgageId: deal.mortgageId,
 		dealId: args.dealId,
 		source: normalizeSource(args.source),
@@ -224,7 +225,7 @@ export async function postDealSellerPayout(
 		amount: args.amount,
 		debitAccountId: lenderPayableAccount._id,
 		creditAccountId: trustCashAccount._id,
-		idempotencyKey: `cash-ledger:deal-seller-payout:${args.dealId}:${args.lenderId}`,
+		idempotencyKey: buildIdempotencyKey("deal-seller-payout", args.dealId, args.lenderId),
 		mortgageId: deal.mortgageId,
 		dealId: args.dealId,
 		lenderId: args.lenderId,
@@ -260,8 +261,8 @@ export async function postLockingFeeReceived(
 		debitAccountId: trustCashAccount._id,
 		creditAccountId: unappliedCashAccount._id,
 		idempotencyKey: args.dealId
-			? `cash-ledger:locking-fee:${args.dealId}:${args.mortgageId}:${args.feeId}`
-			: `cash-ledger:locking-fee:${args.mortgageId}:${args.feeId}`,
+			? buildIdempotencyKey("locking-fee", args.dealId, args.mortgageId, args.feeId)
+			: buildIdempotencyKey("locking-fee", args.mortgageId, args.feeId),
 		mortgageId: args.mortgageId,
 		dealId: args.dealId,
 		source: normalizeSource(args.source),
@@ -296,8 +297,8 @@ export async function postCommitmentDepositReceived(
 		debitAccountId: trustCashAccount._id,
 		creditAccountId: unappliedCashAccount._id,
 		idempotencyKey: args.dealId
-			? `cash-ledger:commitment-deposit:${args.dealId}:${args.mortgageId}:${args.depositId}`
-			: `cash-ledger:commitment-deposit:${args.mortgageId}:${args.depositId}`,
+			? buildIdempotencyKey("commitment-deposit", args.dealId, args.mortgageId, args.depositId)
+			: buildIdempotencyKey("commitment-deposit", args.mortgageId, args.depositId),
 		mortgageId: args.mortgageId,
 		dealId: args.dealId,
 		source: normalizeSource(args.source),
@@ -334,7 +335,7 @@ export async function postOverpaymentToUnappliedCash(
 		amount: args.amount,
 		debitAccountId: trustCashAccount._id,
 		creditAccountId: unappliedCashAccount._id,
-		idempotencyKey: `cash-ledger:overpayment:${args.attemptId}`,
+		idempotencyKey: buildIdempotencyKey("overpayment", args.attemptId),
 		mortgageId: args.mortgageId,
 		attemptId: args.attemptId,
 		borrowerId: args.borrowerId,
@@ -384,7 +385,7 @@ export async function postSettlementAllocation(
 			amount: entry.amount,
 			debitAccountId: allocationControlAccount._id,
 			creditAccountId: lenderPayableAccount._id,
-			idempotencyKey: `cash-ledger:lender-payable:${entry.dispersalEntryId}`,
+			idempotencyKey: buildIdempotencyKey("lender-payable", entry.dispersalEntryId),
 			mortgageId: args.mortgageId,
 			obligationId: args.obligationId,
 			dispersalEntryId: entry.dispersalEntryId,
@@ -407,7 +408,7 @@ export async function postSettlementAllocation(
 			amount: args.servicingFee,
 			debitAccountId: allocationControlAccount._id,
 			creditAccountId: servicingRevenueAccount._id,
-			idempotencyKey: `cash-ledger:servicing-fee:${args.obligationId}`,
+			idempotencyKey: buildIdempotencyKey("servicing-fee", args.obligationId),
 			mortgageId: args.mortgageId,
 			obligationId: args.obligationId,
 			borrowerId: obligation.borrowerId,

--- a/convex/payments/cashLedger/postEntry.ts
+++ b/convex/payments/cashLedger/postEntry.ts
@@ -10,6 +10,7 @@ import { getNextCashSequenceNumber } from "./sequenceCounter";
 import {
 	CASH_ENTRY_TYPE_FAMILY_MAP,
 	type CashEntryType,
+	IDEMPOTENCY_KEY_PREFIX,
 	NEGATIVE_BALANCE_EXEMPT_FAMILIES,
 } from "./types";
 import { postCashEntryArgsValidator } from "./validators";
@@ -228,6 +229,12 @@ export async function postCashEntryInternal(
 ) {
 	// 1. VALIDATE_INPUT
 	validateInput(args);
+	// 1b. IDEMPOTENCY KEY PREFIX CHECK (warn-only, never reject)
+	if (!args.idempotencyKey.startsWith(IDEMPOTENCY_KEY_PREFIX)) {
+		console.warn(
+			`[postCashEntryInternal] idempotencyKey "${args.idempotencyKey}" does not start with "${IDEMPOTENCY_KEY_PREFIX}". Consider using buildIdempotencyKey().`
+		);
+	}
 	// 2. IDEMPOTENCY
 	const existing = await checkIdempotency(ctx, args.idempotencyKey);
 	if (existing) {

--- a/convex/payments/cashLedger/types.ts
+++ b/convex/payments/cashLedger/types.ts
@@ -135,3 +135,28 @@ export const CREDIT_NORMAL_FAMILIES: ReadonlySet<CashAccountFamily> = new Set([
 // already excluded from balance checks (Tech Design §9.1 Step 5).
 export const NEGATIVE_BALANCE_EXEMPT_FAMILIES: ReadonlySet<CashAccountFamily> =
 	new Set(["CONTROL", "BORROWER_RECEIVABLE"]);
+
+// ── Idempotency Key Convention ──────────────────────────────────────
+// All cash ledger journal entries use the prefix `cash-ledger:` followed
+// by a kebab-case entry type and source identifiers:
+//   cash-ledger:{entry-type}:{source-id}
+//   cash-ledger:{entry-type}:{source-type}:{source-id}
+
+export const IDEMPOTENCY_KEY_PREFIX = "cash-ledger:" as const;
+
+/**
+ * Build a standardised idempotency key for cash ledger entries.
+ *
+ * @param entryType  Kebab-case operation name (e.g. "obligation-accrued", "cash-received")
+ * @param segments   One or more source identifiers (e.g. sourceType, sourceId)
+ * @returns          `cash-ledger:{entryType}:{segments joined by ":"}`
+ */
+export function buildIdempotencyKey(
+	entryType: string,
+	...segments: string[]
+): string {
+	if (segments.length === 0) {
+		throw new Error("buildIdempotencyKey requires at least one segment");
+	}
+	return `${IDEMPOTENCY_KEY_PREFIX}${entryType}:${segments.join(":")}`;
+}


### PR DESCRIPTION
Add buildIdempotencyKey() helper and IDEMPOTENCY_KEY_PREFIX constant
to enforce a consistent `cash-ledger:{type}:{source}` key format.
Warn (never reject) on non-conforming keys in postCashEntryInternal().
Migrate all integration functions to use the helper (output unchanged).

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

## Summary by Sourcery

Standardize cash ledger idempotency keys and add guardrails for their usage across integrations.

New Features:
- Introduce a helper to build standardized cash ledger idempotency keys with a shared prefix constant.
- Log warnings when cash ledger entries use non-standard idempotency key prefixes without rejecting the request.

Enhancements:
- Refactor all cash ledger integration functions to construct idempotency keys via the shared helper for consistent formatting.