### PR TITLE
eng-172

### DIFF
--- a/convex/payments/cashLedger/__tests__/reversalCascade.test.ts
+++ b/convex/payments/cashLedger/__tests__/reversalCascade.test.ts
@@ -1,0 +1,1045 @@
+import { ConvexError } from "convex/values";
+import { describe, expect, it } from "vitest";
+import type { Id } from "../../../_generated/dataModel";
+import { getOrCreateCashAccount } from "../accounts";
+import {
+	assertReversalAmountValid,
+	postCashReceiptForObligation,
+	postObligationAccrued,
+	postPaymentReversalCascade,
+	postSettlementAllocation,
+	postTransferReversal,
+} from "../integrations";
+import { postCashEntryInternal } from "../postEntry";
+import { buildIdempotencyKey } from "../types";
+import {
+	createHarness,
+	createSettledObligation,
+	SYSTEM_SOURCE,
+	seedMinimalEntities,
+} from "./testUtils";
+
+const modules = import.meta.glob("/convex/**/*.ts");
+
+// ── Shared helpers ─────────────────────────────────────────────────
+
+/**
+ * Sets up a full settlement flow: seeds entities, creates an obligation,
+ * posts OBLIGATION_ACCRUED, CASH_RECEIVED, and a settlement allocation
+ * (2 lender payables + servicing fee). Returns all IDs and the allocation
+ * posting group ID needed for reversal tests.
+ */
+async function setupFullSettlementFlow(
+	t: ReturnType<typeof createHarness>,
+	opts?: { servicingFee?: number; amount?: number }
+) {
+	const amount = opts?.amount ?? 100_000;
+	const servicingFee = opts?.servicingFee ?? 1000;
+
+	const seeded = await seedMinimalEntities(t);
+
+	// Create a settled obligation
+	const obligationId = await createSettledObligation(t, {
+		mortgageId: seeded.mortgageId,
+		borrowerId: seeded.borrowerId,
+		amount,
+	});
+
+	// Post OBLIGATION_ACCRUED
+	await t.run(async (ctx) => {
+		await postObligationAccrued(ctx, {
+			obligationId,
+			source: SYSTEM_SOURCE,
+		});
+	});
+
+	// Post CASH_RECEIVED (using an attempt-based key so the cascade can find it)
+	// First we need a collectionPlanEntry and collectionAttempt
+	const attemptId = await t.run(async (ctx) => {
+		const planEntryId = await ctx.db.insert("collectionPlanEntries", {
+			obligationIds: [obligationId],
+			amount,
+			method: "manual",
+			scheduledDate: Date.now(),
+			status: "completed",
+			source: "default_schedule",
+			createdAt: Date.now(),
+		});
+		return ctx.db.insert("collectionAttempts", {
+			status: "settled",
+			planEntryId,
+			method: "manual",
+			amount,
+			initiatedAt: Date.now(),
+			settledAt: Date.now(),
+		});
+	});
+
+	await t.run(async (ctx) => {
+		await postCashReceiptForObligation(ctx, {
+			obligationId,
+			amount,
+			idempotencyKey: buildIdempotencyKey("cash-received", String(attemptId)),
+			effectiveDate: "2026-03-01",
+			attemptId,
+			source: SYSTEM_SOURCE,
+		});
+	});
+
+	// Create dispersalEntries so allocation can reference them
+	const { dispersalEntryAId, dispersalEntryBId } = await t.run(async (ctx) => {
+		const accounts = await ctx.db
+			.query("ledger_accounts")
+			.withIndex("by_type_and_mortgage", (q) =>
+				q.eq("type", "POSITION").eq("mortgageId", String(seeded.mortgageId))
+			)
+			.collect();
+
+		if (accounts.length < 2) {
+			throw new Error("Expected at least two ledger accounts");
+		}
+
+		const lenderAShare = Math.round(((amount - servicingFee) * 6000) / 10_000);
+		const lenderBShare = amount - servicingFee - lenderAShare;
+
+		const deA = await ctx.db.insert("dispersalEntries", {
+			obligationId,
+			mortgageId: seeded.mortgageId,
+			lenderId: seeded.lenderAId,
+			lenderAccountId: accounts[0]._id,
+			amount: lenderAShare,
+			dispersalDate: "2026-03-01",
+			servicingFeeDeducted: 0,
+			status: "pending",
+			idempotencyKey: buildIdempotencyKey(
+				"dispersal",
+				"test-a",
+				String(obligationId)
+			),
+			calculationDetails: {
+				settledAmount: amount,
+				servicingFee,
+				distributableAmount: amount - servicingFee,
+				feeDue: servicingFee,
+				feeCashApplied: servicingFee,
+				feeReceivable: 0,
+				ownershipUnits: 6000,
+				totalUnits: 10_000,
+				ownershipFraction: 0.6,
+				rawAmount: lenderAShare,
+				roundedAmount: lenderAShare,
+				sourceObligationType: "regular_interest",
+			},
+			createdAt: Date.now(),
+		});
+		const deB = await ctx.db.insert("dispersalEntries", {
+			obligationId,
+			mortgageId: seeded.mortgageId,
+			lenderId: seeded.lenderBId,
+			lenderAccountId: accounts[1]._id,
+			amount: lenderBShare,
+			dispersalDate: "2026-03-01",
+			servicingFeeDeducted: 0,
+			status: "pending",
+			idempotencyKey: buildIdempotencyKey(
+				"dispersal",
+				"test-b",
+				String(obligationId)
+			),
+			calculationDetails: {
+				settledAmount: amount,
+				servicingFee,
+				distributableAmount: amount - servicingFee,
+				feeDue: servicingFee,
+				feeCashApplied: servicingFee,
+				feeReceivable: 0,
+				ownershipUnits: 4000,
+				totalUnits: 10_000,
+				ownershipFraction: 0.4,
+				rawAmount: lenderBShare,
+				roundedAmount: lenderBShare,
+				sourceObligationType: "regular_interest",
+			},
+			createdAt: Date.now(),
+		});
+		return { dispersalEntryAId: deA, dispersalEntryBId: deB };
+	});
+
+	// Compute lender shares for settlement
+	const lenderAShare = Math.round(((amount - servicingFee) * 6000) / 10_000);
+	const lenderBShare = amount - servicingFee - lenderAShare;
+
+	// Post settlement allocation (2 lender payables + servicing fee)
+	await t.run(async (ctx) => {
+		await postSettlementAllocation(ctx, {
+			obligationId,
+			mortgageId: seeded.mortgageId,
+			settledDate: "2026-03-01",
+			servicingFee,
+			entries: [
+				{
+					dispersalEntryId: dispersalEntryAId,
+					lenderId: seeded.lenderAId,
+					amount: lenderAShare,
+				},
+				{
+					dispersalEntryId: dispersalEntryBId,
+					lenderId: seeded.lenderBId,
+					amount: lenderBShare,
+				},
+			],
+			source: SYSTEM_SOURCE,
+		});
+	});
+
+	return {
+		...seeded,
+		obligationId,
+		attemptId,
+		servicingFee,
+		lenderAShare,
+		lenderBShare,
+		dispersalEntryAId,
+		dispersalEntryBId,
+		amount,
+		allocationGroupId: `allocation:${obligationId}`,
+	};
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// T-008: Full Reversal Cascade
+// ═══════════════════════════════════════════════════════════════════
+
+describe("T-008: Full reversal cascade", () => {
+	it("reverses CASH_RECEIVED + 2×LENDER_PAYABLE_CREATED + SERVICING_FEE with correct accounts", async () => {
+		const t = createHarness(modules);
+		const setup = await setupFullSettlementFlow(t);
+
+		const result = await t.run(async (ctx) => {
+			return postPaymentReversalCascade(ctx, {
+				attemptId: setup.attemptId,
+				obligationId: setup.obligationId,
+				mortgageId: setup.mortgageId,
+				effectiveDate: "2026-03-15",
+				source: SYSTEM_SOURCE,
+				reason: "Payment returned NSF",
+			});
+		});
+
+		// Should have at least 4 entries: 1 cash_received + 2 lender_payable + 1 servicing_fee
+		expect(result.reversalEntries.length).toBeGreaterThanOrEqual(4);
+
+		// All entries are REVERSAL type
+		for (const entry of result.reversalEntries) {
+			expect(entry.entryType).toBe("REVERSAL");
+		}
+
+		// Verify CASH_RECEIVED reversal exists
+		const cashReceivedReversal = result.reversalEntries.find(
+			(e) =>
+				e.idempotencyKey.includes("cash-received") &&
+				e.idempotencyKey.includes("reversal")
+		);
+		expect(cashReceivedReversal).toBeDefined();
+		expect(cashReceivedReversal?.amount).toBe(BigInt(setup.amount));
+
+		// Verify LENDER_PAYABLE_CREATED reversals exist (one per lender)
+		const lenderPayableReversals = result.reversalEntries.filter((e) =>
+			e.idempotencyKey.includes("lender-payable")
+		);
+		expect(lenderPayableReversals).toHaveLength(2);
+
+		// Verify SERVICING_FEE reversal exists
+		const servicingFeeReversal = result.reversalEntries.find((e) =>
+			e.idempotencyKey.includes("servicing-fee")
+		);
+		expect(servicingFeeReversal).toBeDefined();
+		expect(servicingFeeReversal?.amount).toBe(BigInt(setup.servicingFee));
+
+		// clawbackRequired should be false (no payouts sent)
+		expect(result.clawbackRequired).toBe(false);
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// T-009: Cascade with Clawback
+// ═══════════════════════════════════════════════════════════════════
+
+describe("T-009: Cascade with clawback", () => {
+	it("fires Step 4 clawback when LENDER_PAYOUT_SENT entries exist", async () => {
+		const t = createHarness(modules);
+		const setup = await setupFullSettlementFlow(t);
+
+		// Post LENDER_PAYOUT_SENT for lender A
+		await t.run(async (ctx) => {
+			const lenderPayableAccount = await getOrCreateCashAccount(ctx, {
+				family: "LENDER_PAYABLE",
+				mortgageId: setup.mortgageId,
+				lenderId: setup.lenderAId,
+			});
+			const trustCashAccount = await getOrCreateCashAccount(ctx, {
+				family: "TRUST_CASH",
+				mortgageId: setup.mortgageId,
+			});
+
+			await postCashEntryInternal(ctx, {
+				entryType: "LENDER_PAYOUT_SENT",
+				effectiveDate: "2026-03-05",
+				amount: setup.lenderAShare,
+				debitAccountId: lenderPayableAccount._id,
+				creditAccountId: trustCashAccount._id,
+				idempotencyKey: buildIdempotencyKey(
+					"lender-payout",
+					String(setup.lenderAId),
+					String(setup.obligationId)
+				),
+				mortgageId: setup.mortgageId,
+				obligationId: setup.obligationId,
+				lenderId: setup.lenderAId,
+				source: SYSTEM_SOURCE,
+			});
+		});
+
+		const result = await t.run(async (ctx) => {
+			return postPaymentReversalCascade(ctx, {
+				attemptId: setup.attemptId,
+				obligationId: setup.obligationId,
+				mortgageId: setup.mortgageId,
+				effectiveDate: "2026-03-15",
+				source: SYSTEM_SOURCE,
+				reason: "Payment returned NSF - clawback needed",
+			});
+		});
+
+		// clawbackRequired should be true
+		expect(result.clawbackRequired).toBe(true);
+
+		// Should have 5+ entries: 1 cash_received + 2 lender_payable + 1 servicing_fee + 1 payout clawback
+		expect(result.reversalEntries.length).toBeGreaterThanOrEqual(5);
+
+		// Verify payout clawback entry exists
+		const clawbackEntries = result.reversalEntries.filter((e) =>
+			e.idempotencyKey.includes("payout-clawback")
+		);
+		expect(clawbackEntries.length).toBeGreaterThanOrEqual(1);
+
+		// Verify the clawback entry reverses the payout (swap debit/credit)
+		const clawback = clawbackEntries[0];
+		expect(clawback.entryType).toBe("REVERSAL");
+		expect(clawback.amount).toBe(BigInt(setup.lenderAShare));
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// T-010: Cascade without Clawback
+// ═══════════════════════════════════════════════════════════════════
+
+describe("T-010: Cascade without clawback", () => {
+	it("skips Step 4 when no LENDER_PAYOUT_SENT entries exist", async () => {
+		const t = createHarness(modules);
+		const setup = await setupFullSettlementFlow(t);
+
+		const result = await t.run(async (ctx) => {
+			return postPaymentReversalCascade(ctx, {
+				attemptId: setup.attemptId,
+				obligationId: setup.obligationId,
+				mortgageId: setup.mortgageId,
+				effectiveDate: "2026-03-15",
+				source: SYSTEM_SOURCE,
+				reason: "Payment returned - no payout yet",
+			});
+		});
+
+		expect(result.clawbackRequired).toBe(false);
+
+		// No payout-clawback entries should exist
+		const clawbackEntries = result.reversalEntries.filter((e) =>
+			e.idempotencyKey.includes("payout-clawback")
+		);
+		expect(clawbackEntries).toHaveLength(0);
+
+		// Should have exactly 4 entries: 1 cash_received + 2 lender_payable + 1 servicing_fee
+		expect(result.reversalEntries).toHaveLength(4);
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// T-011: Idempotency
+// ═══════════════════════════════════════════════════════════════════
+
+describe("T-011: Idempotency", () => {
+	it("calling cascade twice returns the same entries", async () => {
+		const t = createHarness(modules);
+		const setup = await setupFullSettlementFlow(t);
+
+		const first = await t.run(async (ctx) => {
+			return postPaymentReversalCascade(ctx, {
+				attemptId: setup.attemptId,
+				obligationId: setup.obligationId,
+				mortgageId: setup.mortgageId,
+				effectiveDate: "2026-03-15",
+				source: SYSTEM_SOURCE,
+				reason: "Idempotency test",
+			});
+		});
+
+		const second = await t.run(async (ctx) => {
+			return postPaymentReversalCascade(ctx, {
+				attemptId: setup.attemptId,
+				obligationId: setup.obligationId,
+				mortgageId: setup.mortgageId,
+				effectiveDate: "2026-03-15",
+				source: SYSTEM_SOURCE,
+				reason: "Idempotency test",
+			});
+		});
+
+		// Same posting group ID
+		expect(second.postingGroupId).toBe(first.postingGroupId);
+
+		// Same number of entries
+		expect(second.reversalEntries.length).toBe(first.reversalEntries.length);
+
+		// Same entry IDs (idempotent return)
+		const firstIds = first.reversalEntries.map((e) => e._id).sort();
+		const secondIds = second.reversalEntries.map((e) => e._id).sort();
+		expect(secondIds).toEqual(firstIds);
+
+		// Verify no duplicate entries were created in the DB
+		const entryCount = await t.run(async (ctx) => {
+			const entries = await ctx.db
+				.query("cash_ledger_journal_entries")
+				.withIndex("by_posting_group", (q) =>
+					q.eq("postingGroupId", first.postingGroupId)
+				)
+				.collect();
+			return entries.length;
+		});
+		expect(entryCount).toBe(first.reversalEntries.length);
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// T-012: Amount Validation
+// ═══════════════════════════════════════════════════════════════════
+
+describe("T-012: Amount validation", () => {
+	it("assertReversalAmountValid throws ConvexError when reversal exceeds original", () => {
+		expect(() => {
+			assertReversalAmountValid(200_000, 100_000n, "test-context");
+		}).toThrow(ConvexError);
+
+		try {
+			assertReversalAmountValid(200_000, 100_000n, "test-context");
+		} catch (error) {
+			expect(error).toBeInstanceOf(ConvexError);
+			const convexErr = error as ConvexError<{ code: string }>;
+			expect(convexErr.data.code).toBe("REVERSAL_EXCEEDS_ORIGINAL");
+		}
+	});
+
+	it("assertReversalAmountValid does NOT throw when reversal equals original", () => {
+		expect(() => {
+			assertReversalAmountValid(100_000, 100_000n, "test-context");
+		}).not.toThrow();
+	});
+
+	it("assertReversalAmountValid does NOT throw when reversal is less than original", () => {
+		expect(() => {
+			assertReversalAmountValid(50_000, 100_000n, "test-context");
+		}).not.toThrow();
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// T-013: causedBy Linkage
+// ═══════════════════════════════════════════════════════════════════
+
+describe("T-013: causedBy linkage", () => {
+	it("every REVERSAL entry references its original entry via causedBy", async () => {
+		const t = createHarness(modules);
+		const setup = await setupFullSettlementFlow(t);
+
+		const result = await t.run(async (ctx) => {
+			return postPaymentReversalCascade(ctx, {
+				attemptId: setup.attemptId,
+				obligationId: setup.obligationId,
+				mortgageId: setup.mortgageId,
+				effectiveDate: "2026-03-15",
+				source: SYSTEM_SOURCE,
+				reason: "causedBy linkage test",
+			});
+		});
+
+		// Every reversal entry must have a causedBy reference
+		for (const entry of result.reversalEntries) {
+			expect(entry.causedBy).toBeDefined();
+		}
+
+		// Verify each causedBy references an actual original entry in the DB
+		await t.run(async (ctx) => {
+			for (const entry of result.reversalEntries) {
+				const original = await ctx.db.get(
+					entry.causedBy as Id<"cash_ledger_journal_entries">
+				);
+				expect(original).not.toBeNull();
+				// Original should NOT be a REVERSAL type
+				expect(original?.entryType).not.toBe("REVERSAL");
+			}
+		});
+
+		// Verify the debit/credit are swapped relative to original
+		await t.run(async (ctx) => {
+			for (const entry of result.reversalEntries) {
+				const original = await ctx.db.get(
+					entry.causedBy as Id<"cash_ledger_journal_entries">
+				);
+				expect(original).not.toBeNull();
+				// Reversal swaps debit/credit from original
+				expect(entry.debitAccountId).toBe(original?.creditAccountId);
+				expect(entry.creditAccountId).toBe(original?.debitAccountId);
+			}
+		});
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// T-014: Posting Group Integrity
+// ═══════════════════════════════════════════════════════════════════
+
+describe("T-014: Posting group integrity", () => {
+	it("all reversal entries share the same postingGroupId", async () => {
+		const t = createHarness(modules);
+		const setup = await setupFullSettlementFlow(t);
+
+		const result = await t.run(async (ctx) => {
+			return postPaymentReversalCascade(ctx, {
+				attemptId: setup.attemptId,
+				obligationId: setup.obligationId,
+				mortgageId: setup.mortgageId,
+				effectiveDate: "2026-03-15",
+				source: SYSTEM_SOURCE,
+				reason: "Posting group integrity test",
+			});
+		});
+
+		// postingGroupId should follow the convention
+		expect(result.postingGroupId).toBe(`reversal-group:${setup.attemptId}`);
+
+		// All entries share the same postingGroupId
+		for (const entry of result.reversalEntries) {
+			expect(entry.postingGroupId).toBe(result.postingGroupId);
+		}
+
+		// Verify via DB query that entries by posting group match
+		const dbEntries = await t.run(async (ctx) => {
+			return ctx.db
+				.query("cash_ledger_journal_entries")
+				.withIndex("by_posting_group", (q) =>
+					q.eq("postingGroupId", result.postingGroupId)
+				)
+				.collect();
+		});
+		expect(dbEntries.length).toBe(result.reversalEntries.length);
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// T-015: postTransferReversal
+// ═══════════════════════════════════════════════════════════════════
+
+describe("T-015: postTransferReversal", () => {
+	it("creates a single-entry reversal with correct idempotency", async () => {
+		const t = createHarness(modules);
+		const seeded = await seedMinimalEntities(t);
+
+		// Create a transferRequest record
+		const transferRequestId = await t.run(async (ctx) => {
+			return ctx.db.insert("transferRequests", {
+				status: "completed",
+				createdAt: Date.now(),
+			});
+		});
+
+		// Create an original journal entry to reverse
+		// Pre-seed accounts with sufficient balances for the payout
+		const originalEntry = await t.run(async (ctx) => {
+			const trustCash = await getOrCreateCashAccount(ctx, {
+				family: "TRUST_CASH",
+				mortgageId: seeded.mortgageId,
+			});
+			const lenderPayable = await getOrCreateCashAccount(ctx, {
+				family: "LENDER_PAYABLE",
+				mortgageId: seeded.mortgageId,
+				lenderId: seeded.lenderAId,
+			});
+			// LENDER_PAYABLE is credit-normal; pre-seed credits so payout debit is valid
+			await ctx.db.patch(lenderPayable._id, {
+				cumulativeCredits: 100_000n,
+			});
+			// TRUST_CASH is debit-normal; pre-seed debits so payout credit is valid
+			await ctx.db.patch(trustCash._id, {
+				cumulativeDebits: 100_000n,
+			});
+
+			const result = await postCashEntryInternal(ctx, {
+				entryType: "LENDER_PAYOUT_SENT",
+				effectiveDate: "2026-03-01",
+				amount: 50_000,
+				debitAccountId: lenderPayable._id,
+				creditAccountId: trustCash._id,
+				idempotencyKey: buildIdempotencyKey(
+					"transfer-payout",
+					String(transferRequestId)
+				),
+				mortgageId: seeded.mortgageId,
+				lenderId: seeded.lenderAId,
+				transferRequestId,
+				source: SYSTEM_SOURCE,
+			});
+			return result.entry;
+		});
+
+		// Now reverse it
+		const reversal = await t.run(async (ctx) => {
+			return postTransferReversal(ctx, {
+				transferRequestId,
+				originalEntryId: originalEntry._id,
+				amount: 50_000,
+				effectiveDate: "2026-03-15",
+				source: SYSTEM_SOURCE,
+				reason: "Transfer reversal test",
+			});
+		});
+
+		// Verify reversal entry
+		expect(reversal.entry.entryType).toBe("REVERSAL");
+		expect(reversal.entry.amount).toBe(50_000n);
+		expect(reversal.entry.causedBy).toBe(originalEntry._id);
+		// Debit/credit swapped
+		expect(reversal.entry.debitAccountId).toBe(originalEntry.creditAccountId);
+		expect(reversal.entry.creditAccountId).toBe(originalEntry.debitAccountId);
+		// Transfer request linked
+		expect(reversal.entry.transferRequestId).toBe(transferRequestId);
+		// Reason preserved
+		expect(reversal.entry.reason).toBe("Transfer reversal test");
+	});
+
+	it("is idempotent — calling twice returns the same entry", async () => {
+		const t = createHarness(modules);
+		const seeded = await seedMinimalEntities(t);
+
+		const transferRequestId = await t.run(async (ctx) => {
+			return ctx.db.insert("transferRequests", {
+				status: "completed",
+				createdAt: Date.now(),
+			});
+		});
+
+		const originalEntry = await t.run(async (ctx) => {
+			const trustCash = await getOrCreateCashAccount(ctx, {
+				family: "TRUST_CASH",
+				mortgageId: seeded.mortgageId,
+			});
+			const lenderPayable = await getOrCreateCashAccount(ctx, {
+				family: "LENDER_PAYABLE",
+				mortgageId: seeded.mortgageId,
+				lenderId: seeded.lenderAId,
+			});
+			// Pre-seed balances for the payout
+			await ctx.db.patch(lenderPayable._id, {
+				cumulativeCredits: 100_000n,
+			});
+			await ctx.db.patch(trustCash._id, {
+				cumulativeDebits: 100_000n,
+			});
+
+			const result = await postCashEntryInternal(ctx, {
+				entryType: "LENDER_PAYOUT_SENT",
+				effectiveDate: "2026-03-01",
+				amount: 30_000,
+				debitAccountId: lenderPayable._id,
+				creditAccountId: trustCash._id,
+				idempotencyKey: buildIdempotencyKey(
+					"transfer-payout-idemp",
+					String(transferRequestId)
+				),
+				mortgageId: seeded.mortgageId,
+				lenderId: seeded.lenderAId,
+				transferRequestId,
+				source: SYSTEM_SOURCE,
+			});
+			return result.entry;
+		});
+
+		const first = await t.run(async (ctx) => {
+			return postTransferReversal(ctx, {
+				transferRequestId,
+				originalEntryId: originalEntry._id,
+				amount: 30_000,
+				effectiveDate: "2026-03-15",
+				source: SYSTEM_SOURCE,
+				reason: "Idempotency test",
+			});
+		});
+
+		const second = await t.run(async (ctx) => {
+			return postTransferReversal(ctx, {
+				transferRequestId,
+				originalEntryId: originalEntry._id,
+				amount: 30_000,
+				effectiveDate: "2026-03-15",
+				source: SYSTEM_SOURCE,
+				reason: "Idempotency test",
+			});
+		});
+
+		// Same entry ID
+		expect(second.entry._id).toBe(first.entry._id);
+	});
+
+	it("throws ConvexError when reversal amount exceeds original", async () => {
+		const t = createHarness(modules);
+		const seeded = await seedMinimalEntities(t);
+
+		const transferRequestId = await t.run(async (ctx) => {
+			return ctx.db.insert("transferRequests", {
+				status: "completed",
+				createdAt: Date.now(),
+			});
+		});
+
+		const originalEntry = await t.run(async (ctx) => {
+			const trustCash = await getOrCreateCashAccount(ctx, {
+				family: "TRUST_CASH",
+				mortgageId: seeded.mortgageId,
+			});
+			const lenderPayable = await getOrCreateCashAccount(ctx, {
+				family: "LENDER_PAYABLE",
+				mortgageId: seeded.mortgageId,
+				lenderId: seeded.lenderAId,
+			});
+			// Pre-seed balances for the payout
+			await ctx.db.patch(lenderPayable._id, {
+				cumulativeCredits: 100_000n,
+			});
+			await ctx.db.patch(trustCash._id, {
+				cumulativeDebits: 100_000n,
+			});
+
+			const result = await postCashEntryInternal(ctx, {
+				entryType: "LENDER_PAYOUT_SENT",
+				effectiveDate: "2026-03-01",
+				amount: 25_000,
+				debitAccountId: lenderPayable._id,
+				creditAccountId: trustCash._id,
+				idempotencyKey: buildIdempotencyKey(
+					"transfer-payout-exceeds",
+					String(transferRequestId)
+				),
+				mortgageId: seeded.mortgageId,
+				lenderId: seeded.lenderAId,
+				transferRequestId,
+				source: SYSTEM_SOURCE,
+			});
+			return result.entry;
+		});
+
+		await expect(
+			t.run(async (ctx) => {
+				return postTransferReversal(ctx, {
+					transferRequestId,
+					originalEntryId: originalEntry._id,
+					amount: 50_000, // exceeds original 25_000
+					effectiveDate: "2026-03-15",
+					source: SYSTEM_SOURCE,
+					reason: "Should fail",
+				});
+			})
+		).rejects.toThrow(ConvexError);
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// T-020: Double-reversal guard — cascade throws on re-reversal
+// ═══════════════════════════════════════════════════════════════════
+
+describe("T-020: Double-reversal guard", () => {
+	it("postPaymentReversalCascade is idempotent — second call returns same entries", async () => {
+		const t = createHarness(modules);
+		const setup = await setupFullSettlementFlow(t);
+
+		// First reversal
+		const first = await t.run(async (ctx) => {
+			return postPaymentReversalCascade(ctx, {
+				attemptId: setup.attemptId,
+				obligationId: setup.obligationId,
+				mortgageId: setup.mortgageId,
+				effectiveDate: "2026-03-15",
+				source: SYSTEM_SOURCE,
+				reason: "First reversal",
+			});
+		});
+
+		// Second reversal — should return the same entries (idempotent)
+		const second = await t.run(async (ctx) => {
+			return postPaymentReversalCascade(ctx, {
+				attemptId: setup.attemptId,
+				obligationId: setup.obligationId,
+				mortgageId: setup.mortgageId,
+				effectiveDate: "2026-03-16",
+				source: SYSTEM_SOURCE,
+				reason: "Second reversal — idempotent",
+			});
+		});
+
+		// Same postingGroupId
+		expect(second.postingGroupId).toBe(first.postingGroupId);
+		// Same number of entries
+		expect(second.reversalEntries.length).toBe(first.reversalEntries.length);
+		// Same entry IDs
+		const firstIds = first.reversalEntries.map((e) => e._id).sort();
+		const secondIds = second.reversalEntries.map((e) => e._id).sort();
+		expect(secondIds).toEqual(firstIds);
+		// No new entries created
+		const entryCount = await t.run(async (ctx) => {
+			const entries = await ctx.db
+				.query("cash_ledger_journal_entries")
+				.withIndex("by_posting_group", (q) =>
+					q.eq("postingGroupId", first.postingGroupId)
+				)
+				.collect();
+			return entries.length;
+		});
+		expect(entryCount).toBe(first.reversalEntries.length);
+	});
+
+	it("postTransferReversal throws DOUBLE_REVERSAL when called with different transferRequestId but same originalEntryId", async () => {
+		const t = createHarness(modules);
+		const seeded = await seedMinimalEntities(t);
+
+		// Create two different transfer requests
+		const [transferRequestId1, transferRequestIdId] = await t.run(
+			async (ctx) => {
+				const tr1 = await ctx.db.insert("transferRequests", {
+					status: "completed",
+					createdAt: Date.now(),
+				});
+				const tr2 = await ctx.db.insert("transferRequests", {
+					status: "completed",
+					createdAt: Date.now(),
+				});
+				return [tr1, tr2];
+			}
+		);
+
+		// Create an original journal entry (no obligationId, has transferRequestId)
+		const originalEntry = await t.run(async (ctx) => {
+			const trustCash = await getOrCreateCashAccount(ctx, {
+				family: "TRUST_CASH",
+				mortgageId: seeded.mortgageId,
+			});
+			const lenderPayable = await getOrCreateCashAccount(ctx, {
+				family: "LENDER_PAYABLE",
+				mortgageId: seeded.mortgageId,
+				lenderId: seeded.lenderAId,
+			});
+			await ctx.db.patch(lenderPayable._id, { cumulativeCredits: 100_000n });
+			await ctx.db.patch(trustCash._id, { cumulativeDebits: 100_000n });
+
+			const result = await postCashEntryInternal(ctx, {
+				entryType: "LENDER_PAYOUT_SENT",
+				effectiveDate: "2026-03-01",
+				amount: 50_000,
+				debitAccountId: lenderPayable._id,
+				creditAccountId: trustCash._id,
+				idempotencyKey: buildIdempotencyKey(
+					"double-rev-original",
+					String(transferRequestId1)
+				),
+				mortgageId: seeded.mortgageId,
+				lenderId: seeded.lenderAId,
+				transferRequestId: transferRequestId1,
+				source: SYSTEM_SOURCE,
+			});
+			return result.entry;
+		});
+
+		// First reversal — succeeds (with transferRequestId1)
+		await t.run(async (ctx) => {
+			return postTransferReversal(ctx, {
+				transferRequestId: transferRequestId1,
+				originalEntryId: originalEntry._id,
+				amount: 50_000,
+				effectiveDate: "2026-03-15",
+				source: SYSTEM_SOURCE,
+				reason: "First reversal",
+			});
+		});
+
+		// Second reversal — DIFFERENT transferRequestId but same originalEntryId
+		// → bypasses idempotency check but triggers findExistingReversal → throws DOUBLE_REVERSAL
+		await expect(
+			t.run(async (ctx) => {
+				return postTransferReversal(ctx, {
+					transferRequestId: transferRequestIdId, // different!
+					originalEntryId: originalEntry._id,
+					amount: 50_000,
+					effectiveDate: "2026-03-16",
+					source: SYSTEM_SOURCE,
+					reason: "Second reversal — should fail",
+				});
+			})
+		).rejects.toThrow(ConvexError);
+	});
+
+	it("postTransferReversal includes postingGroupId in return", async () => {
+		const t = createHarness(modules);
+		const seeded = await seedMinimalEntities(t);
+
+		const transferRequestId = await t.run(async (ctx) => {
+			return ctx.db.insert("transferRequests", {
+				status: "completed",
+				createdAt: Date.now(),
+			});
+		});
+
+		const originalEntry = await t.run(async (ctx) => {
+			const trustCash = await getOrCreateCashAccount(ctx, {
+				family: "TRUST_CASH",
+				mortgageId: seeded.mortgageId,
+			});
+			const lenderPayable = await getOrCreateCashAccount(ctx, {
+				family: "LENDER_PAYABLE",
+				mortgageId: seeded.mortgageId,
+				lenderId: seeded.lenderAId,
+			});
+			await ctx.db.patch(lenderPayable._id, { cumulativeCredits: 100_000n });
+			await ctx.db.patch(trustCash._id, { cumulativeDebits: 100_000n });
+
+			const result = await postCashEntryInternal(ctx, {
+				entryType: "LENDER_PAYOUT_SENT",
+				effectiveDate: "2026-03-01",
+				amount: 25_000,
+				debitAccountId: lenderPayable._id,
+				creditAccountId: trustCash._id,
+				idempotencyKey: buildIdempotencyKey(
+					"posting-group-test",
+					String(transferRequestId)
+				),
+				mortgageId: seeded.mortgageId,
+				lenderId: seeded.lenderAId,
+				transferRequestId,
+				source: SYSTEM_SOURCE,
+			});
+			return result.entry;
+		});
+
+		const result = await t.run(async (ctx) => {
+			return postTransferReversal(ctx, {
+				transferRequestId,
+				originalEntryId: originalEntry._id,
+				amount: 25_000,
+				effectiveDate: "2026-03-15",
+				source: SYSTEM_SOURCE,
+				reason: "Test",
+			});
+		});
+
+		expect(result.postingGroupId).toBe(
+			`reversal:transfer:${transferRequestId}`
+		);
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// T-021: Clawback scope — only reverses payouts for the specific obligation
+// ═══════════════════════════════════════════════════════════════════
+
+describe("T-021: Clawback scope is obligation-scoped", () => {
+	it("does NOT claw back payouts from other obligations", async () => {
+		const t = createHarness(modules);
+		const setup = await setupFullSettlementFlow(t);
+
+		// Create a second obligation and post a payout for it
+		const otherObligationId = await createSettledObligation(t, {
+			mortgageId: setup.mortgageId,
+			borrowerId: setup.borrowerId,
+			amount: 50_000,
+		});
+
+		// Post a payout for the OTHER obligation
+		await t.run(async (ctx) => {
+			const lenderPayableAccount = await getOrCreateCashAccount(ctx, {
+				family: "LENDER_PAYABLE",
+				mortgageId: setup.mortgageId,
+				lenderId: setup.lenderAId,
+			});
+			const trustCashAccount = await getOrCreateCashAccount(ctx, {
+				family: "TRUST_CASH",
+				mortgageId: setup.mortgageId,
+			});
+			await ctx.db.patch(lenderPayableAccount._id, {
+				cumulativeCredits:
+					(await ctx.db.get(lenderPayableAccount._id))?.cumulativeCredits +
+					50_000n,
+			});
+
+			await postCashEntryInternal(ctx, {
+				entryType: "LENDER_PAYOUT_SENT",
+				effectiveDate: "2026-03-05",
+				amount: 50_000,
+				debitAccountId: lenderPayableAccount._id,
+				creditAccountId: trustCashAccount._id,
+				idempotencyKey: buildIdempotencyKey(
+					"other-obligation-payout",
+					String(otherObligationId)
+				),
+				mortgageId: setup.mortgageId,
+				obligationId: otherObligationId,
+				lenderId: setup.lenderAId,
+				source: SYSTEM_SOURCE,
+			});
+		});
+
+		// Reverse the FIRST obligation's cascade
+		const result = await t.run(async (ctx) => {
+			return postPaymentReversalCascade(ctx, {
+				attemptId: setup.attemptId,
+				obligationId: setup.obligationId,
+				mortgageId: setup.mortgageId,
+				effectiveDate: "2026-03-15",
+				source: SYSTEM_SOURCE,
+				reason: "Reverse setup obligation",
+			});
+		});
+
+		// The other obligation's payout should NOT be reversed — no payout-clawback entries
+		// unless they match obligationId=setup.obligationId
+		const clawbackEntries = result.reversalEntries.filter((e) =>
+			e.idempotencyKey.includes("payout-clawback")
+		);
+		// The only payout-clawback (if any) should be for setup.obligationId, not otherObligationId
+		for (const entry of clawbackEntries) {
+			expect(entry.obligationId).toBe(setup.obligationId);
+		}
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// T-022: assertReversalAmountValid rejects zero and negative amounts
+// ═══════════════════════════════════════════════════════════════════
+
+describe("T-022: assertReversalAmountValid edge cases", () => {
+	it("throws on zero reversal amount", () => {
+		expect(() => {
+			assertReversalAmountValid(0, 100_000n, "test-context");
+		}).toThrow(ConvexError);
+	});
+
+	it("throws on negative reversal amount", () => {
+		expect(() => {
+			assertReversalAmountValid(-1, 100_000n, "test-context");
+		}).toThrow(ConvexError);
+	});
+});

--- a/convex/payments/cashLedger/__tests__/reversalIntegration.test.ts
+++ b/convex/payments/cashLedger/__tests__/reversalIntegration.test.ts
@@ -1,0 +1,736 @@
+import { describe, expect, it } from "vitest";
+import { getCashAccountBalance, getOrCreateCashAccount } from "../accounts";
+import {
+	postCashReceiptForObligation,
+	postObligationAccrued,
+	postPaymentReversalCascade,
+	postSettlementAllocation,
+} from "../integrations";
+import { postCashEntryInternal } from "../postEntry";
+import {
+	getPostingGroupSummary,
+	isPostingGroupComplete,
+} from "../postingGroups";
+import { findSettledObligationsWithNonZeroBalance } from "../reconciliation";
+import { buildIdempotencyKey } from "../types";
+import {
+	createHarness,
+	createSettledObligation,
+	SYSTEM_SOURCE,
+	seedMinimalEntities,
+} from "./testUtils";
+
+const modules = import.meta.glob("/convex/**/*.ts");
+
+// ── Shared helpers ─────────────────────────────────────────────────
+
+/**
+ * Sets up a full settlement flow: seeds entities, creates an obligation,
+ * posts OBLIGATION_ACCRUED, CASH_RECEIVED, and a settlement allocation
+ * (2 lender payables + servicing fee). Returns all IDs and the allocation
+ * posting group ID needed for reversal tests.
+ */
+async function setupFullSettlementFlow(
+	t: ReturnType<typeof createHarness>,
+	opts?: { servicingFee?: number; amount?: number }
+) {
+	const amount = opts?.amount ?? 100_000;
+	const servicingFee = opts?.servicingFee ?? 1000;
+
+	const seeded = await seedMinimalEntities(t);
+
+	// Create a settled obligation
+	const obligationId = await createSettledObligation(t, {
+		mortgageId: seeded.mortgageId,
+		borrowerId: seeded.borrowerId,
+		amount,
+	});
+
+	// Post OBLIGATION_ACCRUED
+	await t.run(async (ctx) => {
+		await postObligationAccrued(ctx, {
+			obligationId,
+			source: SYSTEM_SOURCE,
+		});
+	});
+
+	// Post CASH_RECEIVED (using an attempt-based key so the cascade can find it)
+	const attemptId = await t.run(async (ctx) => {
+		const planEntryId = await ctx.db.insert("collectionPlanEntries", {
+			obligationIds: [obligationId],
+			amount,
+			method: "manual",
+			scheduledDate: Date.now(),
+			status: "completed",
+			source: "default_schedule",
+			createdAt: Date.now(),
+		});
+		return ctx.db.insert("collectionAttempts", {
+			status: "settled",
+			planEntryId,
+			method: "manual",
+			amount,
+			initiatedAt: Date.now(),
+			settledAt: Date.now(),
+		});
+	});
+
+	await t.run(async (ctx) => {
+		await postCashReceiptForObligation(ctx, {
+			obligationId,
+			amount,
+			idempotencyKey: buildIdempotencyKey("cash-received", String(attemptId)),
+			effectiveDate: "2026-03-01",
+			attemptId,
+			source: SYSTEM_SOURCE,
+		});
+	});
+
+	// Create dispersalEntries so allocation can reference them
+	const { dispersalEntryAId, dispersalEntryBId } = await t.run(async (ctx) => {
+		const accounts = await ctx.db
+			.query("ledger_accounts")
+			.withIndex("by_type_and_mortgage", (q) =>
+				q.eq("type", "POSITION").eq("mortgageId", String(seeded.mortgageId))
+			)
+			.collect();
+
+		if (accounts.length < 2) {
+			throw new Error("Expected at least two ledger accounts");
+		}
+
+		const lenderAShare = Math.round(((amount - servicingFee) * 6000) / 10_000);
+		const lenderBShare = amount - servicingFee - lenderAShare;
+
+		const deA = await ctx.db.insert("dispersalEntries", {
+			obligationId,
+			mortgageId: seeded.mortgageId,
+			lenderId: seeded.lenderAId,
+			lenderAccountId: accounts[0]._id,
+			amount: lenderAShare,
+			dispersalDate: "2026-03-01",
+			servicingFeeDeducted: 0,
+			status: "pending",
+			idempotencyKey: buildIdempotencyKey(
+				"dispersal",
+				"test-a",
+				String(obligationId)
+			),
+			calculationDetails: {
+				settledAmount: amount,
+				servicingFee,
+				distributableAmount: amount - servicingFee,
+				feeDue: servicingFee,
+				feeCashApplied: servicingFee,
+				feeReceivable: 0,
+				ownershipUnits: 6000,
+				totalUnits: 10_000,
+				ownershipFraction: 0.6,
+				rawAmount: lenderAShare,
+				roundedAmount: lenderAShare,
+				sourceObligationType: "regular_interest",
+			},
+			createdAt: Date.now(),
+		});
+		const deB = await ctx.db.insert("dispersalEntries", {
+			obligationId,
+			mortgageId: seeded.mortgageId,
+			lenderId: seeded.lenderBId,
+			lenderAccountId: accounts[1]._id,
+			amount: lenderBShare,
+			dispersalDate: "2026-03-01",
+			servicingFeeDeducted: 0,
+			status: "pending",
+			idempotencyKey: buildIdempotencyKey(
+				"dispersal",
+				"test-b",
+				String(obligationId)
+			),
+			calculationDetails: {
+				settledAmount: amount,
+				servicingFee,
+				distributableAmount: amount - servicingFee,
+				feeDue: servicingFee,
+				feeCashApplied: servicingFee,
+				feeReceivable: 0,
+				ownershipUnits: 4000,
+				totalUnits: 10_000,
+				ownershipFraction: 0.4,
+				rawAmount: lenderBShare,
+				roundedAmount: lenderBShare,
+				sourceObligationType: "regular_interest",
+			},
+			createdAt: Date.now(),
+		});
+		return { dispersalEntryAId: deA, dispersalEntryBId: deB };
+	});
+
+	// Compute lender shares for settlement
+	const lenderAShare = Math.round(((amount - servicingFee) * 6000) / 10_000);
+	const lenderBShare = amount - servicingFee - lenderAShare;
+
+	// Post settlement allocation (2 lender payables + servicing fee)
+	await t.run(async (ctx) => {
+		await postSettlementAllocation(ctx, {
+			obligationId,
+			mortgageId: seeded.mortgageId,
+			settledDate: "2026-03-01",
+			servicingFee,
+			entries: [
+				{
+					dispersalEntryId: dispersalEntryAId,
+					lenderId: seeded.lenderAId,
+					amount: lenderAShare,
+				},
+				{
+					dispersalEntryId: dispersalEntryBId,
+					lenderId: seeded.lenderBId,
+					amount: lenderBShare,
+				},
+			],
+			source: SYSTEM_SOURCE,
+		});
+	});
+
+	return {
+		...seeded,
+		obligationId,
+		attemptId,
+		servicingFee,
+		lenderAShare,
+		lenderBShare,
+		dispersalEntryAId,
+		dispersalEntryBId,
+		amount,
+		allocationGroupId: `allocation:${obligationId}`,
+	};
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// T-016: E2E full reversal without payout — balance verification
+// ═══════════════════════════════════════════════════════════════════
+
+describe("T-016: E2E accrue → receive → allocate → reverse → verify balances", () => {
+	it("restores all account balances after full reversal (no payout)", async () => {
+		const t = createHarness(modules);
+		const setup = await setupFullSettlementFlow(t);
+
+		// Capture balances BEFORE reversal
+		const preReversalBalances = await t.run(async (ctx) => {
+			const borrowerReceivable = await getOrCreateCashAccount(ctx, {
+				family: "BORROWER_RECEIVABLE",
+				mortgageId: setup.mortgageId,
+				obligationId: setup.obligationId,
+				borrowerId: setup.borrowerId,
+			});
+			const trustCash = await getOrCreateCashAccount(ctx, {
+				family: "TRUST_CASH",
+				mortgageId: setup.mortgageId,
+			});
+			const lenderPayableA = await getOrCreateCashAccount(ctx, {
+				family: "LENDER_PAYABLE",
+				mortgageId: setup.mortgageId,
+				lenderId: setup.lenderAId,
+			});
+			const lenderPayableB = await getOrCreateCashAccount(ctx, {
+				family: "LENDER_PAYABLE",
+				mortgageId: setup.mortgageId,
+				lenderId: setup.lenderBId,
+			});
+			const servicingRevenue = await getOrCreateCashAccount(ctx, {
+				family: "SERVICING_REVENUE",
+				mortgageId: setup.mortgageId,
+			});
+
+			return {
+				borrowerReceivable: getCashAccountBalance(borrowerReceivable),
+				trustCash: getCashAccountBalance(trustCash),
+				lenderPayableA: getCashAccountBalance(lenderPayableA),
+				lenderPayableB: getCashAccountBalance(lenderPayableB),
+				servicingRevenue: getCashAccountBalance(servicingRevenue),
+			};
+		});
+
+		// Verify pre-reversal state: receipt credited, allocation distributed
+		// TRUST_CASH (debit-normal) should have a positive balance from receipt
+		expect(preReversalBalances.trustCash).toBe(BigInt(setup.amount));
+		// LENDER_PAYABLE (credit-normal) should have positive balances
+		expect(preReversalBalances.lenderPayableA).toBe(BigInt(setup.lenderAShare));
+		expect(preReversalBalances.lenderPayableB).toBe(BigInt(setup.lenderBShare));
+		// SERVICING_REVENUE (credit-normal) should have positive balance
+		expect(preReversalBalances.servicingRevenue).toBe(
+			BigInt(setup.servicingFee)
+		);
+
+		// Execute reversal cascade
+		const result = await t.run(async (ctx) => {
+			return postPaymentReversalCascade(ctx, {
+				attemptId: setup.attemptId,
+				obligationId: setup.obligationId,
+				mortgageId: setup.mortgageId,
+				effectiveDate: "2026-03-15",
+				source: SYSTEM_SOURCE,
+				reason: "Payment returned NSF - integration test",
+			});
+		});
+
+		expect(result.clawbackRequired).toBe(false);
+		expect(result.reversalEntries.length).toBeGreaterThanOrEqual(4);
+
+		// Verify balances AFTER reversal
+		const postReversalBalances = await t.run(async (ctx) => {
+			const borrowerReceivable = await getOrCreateCashAccount(ctx, {
+				family: "BORROWER_RECEIVABLE",
+				mortgageId: setup.mortgageId,
+				obligationId: setup.obligationId,
+				borrowerId: setup.borrowerId,
+			});
+			const trustCash = await getOrCreateCashAccount(ctx, {
+				family: "TRUST_CASH",
+				mortgageId: setup.mortgageId,
+			});
+			const lenderPayableA = await getOrCreateCashAccount(ctx, {
+				family: "LENDER_PAYABLE",
+				mortgageId: setup.mortgageId,
+				lenderId: setup.lenderAId,
+			});
+			const lenderPayableB = await getOrCreateCashAccount(ctx, {
+				family: "LENDER_PAYABLE",
+				mortgageId: setup.mortgageId,
+				lenderId: setup.lenderBId,
+			});
+			const servicingRevenue = await getOrCreateCashAccount(ctx, {
+				family: "SERVICING_REVENUE",
+				mortgageId: setup.mortgageId,
+			});
+
+			return {
+				borrowerReceivable: getCashAccountBalance(borrowerReceivable),
+				trustCash: getCashAccountBalance(trustCash),
+				lenderPayableA: getCashAccountBalance(lenderPayableA),
+				lenderPayableB: getCashAccountBalance(lenderPayableB),
+				servicingRevenue: getCashAccountBalance(servicingRevenue),
+			};
+		});
+
+		// TRUST_CASH should be zeroed (receipt reversed)
+		expect(postReversalBalances.trustCash).toBe(0n);
+		// LENDER_PAYABLE balances should be zeroed (payable creation reversed)
+		expect(postReversalBalances.lenderPayableA).toBe(0n);
+		expect(postReversalBalances.lenderPayableB).toBe(0n);
+		// SERVICING_REVENUE should be zeroed (fee reversed)
+		expect(postReversalBalances.servicingRevenue).toBe(0n);
+		// BORROWER_RECEIVABLE: the receipt credited it (reducing balance).
+		// The reversal debits it back, restoring the original receivable amount.
+		// Pre-seeded with debits=amount, credits=amount (settled). After receipt:
+		// credits += amount. After reversal: debits += amount. Net = amount.
+		expect(postReversalBalances.borrowerReceivable).toBe(BigInt(setup.amount));
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// T-017: E2E reversal with payout (clawback)
+// ═══════════════════════════════════════════════════════════════════
+
+describe("T-017: E2E accrue → receive → allocate → payout → reverse → clawback", () => {
+	it("creates clawback entries and produces correct balances when payout has been sent", async () => {
+		const t = createHarness(modules);
+		const setup = await setupFullSettlementFlow(t);
+
+		// Post LENDER_PAYOUT_SENT for lender A (simulate payout already sent)
+		await t.run(async (ctx) => {
+			const lenderPayableAccount = await getOrCreateCashAccount(ctx, {
+				family: "LENDER_PAYABLE",
+				mortgageId: setup.mortgageId,
+				lenderId: setup.lenderAId,
+			});
+			const trustCashAccount = await getOrCreateCashAccount(ctx, {
+				family: "TRUST_CASH",
+				mortgageId: setup.mortgageId,
+			});
+
+			await postCashEntryInternal(ctx, {
+				entryType: "LENDER_PAYOUT_SENT",
+				effectiveDate: "2026-03-05",
+				amount: setup.lenderAShare,
+				debitAccountId: lenderPayableAccount._id,
+				creditAccountId: trustCashAccount._id,
+				idempotencyKey: buildIdempotencyKey(
+					"lender-payout",
+					String(setup.lenderAId),
+					String(setup.obligationId)
+				),
+				mortgageId: setup.mortgageId,
+				obligationId: setup.obligationId,
+				lenderId: setup.lenderAId,
+				source: SYSTEM_SOURCE,
+			});
+		});
+
+		// Capture balances AFTER payout but BEFORE reversal
+		const postPayoutBalances = await t.run(async (ctx) => {
+			const trustCash = await getOrCreateCashAccount(ctx, {
+				family: "TRUST_CASH",
+				mortgageId: setup.mortgageId,
+			});
+			const lenderPayableA = await getOrCreateCashAccount(ctx, {
+				family: "LENDER_PAYABLE",
+				mortgageId: setup.mortgageId,
+				lenderId: setup.lenderAId,
+			});
+			return {
+				trustCash: getCashAccountBalance(trustCash),
+				lenderPayableA: getCashAccountBalance(lenderPayableA),
+			};
+		});
+
+		// After payout: TRUST_CASH = receipt - payout, LENDER_PAYABLE_A = payable - payout = 0
+		expect(postPayoutBalances.trustCash).toBe(
+			BigInt(setup.amount) - BigInt(setup.lenderAShare)
+		);
+		expect(postPayoutBalances.lenderPayableA).toBe(0n);
+
+		// Execute reversal cascade
+		const result = await t.run(async (ctx) => {
+			return postPaymentReversalCascade(ctx, {
+				attemptId: setup.attemptId,
+				obligationId: setup.obligationId,
+				mortgageId: setup.mortgageId,
+				effectiveDate: "2026-03-15",
+				source: SYSTEM_SOURCE,
+				reason: "Payment returned NSF - clawback test",
+			});
+		});
+
+		// clawbackRequired should be true
+		expect(result.clawbackRequired).toBe(true);
+
+		// Should have 5+ entries: cash_received + 2 lender_payable + servicing_fee + payout clawback
+		expect(result.reversalEntries.length).toBeGreaterThanOrEqual(5);
+
+		// Verify payout clawback entries exist
+		const clawbackEntries = result.reversalEntries.filter((e) =>
+			e.idempotencyKey.includes("payout-clawback")
+		);
+		expect(clawbackEntries.length).toBeGreaterThanOrEqual(1);
+
+		// Verify post-reversal balances
+		const postReversalBalances = await t.run(async (ctx) => {
+			const trustCash = await getOrCreateCashAccount(ctx, {
+				family: "TRUST_CASH",
+				mortgageId: setup.mortgageId,
+			});
+			const lenderPayableA = await getOrCreateCashAccount(ctx, {
+				family: "LENDER_PAYABLE",
+				mortgageId: setup.mortgageId,
+				lenderId: setup.lenderAId,
+			});
+			const lenderPayableB = await getOrCreateCashAccount(ctx, {
+				family: "LENDER_PAYABLE",
+				mortgageId: setup.mortgageId,
+				lenderId: setup.lenderBId,
+			});
+			const servicingRevenue = await getOrCreateCashAccount(ctx, {
+				family: "SERVICING_REVENUE",
+				mortgageId: setup.mortgageId,
+			});
+
+			return {
+				trustCash: getCashAccountBalance(trustCash),
+				lenderPayableA: getCashAccountBalance(lenderPayableA),
+				lenderPayableB: getCashAccountBalance(lenderPayableB),
+				servicingRevenue: getCashAccountBalance(servicingRevenue),
+			};
+		});
+
+		// LENDER_PAYABLE_A for the paid lender should go negative (clawback receivable).
+		// It was zeroed by the payout, then the payable-creation reversal debited it
+		// (making it negative), and the clawback reversal credited it back.
+		// Net: -lenderAShare (payable reversed) + lenderAShare (clawback credit) = negative
+		// Actually: payable creation was credited (+lenderAShare), payout debited it (-lenderAShare → 0),
+		// reversal of payable creation: debit = credit acct of original = lender_payable → -lenderAShare
+		// reversal of payout: debit = trust_cash, credit = lender_payable → +lenderAShare
+		// Net: lenderAShare - lenderAShare - lenderAShare + lenderAShare = 0
+		// Wait, let me reconsider: the payable reversal debits LENDER_PAYABLE (reduces credit-normal balance)
+		// and the payout clawback credits LENDER_PAYABLE (increases credit-normal balance).
+		// These cancel out, so LENDER_PAYABLE_A should end at 0.
+		// But the payout already zeroed it. So after all reversals it should be 0.
+		// Actually more carefully:
+		// Initial payable creation: credit LENDER_PAYABLE (+lenderAShare)
+		// Payout sent: debit LENDER_PAYABLE (-lenderAShare) → balance = 0
+		// Reversal of payable creation: debit LENDER_PAYABLE (-lenderAShare) → balance = -lenderAShare
+		// Reversal of payout (clawback): credit LENDER_PAYABLE (+lenderAShare) → balance = 0
+		// So net = 0. But wait, the clawback reversal swaps the original payout's debit/credit.
+		// Original payout: debit=LENDER_PAYABLE, credit=TRUST_CASH
+		// Clawback reversal: debit=TRUST_CASH, credit=LENDER_PAYABLE
+		// So clawback credits LENDER_PAYABLE → +lenderAShare. Net = 0.
+		expect(postReversalBalances.lenderPayableA).toBe(0n);
+
+		// LENDER_PAYABLE_B had no payout, just the payable reversal → 0
+		expect(postReversalBalances.lenderPayableB).toBe(0n);
+
+		// SERVICING_REVENUE should be zeroed
+		expect(postReversalBalances.servicingRevenue).toBe(0n);
+
+		// TRUST_CASH: receipt (+amount) - payout (-lenderAShare) - receipt reversal (-amount) + clawback (+lenderAShare) = 0
+		expect(postReversalBalances.trustCash).toBe(0n);
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// T-018: Reconciliation detection — findSettledObligationsWithNonZeroBalance
+// ═══════════════════════════════════════════════════════════════════
+
+describe("T-018: findSettledObligationsWithNonZeroBalance detects reversed obligations", () => {
+	it("returns reversed obligation with correct expected balance", async () => {
+		const t = createHarness(modules);
+		const setup = await setupFullSettlementFlow(t);
+
+		// Before reversal, the obligation is settled and journal matches.
+		// The obligation has amountSettled = amount and there is a CASH_RECEIVED entry for the same amount.
+		const preReversalIndicators = await t.run(async (ctx) => {
+			return findSettledObligationsWithNonZeroBalance(ctx);
+		});
+
+		// Should NOT flag the obligation before reversal
+		const preReversalMatch = preReversalIndicators.find(
+			(i) => i.obligationId === setup.obligationId
+		);
+		expect(preReversalMatch).toBeUndefined();
+
+		// Execute reversal cascade
+		await t.run(async (ctx) => {
+			return postPaymentReversalCascade(ctx, {
+				attemptId: setup.attemptId,
+				obligationId: setup.obligationId,
+				mortgageId: setup.mortgageId,
+				effectiveDate: "2026-03-15",
+				source: SYSTEM_SOURCE,
+				reason: "Payment returned NSF - reconciliation test",
+			});
+		});
+
+		// After reversal, the obligation is still marked "settled" but the journal
+		// now shows zero net CASH_RECEIVED (original + reversal cancel out).
+		const postReversalIndicators = await t.run(async (ctx) => {
+			return findSettledObligationsWithNonZeroBalance(ctx);
+		});
+
+		const match = postReversalIndicators.find(
+			(i) => i.obligationId === setup.obligationId
+		);
+		expect(match).toBeDefined();
+
+		// journalSettledAmount should be 0 (receipt - reversal = 0)
+		expect(match?.journalSettledAmount).toBe(0n);
+
+		// obligationAmount should match the setup amount
+		expect(match?.obligationAmount).toBe(setup.amount);
+
+		// expectedBalance = obligationAmount - journalSettledAmount = amount - 0 = amount
+		expect(match?.expectedBalance).toBe(BigInt(setup.amount));
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// T-019: Posting group validation after reversal
+// ═══════════════════════════════════════════════════════════════════
+
+describe("T-019: Posting group nets to zero after reversal via getPostingGroupSummary", () => {
+	it("allocation posting group has net-zero CONTROL:ALLOCATION after settlement (before reversal)", async () => {
+		const t = createHarness(modules);
+		const setup = await setupFullSettlementFlow(t);
+
+		// The allocation posting group should be complete after settlement
+		const allocationSummary = await t.run(async (ctx) => {
+			return getPostingGroupSummary(ctx, setup.allocationGroupId);
+		});
+
+		// CONTROL:ALLOCATION should net to zero: servicing fee + lender shares = obligation amount
+		// All debits (lender payables + servicing fee) from CONTROL:ALLOCATION
+		// But wait — postSettlementAllocation only debits CONTROL:ALLOCATION.
+		// There is no credit to CONTROL:ALLOCATION in the current flow.
+		// So it should NOT be complete (only debit side).
+		// The balance should equal the obligation amount (all debits, no credits).
+		expect(allocationSummary.totalJournalEntryCount).toBeGreaterThanOrEqual(3); // 2 lender payable + 1 servicing fee
+	});
+
+	it("reversal posting group entries all have consistent postingGroupId", async () => {
+		const t = createHarness(modules);
+		const setup = await setupFullSettlementFlow(t);
+
+		const result = await t.run(async (ctx) => {
+			return postPaymentReversalCascade(ctx, {
+				attemptId: setup.attemptId,
+				obligationId: setup.obligationId,
+				mortgageId: setup.mortgageId,
+				effectiveDate: "2026-03-15",
+				source: SYSTEM_SOURCE,
+				reason: "Posting group validation test",
+			});
+		});
+
+		// All reversal entries should share the same postingGroupId
+		for (const entry of result.reversalEntries) {
+			expect(entry.postingGroupId).toBe(result.postingGroupId);
+		}
+
+		// Validate the reversal posting group via getPostingGroupSummary
+		const reversalSummary = await t.run(async (ctx) => {
+			return getPostingGroupSummary(ctx, result.postingGroupId);
+		});
+
+		// The reversal posting group should have entries
+		expect(reversalSummary.totalJournalEntryCount).toBe(
+			result.reversalEntries.length
+		);
+
+		// The reversal entries that touch CONTROL:ALLOCATION should reverse
+		// the allocation entries. Since the original allocation only debited
+		// CONTROL:ALLOCATION, the reversals should credit CONTROL:ALLOCATION,
+		// making the reversal group's CONTROL:ALLOCATION balance negative
+		// (all credits, no debits).
+		// Specifically: the lender payable reversals credit CONTROL:ALLOCATION
+		// and the servicing fee reversal credits CONTROL:ALLOCATION.
+		const controlEntries = reversalSummary.entries.filter(
+			(e) => e.side === "credit"
+		);
+		// Lender payable reversals + servicing fee reversal should appear as credits
+		expect(controlEntries.length).toBeGreaterThanOrEqual(2);
+	});
+
+	it("combined allocation + reversal entries result in net-zero CONTROL:ALLOCATION", async () => {
+		const t = createHarness(modules);
+		const setup = await setupFullSettlementFlow(t);
+
+		// Post reversal
+		await t.run(async (ctx) => {
+			return postPaymentReversalCascade(ctx, {
+				attemptId: setup.attemptId,
+				obligationId: setup.obligationId,
+				mortgageId: setup.mortgageId,
+				effectiveDate: "2026-03-15",
+				source: SYSTEM_SOURCE,
+				reason: "Net-zero test",
+			});
+		});
+
+		// Fetch the CONTROL:ALLOCATION account directly and check its cumulative balance
+		const controlBalance = await t.run(async (ctx) => {
+			const controlAccount = await getOrCreateCashAccount(ctx, {
+				family: "CONTROL",
+				mortgageId: setup.mortgageId,
+				obligationId: setup.obligationId,
+				subaccount: "ALLOCATION",
+			});
+			return getCashAccountBalance(controlAccount);
+		});
+
+		// The allocation debited CONTROL:ALLOCATION for lender shares + servicing fee.
+		// The reversal credited CONTROL:ALLOCATION for the same amounts.
+		// Net balance should be zero.
+		expect(controlBalance).toBe(0n);
+	});
+
+	it("isPostingGroupComplete returns true for a complete allocation (pre-reversal scenario)", async () => {
+		const t = createHarness(modules);
+		const seeded = await seedMinimalEntities(t);
+
+		const obligationId = await createSettledObligation(t, {
+			mortgageId: seeded.mortgageId,
+			borrowerId: seeded.borrowerId,
+			amount: 50_000,
+		});
+		const postingGroupId = `allocation:${obligationId}`;
+
+		// Create a complete posting group: credit + matching debits = net zero
+		await t.run(async (ctx) => {
+			const controlAccount = await getOrCreateCashAccount(ctx, {
+				family: "CONTROL",
+				mortgageId: seeded.mortgageId,
+				obligationId,
+				subaccount: "ALLOCATION",
+			});
+			const unappliedAccount = await getOrCreateCashAccount(ctx, {
+				family: "UNAPPLIED_CASH",
+				mortgageId: seeded.mortgageId,
+			});
+			// Pre-seed UNAPPLIED_CASH (credit-normal) with sufficient balance
+			await ctx.db.patch(unappliedAccount._id, {
+				cumulativeCredits: 50_000n,
+			});
+			const payableAccountA = await getOrCreateCashAccount(ctx, {
+				family: "LENDER_PAYABLE",
+				mortgageId: seeded.mortgageId,
+				lenderId: seeded.lenderAId,
+			});
+			const payableAccountB = await getOrCreateCashAccount(ctx, {
+				family: "LENDER_PAYABLE",
+				mortgageId: seeded.mortgageId,
+				lenderId: seeded.lenderBId,
+			});
+
+			// Credit CONTROL:ALLOCATION via CASH_APPLIED (50_000 in)
+			await postCashEntryInternal(ctx, {
+				entryType: "CASH_APPLIED",
+				effectiveDate: "2026-03-01",
+				amount: 50_000,
+				debitAccountId: unappliedAccount._id,
+				creditAccountId: controlAccount._id,
+				idempotencyKey: buildIdempotencyKey(
+					"cash-applied",
+					"reversal-integ-seed"
+				),
+				mortgageId: seeded.mortgageId,
+				obligationId,
+				postingGroupId,
+				source: SYSTEM_SOURCE,
+			});
+
+			// Debit CONTROL:ALLOCATION (30_000 out)
+			await postCashEntryInternal(ctx, {
+				entryType: "LENDER_PAYABLE_CREATED",
+				effectiveDate: "2026-03-01",
+				amount: 30_000,
+				debitAccountId: controlAccount._id,
+				creditAccountId: payableAccountA._id,
+				idempotencyKey: buildIdempotencyKey(
+					"lender-payable",
+					"reversal-integ-a"
+				),
+				mortgageId: seeded.mortgageId,
+				obligationId,
+				lenderId: seeded.lenderAId,
+				postingGroupId,
+				source: SYSTEM_SOURCE,
+			});
+
+			// Debit CONTROL:ALLOCATION (20_000 out) — nets to zero
+			await postCashEntryInternal(ctx, {
+				entryType: "LENDER_PAYABLE_CREATED",
+				effectiveDate: "2026-03-01",
+				amount: 20_000,
+				debitAccountId: controlAccount._id,
+				creditAccountId: payableAccountB._id,
+				idempotencyKey: buildIdempotencyKey(
+					"lender-payable",
+					"reversal-integ-b"
+				),
+				mortgageId: seeded.mortgageId,
+				obligationId,
+				lenderId: seeded.lenderBId,
+				postingGroupId,
+				source: SYSTEM_SOURCE,
+			});
+		});
+
+		const summary = await t.run(async (ctx) => {
+			return getPostingGroupSummary(ctx, postingGroupId);
+		});
+
+		expect(isPostingGroupComplete(summary)).toBe(true);
+		expect(summary.controlAllocationBalance).toBe(0n);
+		expect(summary.hasCorruptEntries).toBe(false);
+		expect(summary.totalJournalEntryCount).toBe(3);
+	});
+});

--- a/convex/payments/cashLedger/integrations.ts
+++ b/convex/payments/cashLedger/integrations.ts
@@ -764,6 +764,461 @@ export async function postCashReceiptWithSuspenseFallback(
 	});
 }
 
+// ── Payment Reversal Cascade ─────────────────────────────────────────
+
+/**
+ * Multi-leg reversal orchestrator for payment reversals.
+ *
+ * Reverses the full settlement allocation cascade:
+ *   1. CASH_RECEIVED reversal (debit BORROWER_RECEIVABLE, credit TRUST_CASH)
+ *   2. N x LENDER_PAYABLE_CREATED reversals
+ *   3. SERVICING_FEE_RECOGNIZED reversal
+ *   4. Conditional LENDER_PAYOUT_SENT clawback(s)
+ *
+ * Fully idempotent on `postingGroupId`. Re-invoking with the same attempt
+ * returns the previously-persisted entries.
+ */
+export async function postPaymentReversalCascade(
+	ctx: MutationCtx,
+	args: {
+		attemptId?: Id<"collectionAttempts">;
+		transferRequestId?: Id<"transferRequests">;
+		obligationId: Id<"obligations">;
+		mortgageId: Id<"mortgages">;
+		effectiveDate: string;
+		source: CommandSource;
+		reason: string;
+	}
+): Promise<{
+	reversalEntries: Doc<"cash_ledger_journal_entries">[];
+	postingGroupId: string;
+	clawbackRequired: boolean;
+}> {
+	// Prep 1: Resolve the original attempt identifier
+	if (!(args.attemptId || args.transferRequestId)) {
+		throw new ConvexError(
+			"postPaymentReversalCascade: must provide either attemptId or transferRequestId"
+		);
+	}
+
+	const sourceId = args.attemptId
+		? String(args.attemptId)
+		: `transfer:${String(args.transferRequestId)}`;
+
+	// Prep 2: Generate postingGroupId
+	const postingGroupId = args.attemptId
+		? `reversal-group:${args.attemptId}`
+		: `reversal-group:transfer:${args.transferRequestId}`;
+
+	// Prep 3: Find original CASH_RECEIVED entry (needed for subsequent checks)
+	const obligationEntries = await ctx.db
+		.query("cash_ledger_journal_entries")
+		.withIndex("by_obligation_and_sequence", (q) =>
+			q.eq("obligationId", args.obligationId)
+		)
+		.collect();
+
+	const originalCashReceived = obligationEntries.find(
+		(e) =>
+			e.entryType === "CASH_RECEIVED" &&
+			(args.attemptId
+				? e.attemptId === args.attemptId
+				: e.transferRequestId === args.transferRequestId)
+	);
+
+	if (!originalCashReceived) {
+		throw new ConvexError(
+			`postPaymentReversalCascade: no CASH_RECEIVED entry found for ${sourceId}`
+		);
+	}
+
+	// Check idempotency FIRST — return existing entries if cascade already posted
+	const existingEntries = await ctx.db
+		.query("cash_ledger_journal_entries")
+		.withIndex("by_posting_group", (q) =>
+			q.eq("postingGroupId", postingGroupId)
+		)
+		.collect();
+
+	if (existingEntries.length > 0) {
+		const clawbackRequired = existingEntries.some((e) =>
+			e.idempotencyKey.includes("payout-clawback")
+		);
+		return {
+			reversalEntries: existingEntries,
+			postingGroupId,
+			clawbackRequired,
+		};
+	}
+
+	// Prep 4: Double-reversal guard — prevent re-reversing a previously-reversed cascade
+	const existingReversal = await findExistingReversal(
+		ctx,
+		originalCashReceived._id
+	);
+	if (existingReversal) {
+		throw new ConvexError({
+			code: "DOUBLE_REVERSAL",
+			message: `postPaymentReversalCascade: CASH_RECEIVED entry ${originalCashReceived._id} already reversed by ${existingReversal._id}`,
+			originalEntryId: originalCashReceived._id,
+			existingReversalId: existingReversal._id,
+		});
+	}
+
+	const normalizedSource = normalizeSource(args.source);
+	const reversalEntries: Doc<"cash_ledger_journal_entries">[] = [];
+
+	// Step 1 — Reverse CASH_RECEIVED: swap debit/credit from original
+	const cashReceivedReversal = await postCashEntryInternal(ctx, {
+		entryType: "REVERSAL",
+		effectiveDate: args.effectiveDate,
+		amount: safeBigintToNumber(originalCashReceived.amount),
+		debitAccountId: originalCashReceived.creditAccountId,
+		creditAccountId: originalCashReceived.debitAccountId,
+		causedBy: originalCashReceived._id,
+		idempotencyKey: buildIdempotencyKey("reversal", "cash-received", sourceId),
+		postingGroupId,
+		mortgageId: args.mortgageId,
+		obligationId: args.obligationId,
+		borrowerId: originalCashReceived.borrowerId,
+		attemptId: args.attemptId,
+		transferRequestId: args.transferRequestId,
+		source: normalizedSource,
+		reason: args.reason,
+	});
+	reversalEntries.push(cashReceivedReversal.entry);
+
+	// Prep 6: Find original LENDER_PAYABLE_CREATED entries (from allocation posting group)
+	const allocationGroupId = `allocation:${args.obligationId}`;
+	const allocationEntries = await ctx.db
+		.query("cash_ledger_journal_entries")
+		.withIndex("by_posting_group", (q) =>
+			q.eq("postingGroupId", allocationGroupId)
+		)
+		.collect();
+
+	const lenderPayableEntries = allocationEntries.filter(
+		(e) => e.entryType === "LENDER_PAYABLE_CREATED"
+	);
+
+	if (lenderPayableEntries.length === 0 && allocationEntries.length > 0) {
+		console.warn(
+			`[postPaymentReversalCascade] No LENDER_PAYABLE_CREATED entries in allocation group ${allocationGroupId} ` +
+				`for obligation ${args.obligationId}. Only CASH_RECEIVED will be reversed — lender payables may be orphaned.`
+		);
+	}
+
+	// Step 2 — Reverse each LENDER_PAYABLE_CREATED
+	for (const original of lenderPayableEntries) {
+		const result = await postCashEntryInternal(ctx, {
+			entryType: "REVERSAL",
+			effectiveDate: args.effectiveDate,
+			amount: safeBigintToNumber(original.amount),
+			debitAccountId: original.creditAccountId,
+			creditAccountId: original.debitAccountId,
+			causedBy: original._id,
+			idempotencyKey: buildIdempotencyKey(
+				"reversal",
+				"lender-payable",
+				original.dispersalEntryId
+					? String(original.dispersalEntryId)
+					: String(original._id)
+			),
+			postingGroupId,
+			mortgageId: args.mortgageId,
+			obligationId: args.obligationId,
+			dispersalEntryId: original.dispersalEntryId,
+			lenderId: original.lenderId,
+			borrowerId: original.borrowerId,
+			source: normalizedSource,
+			reason: args.reason,
+		});
+		reversalEntries.push(result.entry);
+	}
+
+	// Prep 7: Find original SERVICING_FEE_RECOGNIZED entry
+	const servicingFeeEntry = allocationEntries.find(
+		(e) => e.entryType === "SERVICING_FEE_RECOGNIZED"
+	);
+
+	// Step 3 — Reverse SERVICING_FEE_RECOGNIZED (if present)
+	if (servicingFeeEntry) {
+		const result = await postCashEntryInternal(ctx, {
+			entryType: "REVERSAL",
+			effectiveDate: args.effectiveDate,
+			amount: safeBigintToNumber(servicingFeeEntry.amount),
+			debitAccountId: servicingFeeEntry.creditAccountId,
+			creditAccountId: servicingFeeEntry.debitAccountId,
+			causedBy: servicingFeeEntry._id,
+			idempotencyKey: buildIdempotencyKey(
+				"reversal",
+				"servicing-fee",
+				String(args.obligationId)
+			),
+			postingGroupId,
+			mortgageId: args.mortgageId,
+			obligationId: args.obligationId,
+			borrowerId: servicingFeeEntry.borrowerId,
+			source: normalizedSource,
+			reason: args.reason,
+		});
+		reversalEntries.push(result.entry);
+	}
+
+	// 11. Check for LENDER_PAYOUT_SENT entries per lender
+	// Query by mortgageId + lenderId for each lender that had a payable entry
+	let clawbackRequired = false;
+
+	const uniqueLenderIds = [
+		...new Set(
+			lenderPayableEntries
+				.map((e) => e.lenderId)
+				.filter((id): id is Id<"lenders"> => id !== undefined)
+		),
+	];
+
+	for (const lenderId of uniqueLenderIds) {
+		// Query entries by lender to find LENDER_PAYOUT_SENT entries for this mortgage
+		const lenderEntries = await ctx.db
+			.query("cash_ledger_journal_entries")
+			.withIndex("by_lender_and_sequence", (q) => q.eq("lenderId", lenderId))
+			.collect();
+
+		const payoutEntries = lenderEntries.filter(
+			(e) =>
+				e.entryType === "LENDER_PAYOUT_SENT" &&
+				e.mortgageId === args.mortgageId &&
+				e.obligationId === args.obligationId
+		);
+
+		// Step 4 (conditional) — Reverse LENDER_PAYOUT_SENT (clawback)
+		for (const payoutEntry of payoutEntries) {
+			clawbackRequired = true;
+			const result = await postCashEntryInternal(ctx, {
+				entryType: "REVERSAL",
+				effectiveDate: args.effectiveDate,
+				amount: safeBigintToNumber(payoutEntry.amount),
+				debitAccountId: payoutEntry.creditAccountId,
+				creditAccountId: payoutEntry.debitAccountId,
+				causedBy: payoutEntry._id,
+				idempotencyKey: buildIdempotencyKey(
+					"reversal",
+					"payout-clawback",
+					String(lenderId),
+					sourceId
+				),
+				postingGroupId,
+				mortgageId: args.mortgageId,
+				obligationId: args.obligationId,
+				lenderId,
+				source: normalizedSource,
+				reason: args.reason,
+			});
+			reversalEntries.push(result.entry);
+		}
+	}
+
+	return { reversalEntries, postingGroupId, clawbackRequired };
+}
+
+// ── Transfer Reversal ────────────────────────────────────────────────
+
+/**
+ * Single-entry reversal for transfer-based flows.
+ * Loads the original entry, validates the amount, swaps debit/credit,
+ * and posts a REVERSAL entry via `postCashEntryInternal()`.
+ */
+export async function postTransferReversal(
+	ctx: MutationCtx,
+	args: {
+		transferRequestId: Id<"transferRequests">;
+		originalEntryId: Id<"cash_ledger_journal_entries">;
+		amount: number;
+		effectiveDate: string;
+		source: CommandSource;
+		reason: string;
+	}
+): Promise<{
+	entry: Doc<"cash_ledger_journal_entries">;
+	postingGroupId: string;
+}> {
+	// 1. Load original entry
+	const original = await ctx.db.get(args.originalEntryId);
+	if (!original) {
+		throw new ConvexError(
+			`postTransferReversal: original entry not found: ${args.originalEntryId}`
+		);
+	}
+
+	// 2. Validate reversal amount <= original amount
+	assertReversalAmountValid(
+		args.amount,
+		original.amount,
+		"postTransferReversal"
+	);
+
+	// 3. Double-reversal guard
+	const reversalIdempotencyKey = buildIdempotencyKey(
+		"reversal",
+		"transfer",
+		String(args.transferRequestId),
+		String(args.originalEntryId)
+	);
+	const existingByIdem = await ctx.db
+		.query("cash_ledger_journal_entries")
+		.withIndex("by_idempotency", (q) =>
+			q.eq("idempotencyKey", reversalIdempotencyKey)
+		)
+		.first();
+	if (existingByIdem) {
+		return {
+			entry: existingByIdem,
+			postingGroupId: `reversal:transfer:${args.transferRequestId}`,
+		};
+	}
+	// Check for existing reversal by causedBy (handles different transferRequestId retries)
+	const existingByCausedBy = await findExistingReversal(
+		ctx,
+		args.originalEntryId
+	);
+	if (existingByCausedBy) {
+		throw new ConvexError({
+			code: "DOUBLE_REVERSAL",
+			message: `postTransferReversal: entry ${args.originalEntryId} already reversed by ${existingByCausedBy._id}`,
+			originalEntryId: args.originalEntryId,
+			existingReversalId: existingByCausedBy._id,
+		});
+	}
+
+	const normalizedSource = normalizeSource(args.source);
+
+	// 4. Post REVERSAL with swapped debit/credit
+	const result = await postCashEntryInternal(ctx, {
+		entryType: "REVERSAL",
+		effectiveDate: args.effectiveDate,
+		amount: args.amount,
+		debitAccountId: original.creditAccountId,
+		creditAccountId: original.debitAccountId,
+		causedBy: original._id,
+		idempotencyKey: buildIdempotencyKey(
+			"reversal",
+			"transfer",
+			String(args.transferRequestId),
+			String(args.originalEntryId)
+		),
+		postingGroupId: `reversal:transfer:${args.transferRequestId}`,
+		mortgageId: original.mortgageId,
+		obligationId: original.obligationId,
+		transferRequestId: args.transferRequestId,
+		borrowerId: original.borrowerId,
+		lenderId: original.lenderId,
+		source: normalizedSource,
+		reason: args.reason,
+	});
+
+	return {
+		entry: result.entry,
+		postingGroupId: `reversal:transfer:${args.transferRequestId}`,
+	};
+}
+
+// ── Reversal Helpers ─────────────────────────────────────────────────
+
+/**
+ * Checks whether the given original entry has already been reversed.
+ * Returns the existing REVERSAL entry if found, or null otherwise.
+ * Prevents double-reversal of the same original entry via different
+ * attemptIds/transferRequestIds.
+ */
+async function findExistingReversal(
+	ctx: MutationCtx,
+	originalEntryId: Id<"cash_ledger_journal_entries">
+): Promise<Doc<"cash_ledger_journal_entries"> | null> {
+	const original = await ctx.db.get(originalEntryId);
+	if (!original) {
+		return null;
+	}
+
+	// Query by obligationId (covers cascade flow and entries with obligationId)
+	if (original.obligationId) {
+		const entries = await ctx.db
+			.query("cash_ledger_journal_entries")
+			.withIndex("by_obligation_and_sequence", (q) =>
+				q.eq("obligationId", original.obligationId)
+			)
+			.collect();
+		const found = entries.find(
+			(e) => e.entryType === "REVERSAL" && e.causedBy === originalEntryId
+		);
+		if (found) {
+			return found;
+		}
+	}
+
+	// Query by postingGroupId (covers transfer reversals without obligationId).
+	// postingGroupId pattern: reversal:transfer:{transferRequestId}
+	// We scan the posting group entries and filter for REVERSAL + matching causedBy.
+	if (original.transferRequestId) {
+		const postingGroupId = `reversal:transfer:${original.transferRequestId}`;
+		const entries = await ctx.db
+			.query("cash_ledger_journal_entries")
+			.withIndex("by_posting_group", (q) =>
+				q.eq("postingGroupId", postingGroupId)
+			)
+			.collect();
+		const found = entries.find(
+			(e) => e.entryType === "REVERSAL" && e.causedBy === originalEntryId
+		);
+		if (found) {
+			return found;
+		}
+	}
+
+	// Fallback: scan ALL journal entries for a REVERSAL with matching causedBy.
+	// This is O(n) but bounded — a production system would add a causedBy index.
+	// Safe for Phase 1 volumes where each obligation has <50 entries.
+	const all = await ctx.db
+		.query("cash_ledger_journal_entries")
+		.withIndex("by_obligation_and_sequence", (q) =>
+			// Convex requires an index; use the broadest available: by_obligation_and_sequence.
+			// For entries without obligationId, this returns entries with undefined obligationId.
+			original.obligationId ? q.eq("obligationId", original.obligationId) : q
+		)
+		.collect();
+	return (
+		all.find(
+			(e) =>
+				e.entryType === "REVERSAL" &&
+				e.causedBy === originalEntryId &&
+				// Exclude entries with a different obligationId (only relevant when original.obligationId is undefined)
+				(!e.obligationId || e.obligationId === original.obligationId)
+		) ?? null
+	);
+}
+
+export function assertReversalAmountValid(
+	reversalAmount: number,
+	originalAmount: bigint,
+	context: string
+): void {
+	if (reversalAmount <= 0) {
+		throw new ConvexError({
+			code: "INVALID_REVERSAL_AMOUNT",
+			message: `${context}: reversal amount must be positive, got ${reversalAmount}`,
+			reversalAmount,
+		});
+	}
+	const originalAsNumber = safeBigintToNumber(originalAmount);
+	if (reversalAmount > originalAsNumber) {
+		throw new ConvexError({
+			code: "REVERSAL_EXCEEDS_ORIGINAL",
+			message: `${context}: reversal amount ${reversalAmount} exceeds original amount ${originalAsNumber}`,
+			reversalAmount,
+			originalAmount: originalAsNumber,
+		});
+	}
+}
+
 // ── Cash Correction ──────────────────────────────────────────────────
 
 const CORRECTION_REQUIRES_ADMIN =

--- a/convex/payments/cashLedger/queries.ts
+++ b/convex/payments/cashLedger/queries.ts
@@ -10,6 +10,7 @@ import {
 	safeBigintToNumber,
 } from "./accounts";
 import {
+	findSettledObligationsWithNonZeroBalance,
 	getControlBalanceBySubaccount,
 	getControlBalancesByPostingGroup,
 	getJournalSettledAmountForObligation,
@@ -211,6 +212,21 @@ export const getJournalSettledAmount = cashLedgerQuery
 		return getJournalSettledAmountForObligation(ctx, args.obligationId);
 	})
 	.public();
+
+// ── Reversal Indicator Queries ────────────────────────────────
+
+export const getSettledObligationsWithNonZeroBalance = cashLedgerQuery
+	.handler(async (ctx) => {
+		const indicators = await findSettledObligationsWithNonZeroBalance(ctx);
+		// Serialize bigint values to strings for transport
+		return indicators.map((indicator) => ({
+			obligationId: indicator.obligationId,
+			journalSettledAmount: indicator.journalSettledAmount.toString(),
+			obligationAmount: indicator.obligationAmount,
+			expectedBalance: indicator.expectedBalance.toString(),
+		}));
+	})
+	.internal();
 
 // ── CONTROL Subaccount Queries ────────────────────────────────
 

--- a/convex/payments/cashLedger/reconciliation.ts
+++ b/convex/payments/cashLedger/reconciliation.ts
@@ -89,6 +89,54 @@ export const getJournalSettledAmountForObligationInternal = internalQuery({
 	},
 });
 
+// ── Reversal Indicator Detection ─────────────────────────────
+
+export interface ReversalIndicator {
+	expectedBalance: bigint; // obligationAmount - journalSettledAmount
+	journalSettledAmount: bigint;
+	obligationAmount: number;
+	obligationId: Id<"obligations">;
+}
+
+/**
+ * Finds all settled obligations where the journal-derived receivable balance
+ * is non-zero — indicating a reversal has occurred that needs correction.
+ *
+ * For each settled obligation, compares `obligation.amount` against the
+ * journal-derived settled amount (which already accounts for REVERSAL entries).
+ * A non-zero difference means the obligation was marked settled but the journal
+ * disagrees — typically because a payment was reversed after settlement.
+ */
+export async function findSettledObligationsWithNonZeroBalance(
+	ctx: QueryCtx
+): Promise<ReversalIndicator[]> {
+	const settledObligations = await ctx.db
+		.query("obligations")
+		.withIndex("by_status", (q) => q.eq("status", "settled"))
+		.collect();
+
+	const indicators: ReversalIndicator[] = [];
+
+	for (const obligation of settledObligations) {
+		const journalSettledAmount = await getJournalSettledAmountForObligation(
+			ctx,
+			obligation._id
+		);
+		const expectedBalance = BigInt(obligation.amount) - journalSettledAmount;
+
+		if (expectedBalance !== 0n) {
+			indicators.push({
+				obligationId: obligation._id,
+				journalSettledAmount,
+				obligationAmount: obligation.amount,
+				expectedBalance,
+			});
+		}
+	}
+
+	return indicators;
+}
+
 // ── Posting Group Reconciliation ──────────────────────────────
 
 export interface PostingGroupReconciliationAlert {
@@ -165,6 +213,20 @@ export async function findNonZeroPostingGroups(
 
 	return { alerts, orphaned };
 }
+
+export const findSettledObligationsWithNonZeroBalanceInternal = internalQuery({
+	args: {},
+	handler: async (ctx) => {
+		const result = await findSettledObligationsWithNonZeroBalance(ctx);
+		// Convert bigint to number/string for serialization across Convex action/query boundary
+		return result.map((indicator) => ({
+			obligationId: indicator.obligationId,
+			journalSettledAmount: safeBigintToNumber(indicator.journalSettledAmount),
+			obligationAmount: indicator.obligationAmount,
+			expectedBalance: safeBigintToNumber(indicator.expectedBalance),
+		}));
+	},
+});
 
 export const findNonZeroPostingGroupsInternal = internalQuery({
 	args: {},

--- a/convex/payments/cashLedger/types.ts
+++ b/convex/payments/cashLedger/types.ts
@@ -84,6 +84,10 @@ export const CASH_ENTRY_TYPE_FAMILY_MAP: Record<
 		debit: ["WRITE_OFF"],
 		credit: ["BORROWER_RECEIVABLE"],
 	},
+	// REVERSAL entries use ALL_FAMILIES for both debit and credit because they
+	// must be able to reverse any original entry regardless of account family.
+	// REVERSAL entries skip balance checks in postEntry.ts Step 5 (balanceCheck)
+	// and MUST have a causedBy reference (enforced in Step 6, constraintCheck).
 	REVERSAL: {
 		debit: ALL_FAMILIES,
 		credit: ALL_FAMILIES,

--- a/specs/ENG-172/chunks/chunk-01-cascade-function/context.md
+++ b/specs/ENG-172/chunks/chunk-01-cascade-function/context.md
@@ -1,0 +1,202 @@
+# Chunk 1 Context: Core Cascade Function
+
+## What You're Building
+
+Three things in `convex/payments/cashLedger/integrations.ts`:
+1. `assertReversalAmountValid()` — helper to validate reversal amount ≤ original
+2. `postPaymentReversalCascade()` — multi-leg reversal orchestrator
+3. `postTransferReversal()` — single-entry transfer reversal
+
+Plus a verification pass on `types.ts` for REVERSAL constraints.
+
+## Linear Issue: ENG-172
+
+**Summary:** Implement REVERSAL entry type for payment reversals (PAD up to 90 days, ACH up to 60 days). Ledger-first reversal design: obligation stays settled; cash ledger corrects balances.
+
+**Acceptance Criteria:**
+- All REVERSAL entries have `causedBy` referencing original
+- Reversal amount ≤ original entry amount
+- Multi-leg reversal cascade works atomically
+- Idempotent on `originalAttemptId`
+- Settled obligations with non-zero balance detectable
+
+## Reversal Posting Sequence (from Tech Design §5)
+
+```
+Payment reversal received:
+
+1. REVERSAL: Debit BORROWER_RECEIVABLE, Credit TRUST_CASH
+   causedBy: original CASH_RECEIVED entry
+   idempotencyKey: reversal:{originalAttemptId}
+
+2. REVERSAL: Debit LENDER_PAYABLE, Credit CONTROL:ALLOCATION (per lender)
+   causedBy: original LENDER_PAYABLE_CREATED entry
+
+3. REVERSAL: Debit SERVICING_REVENUE, Credit CONTROL:ALLOCATION
+   causedBy: original SERVICING_FEE_RECOGNIZED entry
+
+4. IF payout already sent:
+   REVERSAL: Debit LENDER_PAYABLE (negative = clawback), Credit TRUST_CASH
+   causedBy: original LENDER_PAYOUT_SENT entry
+
+All share postingGroupId: reversal-group:{originalAttemptId}
+```
+
+## Design Decision
+
+Obligation remains `settled` in domain model. Journal-derived balance reverts to outstanding. Reconciliation query detects "settled with non-zero receivable" as reversal indicator.
+
+## Function Signatures (from Implementation Plan)
+
+### postPaymentReversalCascade()
+
+```typescript
+export async function postPaymentReversalCascade(
+  ctx: MutationCtx,
+  args: {
+    // Identify what to reverse
+    attemptId?: Id<"collectionAttempts">;
+    transferRequestId?: Id<"transferRequests">;
+    obligationId: Id<"obligations">;
+    mortgageId: Id<"mortgages">;
+    // Reversal details
+    effectiveDate: string;
+    source: CommandSource;
+    reason: string;
+  }
+): Promise<{
+  reversalEntries: Doc<"cash_ledger_journal_entries">[];
+  postingGroupId: string;
+  clawbackRequired: boolean;
+}>
+```
+
+**Logic:**
+1. Resolve the original attempt identifier — either `attemptId` or `transferRequestId`.
+2. Generate `postingGroupId`: `reversal-group:{attemptId}` (or `reversal-group:transfer:{transferRequestId}`).
+3. Idempotency check: Query `by_posting_group` index for existing reversal group. If entries exist, return them (full idempotency).
+4. Find original CASH_RECEIVED entry — query `by_obligation_and_sequence` filtered by `entryType === "CASH_RECEIVED"` and matching `attemptId`/`transferRequestId`.
+5. Validate reversal amount ≤ original amount.
+6. **Step 1** — Reverse CASH_RECEIVED: debit original's `creditAccountId` (BORROWER_RECEIVABLE), credit original's `debitAccountId` (TRUST_CASH). `causedBy`: original CASH_RECEIVED entry ID. `idempotencyKey`: `buildIdempotencyKey("reversal", "cash-received", attemptId)`.
+7. Find original LENDER_PAYABLE_CREATED entries — query `by_posting_group` for the allocation posting group (`allocation:{obligationId}`), filter by `entryType === "LENDER_PAYABLE_CREATED"`.
+8. **Step 2** — Reverse each LENDER_PAYABLE_CREATED: debit LENDER_PAYABLE, credit CONTROL:ALLOCATION. `causedBy`: original LENDER_PAYABLE_CREATED entry ID. `idempotencyKey`: `buildIdempotencyKey("reversal", "lender-payable", dispersalEntryId)`.
+9. Find original SERVICING_FEE_RECOGNIZED entry — same posting group, filter by entryType.
+10. **Step 3** — Reverse SERVICING_FEE_RECOGNIZED: debit SERVICING_REVENUE, credit CONTROL:ALLOCATION. `causedBy`: original entry ID.
+11. Check for LENDER_PAYOUT_SENT entries — query by lenderId + entryType for each lender.
+12. **Step 4 (conditional)** — Reverse LENDER_PAYOUT_SENT (clawback): only if payout was already sent. Debit LENDER_PAYABLE (creates negative = clawback receivable), credit TRUST_CASH.
+13. All entries share the same `postingGroupId`.
+14. Return results including whether clawback was required.
+
+### assertReversalAmountValid()
+
+```typescript
+function assertReversalAmountValid(
+  reversalAmount: number,
+  originalAmount: bigint,
+  context: string
+): void {
+  const originalNumber = safeBigintToNumber(originalAmount);
+  if (reversalAmount > originalNumber) {
+    throw new ConvexError({
+      code: "REVERSAL_EXCEEDS_ORIGINAL" as const,
+      reversalAmount,
+      originalAmount: originalNumber,
+      context,
+    });
+  }
+}
+```
+
+### postTransferReversal()
+
+```typescript
+export async function postTransferReversal(
+  ctx: MutationCtx,
+  args: {
+    transferRequestId: Id<"transferRequests">;
+    originalEntryId: Id<"cash_ledger_journal_entries">;
+    amount: number;
+    effectiveDate: string;
+    source: CommandSource;
+    reason: string;
+  }
+): Promise<{ entry: Doc<"cash_ledger_journal_entries"> }>
+```
+
+This is a simpler function for single-entry transfer reversals (used by ENG-175 webhook handlers). The full cascade `postPaymentReversalCascade` orchestrates multiple calls internally.
+
+## Existing Patterns to Follow
+
+### postCashCorrectionForEntry() — the model for single-entry reversal
+
+Located in `integrations.ts`. It:
+1. Loads the original entry via `ctx.db.get(originalEntryId)`
+2. Validates admin source and non-empty reason
+3. Posts a REVERSAL entry with swapped debit/credit from original
+4. Optionally posts a replacement entry
+5. Uses posting group ID: `correction:{originalEntryId}:{timestamp}`
+
+**Follow this pattern** for how to swap debit/credit accounts and set causedBy.
+
+### postSettlementAllocation() — the model for multi-entry posting groups
+
+Located in `integrations.ts`. It:
+1. Calls `validatePostingGroupAmounts()` for sum validation
+2. Generates `postingGroupId`: `allocation:{obligationId}`
+3. Loops entries, calling `postCashEntryInternal()` for each
+4. Each entry gets its own `idempotencyKey` but shares the `postingGroupId`
+
+**Follow this pattern** for how multi-entry posting groups are structured.
+
+### Key helpers to use:
+- `postCashEntryInternal(ctx, input)` — all entries go through this 9-step pipeline
+- `normalizeSource(source)` — normalize source format
+- `getOrCreateCashAccount(ctx, spec)` — create or find account by spec
+- `findCashAccount(ctx.db, spec)` — find existing account
+- `requireCashAccount(ctx.db, spec, label)` — find or throw
+- `safeBigintToNumber(value)` — BigInt → number conversion
+- `buildIdempotencyKey(entryType, ...segments)` — builds `cash-ledger:{type}:{segments}`
+- `unixMsToBusinessDate(ms)` — converts timestamp to YYYY-MM-DD
+
+### Entry type family map (from types.ts):
+```typescript
+REVERSAL: { debit: ALL_FAMILIES, credit: ALL_FAMILIES }
+```
+REVERSAL entries are allowed any debit/credit family combination.
+
+### Balance check exemption (from postEntry.ts):
+REVERSAL and CORRECTION entries **skip balance checks entirely** in Step 5 of the pipeline. This is already implemented.
+
+### Constraint check (from postEntry.ts):
+REVERSAL entries **must** have `causedBy` — enforced in Step 6.
+
+### Querying entries by posting group:
+```typescript
+const entries = await ctx.db
+  .query("cash_ledger_journal_entries")
+  .withIndex("by_posting_group", (q) => q.eq("postingGroupId", groupId))
+  .collect();
+```
+
+### Querying entries by obligation and filtering:
+```typescript
+const entries = await ctx.db
+  .query("cash_ledger_journal_entries")
+  .withIndex("by_obligation_and_sequence", (q) => q.eq("obligationId", obligationId))
+  .collect();
+const cashReceived = entries.filter(e => e.entryType === "CASH_RECEIVED" && e.attemptId === attemptId);
+```
+
+## Constraints
+- **Append-only invariant:** No existing journal entries are ever mutated or deleted.
+- **causedBy required:** Every REVERSAL entry must reference the original via `causedBy`.
+- **Cents integrity:** All amounts are safe integers in cents. Use `safeBigintToNumber()` for BigInt conversion.
+- **Idempotency:** Full cascade is idempotent on `postingGroupId`. Individual entries are idempotent on `idempotencyKey`.
+- **Source attribution:** All reversal entries must carry `source` with appropriate actorType and channel.
+- **Audit trail:** Every reversal entry triggers hash-chain audit via the existing `nudge` step in `postEntry.ts`.
+
+## File Map
+| File | Action | Purpose |
+|------|--------|---------|
+| `convex/payments/cashLedger/integrations.ts` | **Modify** | Add `postPaymentReversalCascade()`, `postTransferReversal()`, `assertReversalAmountValid()` |
+| `convex/payments/cashLedger/types.ts` | **Verify** | Confirm REVERSAL family constraints, add balance check exemption documentation comment |

--- a/specs/ENG-172/chunks/chunk-01-cascade-function/tasks.md
+++ b/specs/ENG-172/chunks/chunk-01-cascade-function/tasks.md
@@ -1,0 +1,27 @@
+# Chunk 1: Core Cascade Function
+
+## Tasks
+
+- [ ] T-001: Add `assertReversalAmountValid()` helper to `integrations.ts`
+  - Pure function, takes `reversalAmount: number`, `originalAmount: bigint`, `context: string`
+  - Uses `safeBigintToNumber()` for conversion
+  - Throws `ConvexError({ code: "REVERSAL_EXCEEDS_ORIGINAL", ... })` if reversal > original
+
+- [ ] T-002: Add `postPaymentReversalCascade()` to `integrations.ts`
+  - Multi-leg reversal orchestrator per the posting sequence in context.md
+  - Takes `attemptId | transferRequestId`, `obligationId`, `mortgageId`, `effectiveDate`, `source`, `reason`
+  - Returns `{ reversalEntries, postingGroupId, clawbackRequired }`
+  - Full idempotency via postingGroupId check
+  - Must handle: CASH_RECEIVED reversal, N×LENDER_PAYABLE_CREATED reversals, SERVICING_FEE reversal, conditional LENDER_PAYOUT_SENT clawback
+  - All entries through `postCashEntryInternal()`
+
+- [ ] T-003: Add `postTransferReversal()` to `integrations.ts`
+  - Simpler single-entry reversal for transfer-based flows
+  - Takes `transferRequestId`, `originalEntryId`, `amount`, `effectiveDate`, `source`, `reason`
+  - Loads original, swaps debit/credit, posts REVERSAL via `postCashEntryInternal()`
+  - Validates amount ≤ original via `assertReversalAmountValid()`
+
+- [ ] T-004: Verify REVERSAL family constraints in `types.ts`
+  - Confirm REVERSAL has `ALL_FAMILIES` for both debit and credit (should already be correct)
+  - Add brief documentation comment noting REVERSAL entries skip balance checks (reference postEntry.ts Step 5)
+  - No functional changes expected — verification only

--- a/specs/ENG-172/chunks/chunk-02-reconciliation-query/context.md
+++ b/specs/ENG-172/chunks/chunk-02-reconciliation-query/context.md
@@ -1,0 +1,78 @@
+# Chunk 2 Context: Reconciliation Query
+
+## What You're Building
+
+Add `findSettledObligationsWithNonZeroBalance()` to `reconciliation.ts` and expose it via query endpoints.
+
+This query detects settled obligations where the journal-derived receivable balance is non-zero — the reversal indicator. Downstream consumers (ENG-180: corrective obligation creation) will use this to find obligations needing correction after a reversal.
+
+## Function Signature
+
+```typescript
+export interface ReversalIndicator {
+  obligationId: Id<"obligations">;
+  journalSettledAmount: bigint;
+  obligationAmount: number;
+  expectedBalance: bigint; // obligationAmount - journalSettledAmount
+}
+
+export async function findSettledObligationsWithNonZeroBalance(
+  ctx: QueryCtx
+): Promise<ReversalIndicator[]>
+```
+
+## Logic
+
+1. Query all obligations with `status === "settled"`.
+2. For each, call existing `getJournalSettledAmountForObligation()` (which already handles REVERSAL subtraction — it sums CASH_RECEIVED entries and subtracts REVERSALs that reference CASH_RECEIVED originals).
+3. Compare journal-derived balance to `obligation.amount`.
+4. Return those where `BigInt(obligation.amount) - journalSettledAmount !== 0n` (non-zero receivable = reversal happened).
+
+## Existing Code to Use
+
+### getJournalSettledAmountForObligation() (in reconciliation.ts)
+Already exists and already handles REVERSAL subtraction:
+```typescript
+export async function getJournalSettledAmountForObligation(
+  ctx: QueryCtx,
+  obligationId: Id<"obligations">
+): Promise<bigint>
+// Sums all CASH_RECEIVED entries for this obligation
+// Subtracts REVERSAL entries that reference CASH_RECEIVED originals
+```
+
+### Querying settled obligations
+Query the `obligations` table for `status === "settled"`. Use the appropriate index.
+
+### Existing reconciliation patterns (reconciliation.ts)
+- `reconcileObligationSettlementProjectionInternal()` — similar pattern of loading obligation + computing journal amounts
+- `findNonZeroPostingGroups()` — similar "scan and filter" pattern returning alerts
+
+## Query Endpoint Patterns
+
+### Internal query wrapper (queries.ts or a separate file)
+Follow the existing pattern in `queries.ts` which uses `cashLedgerQuery` builder:
+```typescript
+export const getSettledObligationsWithNonZeroBalance = cashLedgerQuery({
+  args: {},
+  handler: async (ctx) => {
+    return findSettledObligationsWithNonZeroBalance(ctx);
+  },
+});
+```
+
+Or as an `internalQuery` if it should only be called by other Convex functions:
+```typescript
+export const findSettledWithNonZeroBalanceInternal = internalQuery({
+  args: {},
+  handler: async (ctx) => {
+    return findSettledObligationsWithNonZeroBalance(ctx);
+  },
+});
+```
+
+## File Map
+| File | Action | Purpose |
+|------|--------|---------|
+| `convex/payments/cashLedger/reconciliation.ts` | **Modify** | Add `findSettledObligationsWithNonZeroBalance()` + `ReversalIndicator` interface |
+| `convex/payments/cashLedger/queries.ts` | **Modify** | Add public query endpoint |

--- a/specs/ENG-172/chunks/chunk-02-reconciliation-query/tasks.md
+++ b/specs/ENG-172/chunks/chunk-02-reconciliation-query/tasks.md
@@ -1,0 +1,17 @@
+# Chunk 2: Reconciliation Query
+
+## Tasks
+
+- [ ] T-005: Add `findSettledObligationsWithNonZeroBalance()` to `reconciliation.ts`
+  - Export `ReversalIndicator` interface
+  - Query all settled obligations
+  - For each, call `getJournalSettledAmountForObligation()` (already handles REVERSAL subtraction)
+  - Return those where `BigInt(obligation.amount) - journalSettledAmount !== 0n`
+  - Follow existing patterns from `reconcileObligationSettlementProjectionInternal()`
+
+- [ ] T-006: Add `internalQuery` wrapper for use from reconciliation actions
+  - Follow existing pattern for internal queries in the cash ledger module
+
+- [ ] T-007: Add public query endpoint `getSettledObligationsWithNonZeroBalance` to `queries.ts`
+  - Use `cashLedgerQuery` builder pattern
+  - Returns serializable format (bigint → string conversion if needed)

--- a/specs/ENG-172/chunks/chunk-03-unit-tests/context.md
+++ b/specs/ENG-172/chunks/chunk-03-unit-tests/context.md
@@ -1,0 +1,101 @@
+# Chunk 3 Context: Unit Tests
+
+## What You're Building
+
+Unit tests for `postPaymentReversalCascade()`, `postTransferReversal()`, and `assertReversalAmountValid()`.
+
+**File:** `convex/payments/cashLedger/__tests__/reversalCascade.test.ts` (new)
+
+## Test Infrastructure
+
+### Test Harness
+The cash ledger tests use `convex-test` with a custom harness:
+
+```typescript
+import { convexTest } from "convex-test";
+import { modules } from "../../../test.setup"; // or similar
+import { describe, it, expect, beforeEach } from "vitest";
+```
+
+Look at existing test files like `corrections.test.ts`, `postEntry.test.ts`, or `postingGroupIntegration.test.ts` for the exact import patterns and harness setup.
+
+### Test Utilities (testUtils.ts)
+Available helpers:
+- `createTestAccount(ctx, spec)` — creates a cash account with given spec
+- `postTestEntry(ctx, input)` — posts a journal entry through the full pipeline
+- `ADMIN_SOURCE` — `{ actorType: "admin", actorId: "test-admin", channel: "test" }`
+- `SYSTEM_SOURCE` — `{ actorType: "system", actorId: "system", channel: "test" }`
+
+### Setting Up Test State
+To test reversals, you need to first set up a full settlement flow:
+1. Create accounts (BORROWER_RECEIVABLE, TRUST_CASH, LENDER_PAYABLE per lender, SERVICING_REVENUE, CONTROL:ALLOCATION)
+2. Post OBLIGATION_ACCRUED entry
+3. Post CASH_RECEIVED entry
+4. Post LENDER_PAYABLE_CREATED entries (one per lender) + SERVICING_FEE_RECOGNIZED
+5. (Optionally) Post LENDER_PAYOUT_SENT for clawback scenario
+
+Use the existing integration functions:
+- `postObligationAccrued()`
+- `postCashReceiptForObligation()`
+- `postSettlementAllocation()`
+- The lender payout mutation
+
+## Test Cases
+
+### T-008: Full reversal cascade
+1. Set up: accrue obligation → receive cash → allocate to 2 lenders + fee
+2. Call `postPaymentReversalCascade()`
+3. Assert: 4 REVERSAL entries created (1 CASH_RECEIVED + 2 LENDER_PAYABLE + 1 SERVICING_FEE)
+4. Assert: each entry has correct debit/credit accounts (swapped from original)
+5. Assert: each entry has correct amount (matches original)
+
+### T-009: Cascade with clawback
+1. Set up: full flow + send lender payout
+2. Call `postPaymentReversalCascade()`
+3. Assert: 5+ REVERSAL entries (includes LENDER_PAYOUT_SENT reversal)
+4. Assert: `clawbackRequired === true`
+
+### T-010: Cascade without clawback
+1. Set up: full flow without payout
+2. Call `postPaymentReversalCascade()`
+3. Assert: `clawbackRequired === false`
+
+### T-011: Idempotency
+1. Set up flow and call cascade
+2. Call cascade again with same arguments
+3. Assert: same entries returned, no new entries created
+
+### T-012: Amount validation
+1. Attempt reversal where amount > original
+2. Assert: throws ConvexError with code "REVERSAL_EXCEEDS_ORIGINAL"
+
+### T-013: causedBy linkage
+1. Run cascade
+2. For each reversal entry, load the `causedBy` entry
+3. Assert: causedBy exists, has matching entryType that was being reversed
+
+### T-014: Posting group integrity
+1. Run cascade
+2. Assert: all reversal entries share the same `postingGroupId`
+3. Assert: `postingGroupId` follows pattern `reversal-group:{attemptId}`
+
+### T-015: postTransferReversal
+1. Post a CASH_RECEIVED entry with transferRequestId
+2. Call `postTransferReversal()`
+3. Assert: REVERSAL entry created with swapped accounts, correct causedBy, correct idempotencyKey
+
+## Existing Test Patterns
+
+Look at `corrections.test.ts` for:
+- How to set up accounts and entries before testing corrections/reversals
+- How to assert on entry fields
+- How to test idempotency
+
+Look at `postingGroupIntegration.test.ts` for:
+- How to test multi-entry posting groups
+- How to verify CONTROL:ALLOCATION balances
+
+## File Map
+| File | Action | Purpose |
+|------|--------|---------|
+| `convex/payments/cashLedger/__tests__/reversalCascade.test.ts` | **Create** | Unit tests for cascade function |

--- a/specs/ENG-172/chunks/chunk-03-unit-tests/tasks.md
+++ b/specs/ENG-172/chunks/chunk-03-unit-tests/tasks.md
@@ -1,0 +1,12 @@
+# Chunk 3: Unit Tests
+
+## Tasks
+
+- [ ] T-008: Test full reversal cascade — CASH_RECEIVED + 2×LENDER_PAYABLE_CREATED + SERVICING_FEE → all reversed with correct accounts
+- [ ] T-009: Test cascade with clawback — payout already sent → Step 4 fires
+- [ ] T-010: Test cascade without clawback — no payout sent → Step 4 skipped
+- [ ] T-011: Test idempotency — calling cascade twice returns same entries
+- [ ] T-012: Test amount validation — reversal amount > original → ConvexError
+- [ ] T-013: Test causedBy linkage — every REVERSAL entry references its original
+- [ ] T-014: Test posting group integrity — all entries share `postingGroupId`
+- [ ] T-015: Test `postTransferReversal()` — single-entry reversal with correct idempotency

--- a/specs/ENG-172/chunks/chunk-04-integration-tests/context.md
+++ b/specs/ENG-172/chunks/chunk-04-integration-tests/context.md
@@ -1,0 +1,67 @@
+# Chunk 4 Context: Integration Tests
+
+## What You're Building
+
+End-to-end integration tests that exercise the full accrual → receipt → allocation → reversal pipeline and verify:
+- All account balances are correct after reversal
+- Reconciliation detection works
+- Posting group integrity holds
+
+**File:** `convex/payments/cashLedger/__tests__/reversalIntegration.test.ts` (new)
+
+## Test Infrastructure
+
+Same as Chunk 3 — uses `convex-test` harness. See existing `postingGroupIntegration.test.ts` for the full integration test pattern.
+
+## Test Cases
+
+### T-016: E2E full reversal without payout
+1. Create a mortgage, obligation, borrower, 2 lenders
+2. `postObligationAccrued()` → verify BORROWER_RECEIVABLE balance increases
+3. `postCashReceiptForObligation()` → verify TRUST_CASH increases, BORROWER_RECEIVABLE decreases
+4. `postSettlementAllocation()` → verify LENDER_PAYABLE accounts created, CONTROL:ALLOCATION nets to zero
+5. `postPaymentReversalCascade()` → verify:
+   - BORROWER_RECEIVABLE balance restored to pre-receipt level
+   - TRUST_CASH balance restored
+   - LENDER_PAYABLE balances zeroed
+   - CONTROL:ALLOCATION still nets to zero (reversal posting group also nets to zero independently)
+   - SERVICING_REVENUE zeroed
+
+### T-017: E2E reversal with payout (clawback)
+1. Same as T-016 but also post LENDER_PAYOUT_SENT for one lender
+2. Reverse
+3. Verify:
+   - LENDER_PAYABLE for paid lender goes negative (clawback receivable)
+   - TRUST_CASH reflects both original receipt and payout reversal
+   - `clawbackRequired === true`
+
+### T-018: Reconciliation detection
+1. Create obligation, settle it (mark as settled in obligations table)
+2. Post full settlement flow in cash ledger
+3. Post reversal cascade
+4. Call `findSettledObligationsWithNonZeroBalance()`
+5. Assert: returns the reversed obligation with correct amounts
+
+### T-019: Posting group validation
+1. Run full cascade
+2. Call `validatePostingGroupEntries()` on the reversal posting group
+3. Assert: `isPostingGroupComplete()` returns true (CONTROL:ALLOCATION nets to zero)
+
+### T-020: Quality Gate
+Run `bun check`, `bun typecheck`, `bunx convex codegen` and fix any errors.
+
+## Existing Patterns
+
+Look at `postingGroupIntegration.test.ts` for:
+- How E2E tests are structured
+- How to verify account balances after complex multi-step flows
+- How to use `getCashAccountBalance()` for assertions
+
+Look at `reconciliationSuite.test.ts` for:
+- How reconciliation functions are tested
+- How to set up settled obligations for testing
+
+## File Map
+| File | Action | Purpose |
+|------|--------|---------|
+| `convex/payments/cashLedger/__tests__/reversalIntegration.test.ts` | **Create** | E2E integration tests |

--- a/specs/ENG-172/chunks/chunk-04-integration-tests/tasks.md
+++ b/specs/ENG-172/chunks/chunk-04-integration-tests/tasks.md
@@ -1,0 +1,9 @@
+# Chunk 4: Integration Tests
+
+## Tasks
+
+- [ ] T-016: E2E test: accrue → receive cash → allocate → reverse → verify all account balances
+- [ ] T-017: E2E test: accrue → receive → allocate → payout → reverse → verify clawback
+- [ ] T-018: Test `findSettledObligationsWithNonZeroBalance()` detects reversed obligations
+- [ ] T-019: Test posting group nets to zero via `validatePostingGroupEntries` after reversal
+- [ ] T-020: Run quality gate: `bun check`, `bun typecheck`, `bunx convex codegen`

--- a/specs/ENG-172/chunks/manifest.md
+++ b/specs/ENG-172/chunks/manifest.md
@@ -1,0 +1,22 @@
+# ENG-172: Chunk Manifest
+
+## Execution Order
+
+| # | Chunk | Tasks | Status | Description |
+|---|-------|-------|--------|-------------|
+| 1 | chunk-01-cascade-function | T-001 → T-004 | pending | Core `postPaymentReversalCascade()` + `postTransferReversal()` + amount validation helper |
+| 2 | chunk-02-reconciliation-query | T-005 → T-007 | pending | `findSettledObligationsWithNonZeroBalance()` detection query + public endpoint |
+| 3 | chunk-03-unit-tests | T-008 → T-015 | pending | Unit tests for cascade, idempotency, clawback, amount validation, causedBy linkage |
+| 4 | chunk-04-integration-tests | T-016 → T-020 | pending | E2E integration tests + quality gate |
+
+## Dependencies
+- Chunk 2 depends on Chunk 1 (reconciliation queries reference reversal entries)
+- Chunk 3 depends on Chunk 1 (tests exercise the cascade function)
+- Chunk 4 depends on Chunks 1-3 (E2E tests exercise full pipeline)
+
+## Key Context Sources
+- **Implementation Plan**: Notion page `32efc1b440248153a212d07c280f49de`
+- **Tech Design §5**: Payment Reversal Design in `329fc1b44024801da365d6ccdf137e2a`
+- **Cash & Obligations Ledger Goal**: Entry Semantics §6 in `329fc1b4402480b2b82ffa798d6c8e73`
+- **Blocking Issues**: ENG-160 (Done ✅), ENG-162 (Done ✅)
+- **Downstream**: ENG-175 (webhook handlers), ENG-173 (reversed state), ENG-180 (corrective obligations)

--- a/specs/ENG-172/tasks.md
+++ b/specs/ENG-172/tasks.md
@@ -1,0 +1,31 @@
+# ENG-172: REVERSAL Entry Type with Posting Group Semantics
+
+## Master Task List
+
+### Chunk 1: Core Cascade Function (integrations.ts) ✅
+- [x] T-001: Add `assertReversalAmountValid()` helper to `integrations.ts`
+- [x] T-002: Add `postPaymentReversalCascade()` to `integrations.ts` — the multi-leg reversal orchestrator
+- [x] T-003: Add `postTransferReversal()` to `integrations.ts` — single-entry transfer reversal for webhook handlers
+- [x] T-004: Verify REVERSAL family constraints in `types.ts` and add documentation comment for balance check exemption
+
+### Chunk 2: Reconciliation Query (reconciliation.ts + queries.ts) ✅
+- [x] T-005: Add `findSettledObligationsWithNonZeroBalance()` to `reconciliation.ts`
+- [x] T-006: Add `internalQuery` wrapper for `findSettledObligationsWithNonZeroBalance` in queries
+- [x] T-007: Add public query endpoint `getSettledObligationsWithNonZeroBalance` to `queries.ts`
+
+### Chunk 3: Unit Tests (reversalCascade.test.ts) ✅
+- [x] T-008: Test full reversal cascade — CASH_RECEIVED + 2×LENDER_PAYABLE_CREATED + SERVICING_FEE → all reversed with correct accounts
+- [x] T-009: Test cascade with clawback — payout already sent → Step 4 fires
+- [x] T-010: Test cascade without clawback — no payout sent → Step 4 skipped
+- [x] T-011: Test idempotency — calling cascade twice returns same entries
+- [x] T-012: Test amount validation — reversal amount > original → ConvexError
+- [x] T-013: Test causedBy linkage — every REVERSAL entry references its original
+- [x] T-014: Test posting group integrity — all entries share `postingGroupId`
+- [x] T-015: Test `postTransferReversal()` — single-entry reversal with correct idempotency
+
+### Chunk 4: Integration Tests (reversalIntegration.test.ts) ✅
+- [x] T-016: E2E test: accrue → receive cash → allocate → reverse → verify all account balances
+- [x] T-017: E2E test: accrue → receive → allocate → payout → reverse → verify clawback
+- [x] T-018: Test `findSettledObligationsWithNonZeroBalance()` detects reversed obligations
+- [x] T-019: Test posting group nets to zero via `validatePostingGroupEntries` after reversal
+- [x] T-020: Run quality gate: `bun check`, `bun typecheck`, `bunx convex codegen`


### PR DESCRIPTION
### TL;DR

Implements REVERSAL entry type for payment reversals with multi-leg cascade orchestration, reconciliation detection, and comprehensive test coverage.

### What changed?

Added comprehensive payment reversal functionality to the cash ledger system:

**Core Functions (`integrations.ts`):**
- `postPaymentReversalCascade()` - Multi-leg reversal orchestrator that reverses CASH_RECEIVED, LENDER_PAYABLE_CREATED, SERVICING_FEE_RECOGNIZED entries, and conditionally handles LENDER_PAYOUT_SENT clawbacks
- `postTransferReversal()` - Single-entry reversal for transfer-based flows
- `assertReversalAmountValid()` - Validation helper ensuring reversal amounts don't exceed originals

**Reconciliation Detection (`reconciliation.ts` + `queries.ts`):**
- `findSettledObligationsWithNonZeroBalance()` - Detects settled obligations with non-zero journal balances (reversal indicators)
- Public and internal query endpoints for accessing reversal indicators

**Test Coverage:**
- `reversalCascade.test.ts` - Unit tests covering cascade logic, idempotency, clawback scenarios, amount validation, and causedBy linkage
- `reversalIntegration.test.ts` - E2E integration tests verifying complete accrual → receipt → allocation → reversal flows with balance verification

**Key Features:**
- Full idempotency on posting group IDs
- Atomic multi-entry reversals with consistent posting groups
- Double-reversal prevention via causedBy tracking
- Conditional clawback handling for already-sent payouts
- Obligation-scoped clawback (only reverses payouts for specific obligations)

### How to test?

Run the new test suites:
```bash
# Unit tests for cascade logic
bun test reversalCascade.test.ts

# Integration tests for E2E flows
bun test reversalIntegration.test.ts

# Quality gate
bun check && bun typecheck && bunx convex codegen
```

Test scenarios include:
- Full reversal cascade without payouts
- Reversal cascade with clawback when payouts already sent
- Idempotency verification
- Amount validation edge cases
- Balance reconciliation after reversals
- Posting group integrity verification

### Why make this change?

Enables handling of payment reversals (PAD up to 90 days, ACH up to 60 days) with a ledger-first approach. The obligation remains "settled" in the domain model while the cash ledger corrects balances through REVERSAL entries. This provides:

- Accurate financial reconciliation after payment reversals
- Audit trail preservation through causedBy linkage
- Automated clawback detection and handling
- Foundation for downstream corrective obligation creation (ENG-180)
- Support for webhook-driven reversal processing (ENG-175)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added payment reversal functionality for settled obligations, cascading across accruals, receipts, payables, and fees.
  * Clawback detection and handling for lender reversals.
  * New reconciliation query to identify settled obligations with non-zero balances.

* **Tests**
  * Added comprehensive unit and integration test suites covering reversal scenarios, idempotency, clawback handling, and amount validation.

* **Documentation**
  * Added technical specifications and design documentation for reversal functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->