### PR TITLE
ENG-189: Define TransferProvider Interface and Result Types

### DIFF
--- a/convex/payments/transfers/types.ts
+++ b/convex/payments/transfers/types.ts
@@ -34,9 +34,15 @@ export type TransferType = InboundTransferType | OutboundTransferType;
  * Used by the Provider Capability Registry (ENG-215) to map
  * (transferType, direction) pairs to enabled providers.
  *
+ * Only semantically valid combinations are allowed:
+ * - inbound transfer types with 'inbound'
+ * - outbound transfer types with 'outbound'
+ *
  * Example: 'borrower_interest_collection:inbound'
  */
-export type ProviderCapabilityKey = `${TransferType}:${TransferDirection}`;
+export type ProviderCapabilityKey =
+	| `${InboundTransferType}:inbound`
+	| `${OutboundTransferType}:outbound`;
 
 export const ALL_TRANSFER_TYPES = [
 	...INBOUND_TRANSFER_TYPES,


### PR DESCRIPTION
This introduces a `ProviderCapabilityKey` type that combines `TransferType` and `TransferDirection` into a composite string union for the Provider Capability Registry (ENG-215).

## Enhancements:
- Add `ProviderCapabilityKey` template literal type that creates composite keys in the format `${TransferType}:${TransferDirection}` for mapping transfer type and direction pairs to enabled providers

## Summary by Sourcery

Enhancements:
- Add ProviderCapabilityKey template literal type to represent `${TransferType}:${TransferDirection}` composite keys for provider capability lookup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal type constraints for payment provider capabilities to improve system reliability and prevent invalid configurations.

---

**Note:** This change is internal and has no visible impact on user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->