### PR TITLE
fixes to viewEngine tests

### DIFF
--- a/convex/crm/__tests__/viewEngine.test.ts
+++ b/convex/crm/__tests__/viewEngine.test.ts
@@ -640,7 +640,7 @@ describe("View Engine", () => {
 			expect(rows[0].fields.company_name).toBe("Small Deal");
 		});
 
-		it("gte/lte filter: inclusive numeric range", async () => {
+		it("gte filter: inclusive numeric range", async () => {
 			const fixture = await seedLeadFixture(t);
 
 			await seedRecord(t, fixture.objectDefId, {
@@ -881,13 +881,13 @@ describe("View Engine", () => {
 			);
 			expect(movedRecord?.fields.status).toBe("contacted");
 
-			// Audit: verify crm.record.updated event was emitted
+			// Audit: verify crm.record.fieldUpdated event was emitted
 			const auditEntries = await t.query(
 				components.auditLog.lib.queryByResource,
 				{ resourceType: "records", resourceId: recordId }
 			);
 			const updateEntry = auditEntries.find(
-				(e: { action: string }) => e.action === "crm.record.updated"
+				(e: { action: string }) => e.action === "crm.record.fieldUpdated"
 			);
 			expect(updateEntry).toBeDefined();
 		});

--- a/convex/crm/__tests__/walkthrough.test.ts
+++ b/convex/crm/__tests__/walkthrough.test.ts
@@ -210,14 +210,14 @@ describe("EAV-CRM Walk-Through", () => {
 		} catch (error) {
 			// Only treat explicit "search not supported" errors as a reason to skip.
 			if (error instanceof Error && SEARCH_UNSUPPORTED_RE.test(error.message)) {
-				// convex-test may not support search indexes — skip gracefully
+				// convex-test may not support search indexes — warn and continue
 				console.warn(
 					"Search index not supported in convex-test — skipping search assertion"
 				);
-				return;
+			} else {
+				// Unexpected error — surface it instead of silently skipping.
+				throw error;
 			}
-			// Unexpected error — surface it instead of silently skipping.
-			throw error;
 		}
 
 		// 10. Performance check (generous margins for convex-test in-process)


### PR DESCRIPTION
## Summary by Sourcery

Tighten test behavior around search and view engine auditing to better reflect expected runtime behavior and events.

Bug Fixes:
- Ensure walkthrough tests only skip search assertions when search is explicitly unsupported and rethrow unexpected errors.
- Align view engine audit log expectations with the correct crm.record.fieldUpdated event name.

Enhancements:
- Clarify the intent of the inclusive numeric range filter test by renaming it to focus on the gte behavior.