### PR TITLE
eng-274 feat(crm): add personal saved views

### DIFF
--- a/convex/crm/__tests__/records.test.ts
+++ b/convex/crm/__tests__/records.test.ts
@@ -630,6 +630,49 @@ describe("Record CRUD", () => {
 			);
 			expect(afterResult.records).toHaveLength(0);
 		});
+
+		it("queryRecords respects logicalOperator OR filters", async () => {
+			const fixture = await seedObjectWithFields(t, {
+				name: "or_filter_obj",
+				fields: [{ name: "title", fieldType: "text" }],
+			});
+
+			await seedRecord(t, fixture.objectDefId, {
+				title: "Acme",
+			});
+			await seedRecord(t, fixture.objectDefId, {
+				title: "Beta",
+			});
+			await seedRecord(t, fixture.objectDefId, {
+				title: "Charlie",
+			});
+
+			const result = await asAdmin(t).query(
+				api.crm.recordQueries.queryRecords,
+				{
+					objectDefId: fixture.objectDefId,
+					filters: [
+						{
+							fieldDefId: fixture.fieldDefs.title,
+							operator: "contains",
+							value: "Acme",
+						},
+						{
+							fieldDefId: fixture.fieldDefs.title,
+							logicalOperator: "or",
+							operator: "contains",
+							value: "Beta",
+						},
+					],
+					paginationOpts: { numItems: 25, cursor: null },
+				}
+			);
+
+			expect(result.records).toHaveLength(2);
+			expect(
+				result.records.map((record) => record.fields.title).sort()
+			).toEqual(["Acme", "Beta"]);
+		});
 	});
 });
 

--- a/convex/crm/__tests__/userSavedViews.test.ts
+++ b/convex/crm/__tests__/userSavedViews.test.ts
@@ -257,6 +257,96 @@ describe("CRM user saved views", () => {
 	expect(schema.effectiveView.filters[0]?.value).toBe("new");
 	});
 
+	it("does not apply a default saved view to a different requested system view", async () => {
+		const fixture = await seedLeadFixture(t);
+
+		await seedRecord(t, fixture.objectDefId, {
+			company_name: "Acme",
+			status: "new",
+		});
+		await seedRecord(t, fixture.objectDefId, {
+			company_name: "Beta",
+			status: "contacted",
+		});
+
+		await asAdmin(t).mutation(CREATE_USER_SAVED_VIEW, {
+			name: "Default New Leads",
+			objectDefId: fixture.objectDefId,
+			sourceViewDefId: fixture.defaultViewId,
+			viewType: "table",
+			isDefault: true,
+			filters: [
+				{
+					fieldDefId: fixture.fieldDefs.status,
+					operator: "is",
+					value: "new",
+				},
+			],
+		});
+
+		const alternateTableViewId = await asAdmin(t).mutation(
+			api.crm.viewDefs.createView,
+			{
+				objectDefId: fixture.objectDefId,
+				name: "All Leads Table",
+				viewType: "table",
+			}
+		);
+
+		const result = (await asAdmin(t).query(
+			api.crm.viewQueries.queryViewRecords,
+			{
+				viewDefId: alternateTableViewId,
+				limit: 25,
+			}
+		)) as TableQueryResult;
+
+		expect(result.totalCount).toBe(2);
+
+		const schema = (await asAdmin(t).query(api.crm.viewQueries.getViewSchema, {
+			viewDefId: alternateTableViewId,
+		})) as ViewSchemaResult;
+		expect(schema.savedView).toBeNull();
+		expect(schema.view.activeSavedViewId).toBeUndefined();
+		expect(schema.view.name).toBe("All Leads Table");
+	});
+
+	it("rejects applying a saved view to a different requested system view", async () => {
+		const fixture = await seedLeadFixture(t);
+
+		const savedViewId = await asAdmin(t).mutation(CREATE_USER_SAVED_VIEW, {
+			name: "Default New Leads",
+			objectDefId: fixture.objectDefId,
+			sourceViewDefId: fixture.defaultViewId,
+			viewType: "table",
+			filters: [
+				{
+					fieldDefId: fixture.fieldDefs.status,
+					operator: "is",
+					value: "new",
+				},
+			],
+		});
+
+		const alternateTableViewId = await asAdmin(t).mutation(
+			api.crm.viewDefs.createView,
+			{
+				objectDefId: fixture.objectDefId,
+				name: "All Leads Table",
+				viewType: "table",
+			}
+		);
+
+		await expect(
+			asAdmin(t).query(api.crm.viewQueries.queryViewRecords, {
+				viewDefId: alternateTableViewId,
+				userSavedViewId: savedViewId,
+			})
+		).rejects.toThrow(
+			"Saved view does not belong to the requested system view"
+		);
+	});
+
 	it("applies personal kanban overlays when an explicit saved view is requested", async () => {
 		const fixture = await seedLeadFixture(t);
 

--- a/convex/crm/__tests__/userSavedViews.test.ts
+++ b/convex/crm/__tests__/userSavedViews.test.ts
@@ -1,0 +1,377 @@
+import { makeFunctionReference } from "convex/server";
+import { beforeEach, describe, expect, it } from "vitest";
+import { api } from "../../_generated/api";
+import type { Id } from "../../_generated/dataModel";
+import type {
+	RecordFilter,
+	SavedViewFilterDefinition,
+	UserSavedViewDefinition,
+	ViewLayout,
+} from "../types";
+import {
+	asAdmin,
+	asUser,
+	type CrmTestFixture,
+	type CrmTestHarness,
+	createCrmTestHarness,
+	seedObjectWithFields,
+	seedRecord,
+} from "./helpers";
+
+interface CreateUserSavedViewArgs {
+	fieldOrder?: Id<"fieldDefs">[];
+	filters?: SavedViewFilterDefinition[];
+	groupByFieldId?: Id<"fieldDefs">;
+	isDefault?: boolean;
+	name: string;
+	objectDefId: Id<"objectDefs">;
+	sourceViewDefId?: Id<"viewDefs">;
+	viewType: ViewLayout;
+	visibleFieldIds?: Id<"fieldDefs">[];
+}
+
+interface TableQueryResult {
+	columns: Array<{ displayOrder: number; isVisible: boolean; name: string }>;
+	rows: Array<{ fields: Record<string, unknown> }>;
+	totalCount: number;
+}
+
+interface KanbanQueryResult {
+	groups: Array<{ count: number; label: string }>;
+	totalCount: number;
+}
+
+interface CalendarQueryResult {
+	events: Array<{ records: Array<{ fields: Record<string, unknown> }> }>;
+}
+
+interface ViewSchemaResult {
+	columns: Array<{ displayOrder: number; isVisible: boolean; name: string }>;
+	savedView: UserSavedViewDefinition | null;
+	systemView: { name: string };
+	view: {
+		activeSavedViewId?: Id<"userSavedViews">;
+		filters: RecordFilter[];
+		name: string;
+	};
+}
+
+const CREATE_USER_SAVED_VIEW = makeFunctionReference<
+	"mutation",
+	CreateUserSavedViewArgs,
+	Id<"userSavedViews">
+>("crm/userSavedViews:createUserSavedView");
+
+const GET_DEFAULT_USER_SAVED_VIEW = makeFunctionReference<
+	"query",
+	{ objectDefId: Id<"objectDefs"> },
+	UserSavedViewDefinition | null
+>("crm/userSavedViews:getDefaultUserSavedView");
+
+const LIST_USER_SAVED_VIEWS = makeFunctionReference<
+	"query",
+	{ objectDefId: Id<"objectDefs"> },
+	UserSavedViewDefinition[]
+>("crm/userSavedViews:listUserSavedViews");
+
+const SET_DEFAULT_USER_SAVED_VIEW = makeFunctionReference<
+	"mutation",
+	{ userSavedViewId: Id<"userSavedViews"> },
+	void
+>("crm/userSavedViews:setDefaultUserSavedView");
+
+async function seedLeadFixture(t: CrmTestHarness): Promise<CrmTestFixture> {
+	return seedObjectWithFields(t, {
+		name: "lead",
+		fields: [
+			{ name: "company_name", fieldType: "text", isRequired: true },
+			{
+				name: "status",
+				fieldType: "select",
+				options: [
+					{ value: "new", label: "New", color: "#3b82f6", order: 0 },
+					{
+						value: "contacted",
+						label: "Contacted",
+						color: "#eab308",
+						order: 1,
+					},
+					{
+						value: "qualified",
+						label: "Qualified",
+						color: "#22c55e",
+						order: 2,
+					},
+				],
+			},
+			{ name: "next_followup", fieldType: "date" },
+			{ name: "deal_value", fieldType: "currency" },
+			{ name: "is_active", fieldType: "boolean" },
+		],
+	});
+}
+
+describe("CRM user saved views", () => {
+	let t: CrmTestHarness;
+
+	beforeEach(() => {
+		t = createCrmTestHarness();
+	});
+
+	it("enforces one default saved view per owner and scopes access per user", async () => {
+		const fixture = await seedLeadFixture(t);
+
+		const adminDefaultA = await asAdmin(t).mutation(CREATE_USER_SAVED_VIEW, {
+			name: "Admin Compact",
+			objectDefId: fixture.objectDefId,
+			sourceViewDefId: fixture.defaultViewId,
+			viewType: "table",
+			isDefault: true,
+		});
+		const adminDefaultB = await asAdmin(t).mutation(CREATE_USER_SAVED_VIEW, {
+			name: "Admin Pipeline",
+			objectDefId: fixture.objectDefId,
+			sourceViewDefId: fixture.defaultViewId,
+			viewType: "table",
+			isDefault: true,
+		});
+		const userDefault = await asUser(t).mutation(CREATE_USER_SAVED_VIEW, {
+			name: "User Default",
+			objectDefId: fixture.objectDefId,
+			sourceViewDefId: fixture.defaultViewId,
+			viewType: "table",
+			isDefault: true,
+		});
+
+		const adminViews = await asAdmin(t).query(LIST_USER_SAVED_VIEWS, {
+			objectDefId: fixture.objectDefId,
+		});
+		expect(adminViews).toHaveLength(2);
+		expect(adminViews[0].userSavedViewId).toBe(adminDefaultB);
+		expect(adminViews[0].isDefault).toBe(true);
+		expect(
+			adminViews.find((view) => view.userSavedViewId === adminDefaultA)
+				?.isDefault
+		).toBe(false);
+
+		const adminDefault = await asAdmin(t).query(GET_DEFAULT_USER_SAVED_VIEW, {
+			objectDefId: fixture.objectDefId,
+		});
+		expect(adminDefault?.userSavedViewId).toBe(adminDefaultB);
+
+		const memberViews = await asUser(t).query(LIST_USER_SAVED_VIEWS, {
+			objectDefId: fixture.objectDefId,
+		});
+		expect(memberViews).toHaveLength(1);
+		expect(memberViews[0].userSavedViewId).toBe(userDefault);
+
+		const memberDefault = await asUser(t).query(GET_DEFAULT_USER_SAVED_VIEW, {
+			objectDefId: fixture.objectDefId,
+		});
+		expect(memberDefault?.userSavedViewId).toBe(userDefault);
+
+		await expect(
+			asUser(t).mutation(SET_DEFAULT_USER_SAVED_VIEW, {
+				userSavedViewId: adminDefaultB,
+			})
+		).rejects.toThrow("Saved view not found or access denied");
+
+		await expect(
+			asUser(t).query(api.crm.viewQueries.queryViewRecords, {
+				viewDefId: fixture.defaultViewId,
+				userSavedViewId: adminDefaultB,
+			})
+		).rejects.toThrow("Saved view not found or access denied");
+	});
+
+	it("applies the default personal table view to records and schema", async () => {
+		const fixture = await seedLeadFixture(t);
+
+		await seedRecord(t, fixture.objectDefId, {
+			company_name: "Acme",
+			status: "new",
+			deal_value: 100_000,
+		});
+		await seedRecord(t, fixture.objectDefId, {
+			company_name: "Beta",
+			status: "contacted",
+			deal_value: 250_000,
+		});
+		await seedRecord(t, fixture.objectDefId, {
+			company_name: "Gamma",
+			status: "new",
+			deal_value: 300_000,
+		});
+
+		const userSavedViewId = await asAdmin(t).mutation(CREATE_USER_SAVED_VIEW, {
+			name: "My Active Leads",
+			objectDefId: fixture.objectDefId,
+			sourceViewDefId: fixture.defaultViewId,
+			viewType: "table",
+			isDefault: true,
+			visibleFieldIds: [
+				fixture.fieldDefs.status,
+				fixture.fieldDefs.company_name,
+			],
+			fieldOrder: [fixture.fieldDefs.status, fixture.fieldDefs.company_name],
+			filters: [
+				{
+					fieldDefId: fixture.fieldDefs.status,
+					operator: "is",
+					value: "new",
+				},
+			],
+		});
+
+		const result = (await asAdmin(t).query(
+			api.crm.viewQueries.queryViewRecords,
+			{
+				viewDefId: fixture.defaultViewId,
+				limit: 25,
+			}
+		)) as TableQueryResult;
+
+		expect(result.totalCount).toBe(2);
+		expect(
+			result.columns
+				.filter((column) => column.isVisible)
+				.map((column) => column.name)
+		).toEqual(["status", "company_name"]);
+		for (const row of result.rows) {
+			expect(Object.keys(row.fields).sort()).toEqual(
+				["company_name", "status"].sort()
+			);
+			expect(row.fields.status).toBe("new");
+		}
+
+		const schema = (await asAdmin(t).query(api.crm.viewQueries.getViewSchema, {
+			viewDefId: fixture.defaultViewId,
+		})) as ViewSchemaResult;
+
+	expect(schema.savedView?.userSavedViewId).toBe(userSavedViewId);
+	expect(schema.systemView.name).not.toBe(schema.effectiveView.name);
+	expect(schema.view.name).toBe(schema.systemView.name);
+	expect(schema.effectiveView.name).toBe("My Active Leads");
+	expect(schema.effectiveView.activeSavedViewId).toBe(userSavedViewId);
+	expect(schema.effectiveView.filters[0]?.operator).toBe("is");
+	expect(schema.effectiveView.filters[0]?.value).toBe("new");
+	});
+
+	it("applies personal kanban overlays when an explicit saved view is requested", async () => {
+		const fixture = await seedLeadFixture(t);
+
+		await seedRecord(t, fixture.objectDefId, {
+			company_name: "Acme North",
+			status: "new",
+		});
+		await seedRecord(t, fixture.objectDefId, {
+			company_name: "Beta South",
+			status: "contacted",
+		});
+		await seedRecord(t, fixture.objectDefId, {
+			company_name: "Acme West",
+			status: "new",
+		});
+
+		const kanbanViewId = await asAdmin(t).mutation(
+			api.crm.viewDefs.createView,
+			{
+				objectDefId: fixture.objectDefId,
+				name: "Pipeline",
+				viewType: "kanban",
+				boundFieldId: fixture.fieldDefs.status,
+			}
+		);
+
+		const userSavedViewId = await asAdmin(t).mutation(CREATE_USER_SAVED_VIEW, {
+			name: "New Leads Only",
+			objectDefId: fixture.objectDefId,
+			sourceViewDefId: kanbanViewId,
+			viewType: "kanban",
+			filters: [
+				{
+					fieldDefId: fixture.fieldDefs.status,
+					operator: "is",
+					value: "new",
+				},
+			],
+		});
+
+		const result = (await asAdmin(t).query(
+			api.crm.viewQueries.queryViewRecords,
+			{
+				viewDefId: kanbanViewId,
+				userSavedViewId,
+			}
+		)) as KanbanQueryResult;
+
+		expect(result.totalCount).toBe(2);
+		expect(result.groups.find((group) => group.label === "New")?.count).toBe(2);
+		expect(
+			result.groups.find((group) => group.label === "Contacted")?.count
+		).toBe(0);
+	});
+
+	it("applies personal calendar overlays when an explicit saved view is requested", async () => {
+		const fixture = await seedLeadFixture(t);
+
+		const jan15 = new Date("2026-01-15T00:00:00Z").getTime();
+		const feb10 = new Date("2026-02-10T00:00:00Z").getTime();
+		const mar20 = new Date("2026-03-20T00:00:00Z").getTime();
+		const marchStart = new Date("2026-03-01T00:00:00Z").getTime();
+
+		await seedRecord(t, fixture.objectDefId, {
+			company_name: "Jan Corp",
+			next_followup: jan15,
+		});
+		await seedRecord(t, fixture.objectDefId, {
+			company_name: "Feb Corp",
+			next_followup: feb10,
+		});
+		await seedRecord(t, fixture.objectDefId, {
+			company_name: "Mar Corp",
+			next_followup: mar20,
+		});
+
+		const calendarViewId = await asAdmin(t).mutation(
+			api.crm.viewDefs.createView,
+			{
+				objectDefId: fixture.objectDefId,
+				name: "Follow-up Calendar",
+				viewType: "calendar",
+				boundFieldId: fixture.fieldDefs.next_followup,
+			}
+		);
+
+		const userSavedViewId = await asAdmin(t).mutation(CREATE_USER_SAVED_VIEW, {
+			name: "Q1 Before March",
+			objectDefId: fixture.objectDefId,
+			sourceViewDefId: calendarViewId,
+			viewType: "calendar",
+			filters: [
+				{
+					fieldDefId: fixture.fieldDefs.next_followup,
+					operator: "before",
+					value: String(marchStart),
+				},
+			],
+		});
+
+		const result = (await asAdmin(t).query(
+			api.crm.calendarQuery.queryCalendarRecords,
+			{
+				viewDefId: calendarViewId,
+				userSavedViewId,
+				rangeStart: new Date("2026-01-01T00:00:00Z").getTime(),
+				rangeEnd: new Date("2026-12-31T23:59:59Z").getTime(),
+			}
+		)) as CalendarQueryResult;
+
+		const companyNames = result.events.flatMap((event) =>
+			event.records.map((record) => record.fields.company_name)
+		);
+		expect(companyNames).toContain("Jan Corp");
+		expect(companyNames).toContain("Feb Corp");
+		expect(companyNames).not.toContain("Mar Corp");
+	});
+});

--- a/convex/crm/__tests__/userSavedViews.test.ts
+++ b/convex/crm/__tests__/userSavedViews.test.ts
@@ -47,11 +47,14 @@ interface CalendarQueryResult {
 
 interface ViewSchemaResult {
 	columns: Array<{ displayOrder: number; isVisible: boolean; name: string }>;
+	effectiveView: {
+		activeSavedViewId?: Id<"userSavedViews">;
+		filters: RecordFilter[];
+		name: string;
+	};
 	savedView: UserSavedViewDefinition | null;
 	systemView: { name: string };
 	view: {
-		activeSavedViewId?: Id<"userSavedViews">;
-		filters: RecordFilter[];
 		name: string;
 	};
 }
@@ -248,13 +251,13 @@ describe("CRM user saved views", () => {
 			viewDefId: fixture.defaultViewId,
 		})) as ViewSchemaResult;
 
-	expect(schema.savedView?.userSavedViewId).toBe(userSavedViewId);
-	expect(schema.systemView.name).not.toBe(schema.effectiveView.name);
-	expect(schema.view.name).toBe(schema.systemView.name);
-	expect(schema.effectiveView.name).toBe("My Active Leads");
-	expect(schema.effectiveView.activeSavedViewId).toBe(userSavedViewId);
-	expect(schema.effectiveView.filters[0]?.operator).toBe("is");
-	expect(schema.effectiveView.filters[0]?.value).toBe("new");
+		expect(schema.savedView?.userSavedViewId).toBe(userSavedViewId);
+		expect(schema.systemView.name).not.toBe(schema.effectiveView.name);
+		expect(schema.view.name).toBe(schema.systemView.name);
+		expect(schema.effectiveView.name).toBe("My Active Leads");
+		expect(schema.effectiveView.activeSavedViewId).toBe(userSavedViewId);
+		expect(schema.effectiveView.filters[0]?.operator).toBe("is");
+		expect(schema.effectiveView.filters[0]?.value).toBe("new");
 	});
 
 	it("does not apply a default saved view to a different requested system view", async () => {
@@ -307,7 +310,7 @@ describe("CRM user saved views", () => {
 			viewDefId: alternateTableViewId,
 		})) as ViewSchemaResult;
 		expect(schema.savedView).toBeNull();
-		expect(schema.view.activeSavedViewId).toBeUndefined();
+		expect(schema.effectiveView.activeSavedViewId).toBeUndefined();
 		expect(schema.view.name).toBe("All Leads Table");
 	});
 
@@ -402,6 +405,70 @@ describe("CRM user saved views", () => {
 		).toBe(0);
 	});
 
+	it("applies logical OR filters for personal kanban overlays", async () => {
+		const fixture = await seedLeadFixture(t);
+
+		await seedRecord(t, fixture.objectDefId, {
+			company_name: "Acme North",
+			status: "new",
+		});
+		await seedRecord(t, fixture.objectDefId, {
+			company_name: "Beta South",
+			status: "contacted",
+		});
+		await seedRecord(t, fixture.objectDefId, {
+			company_name: "Gamma West",
+			status: "qualified",
+		});
+
+		const kanbanViewId = await asAdmin(t).mutation(
+			api.crm.viewDefs.createView,
+			{
+				objectDefId: fixture.objectDefId,
+				name: "Pipeline",
+				viewType: "kanban",
+				boundFieldId: fixture.fieldDefs.status,
+			}
+		);
+
+		const userSavedViewId = await asAdmin(t).mutation(CREATE_USER_SAVED_VIEW, {
+			name: "New Or Qualified",
+			objectDefId: fixture.objectDefId,
+			sourceViewDefId: kanbanViewId,
+			viewType: "kanban",
+			filters: [
+				{
+					fieldDefId: fixture.fieldDefs.status,
+					operator: "is",
+					value: "new",
+				},
+				{
+					fieldDefId: fixture.fieldDefs.status,
+					logicalOperator: "or",
+					operator: "is",
+					value: "qualified",
+				},
+			],
+		});
+
+		const result = (await asAdmin(t).query(
+			api.crm.viewQueries.queryViewRecords,
+			{
+				viewDefId: kanbanViewId,
+				userSavedViewId,
+			}
+		)) as KanbanQueryResult;
+
+		expect(result.totalCount).toBe(2);
+		expect(result.groups.find((group) => group.label === "New")?.count).toBe(1);
+		expect(
+			result.groups.find((group) => group.label === "Qualified")?.count
+		).toBe(1);
+		expect(
+			result.groups.find((group) => group.label === "Contacted")?.count
+		).toBe(0);
+	});
+
 	it("applies personal calendar overlays when an explicit saved view is requested", async () => {
 		const fixture = await seedLeadFixture(t);
 
@@ -463,5 +530,126 @@ describe("CRM user saved views", () => {
 		expect(companyNames).toContain("Jan Corp");
 		expect(companyNames).toContain("Feb Corp");
 		expect(companyNames).not.toContain("Mar Corp");
+	});
+
+	it("parses legacy raw string is_any_of filters for personal calendar overlays", async () => {
+		const fixture = await seedLeadFixture(t);
+
+		const jan15 = new Date("2026-01-15T00:00:00Z").getTime();
+		const feb10 = new Date("2026-02-10T00:00:00Z").getTime();
+
+		await seedRecord(t, fixture.objectDefId, {
+			company_name: "Jan Corp",
+			next_followup: jan15,
+			status: "new",
+		});
+		await seedRecord(t, fixture.objectDefId, {
+			company_name: "Feb Corp",
+			next_followup: feb10,
+			status: "contacted",
+		});
+
+		const calendarViewId = await asAdmin(t).mutation(
+			api.crm.viewDefs.createView,
+			{
+				objectDefId: fixture.objectDefId,
+				name: "Follow-up Calendar",
+				viewType: "calendar",
+				boundFieldId: fixture.fieldDefs.next_followup,
+			}
+		);
+
+		const userSavedViewId = await asAdmin(t).mutation(CREATE_USER_SAVED_VIEW, {
+			name: "New Only",
+			objectDefId: fixture.objectDefId,
+			sourceViewDefId: calendarViewId,
+			viewType: "calendar",
+			filters: [
+				{
+					fieldDefId: fixture.fieldDefs.status,
+					operator: "is_any_of",
+					value: "new",
+				},
+			],
+		});
+
+		const result = (await asAdmin(t).query(
+			api.crm.calendarQuery.queryCalendarRecords,
+			{
+				viewDefId: calendarViewId,
+				userSavedViewId,
+				rangeStart: new Date("2026-01-01T00:00:00Z").getTime(),
+				rangeEnd: new Date("2026-12-31T23:59:59Z").getTime(),
+			}
+		)) as CalendarQueryResult;
+
+		const companyNames = result.events.flatMap((event) =>
+			event.records.map((record) => record.fields.company_name)
+		);
+		expect(companyNames).toEqual(["Jan Corp"]);
+	});
+
+	it("reads legacy filtersJson saved views when resolving defaults", async () => {
+		const fixture = await seedLeadFixture(t);
+
+		await seedRecord(t, fixture.objectDefId, {
+			company_name: "Acme",
+			status: "new",
+		});
+		await seedRecord(t, fixture.objectDefId, {
+			company_name: "Beta",
+			status: "contacted",
+		});
+
+		await t.run(async (ctx) => {
+			const legacySavedView = {
+				orgId: "org_crm_test_001",
+				objectDefId: fixture.objectDefId,
+				ownerAuthId: "test-crm-admin",
+				sourceViewDefId: fixture.defaultViewId,
+				name: "Legacy New Leads",
+				viewType: "table" as const,
+				visibleFieldIds: [
+					fixture.fieldDefs.company_name,
+					fixture.fieldDefs.status,
+				],
+				fieldOrder: [fixture.fieldDefs.company_name, fixture.fieldDefs.status],
+				filtersJson: JSON.stringify([
+					{
+						fieldDefId: fixture.fieldDefs.status,
+						operator: "is",
+						value: "new",
+					},
+				]),
+				isDefault: true,
+				createdAt: Date.now(),
+				updatedAt: Date.now(),
+			};
+
+			await ctx.db.insert(
+				"userSavedViews",
+				legacySavedView as unknown as Parameters<typeof ctx.db.insert>[1]
+			);
+		});
+
+		const defaultSavedView = await asAdmin(t).query(
+			GET_DEFAULT_USER_SAVED_VIEW,
+			{
+				objectDefId: fixture.objectDefId,
+			}
+		);
+		expect(defaultSavedView?.filters[0]?.operator).toBe("is");
+		expect(defaultSavedView?.filters[0]?.value).toBe("new");
+
+		const result = (await asAdmin(t).query(
+			api.crm.viewQueries.queryViewRecords,
+			{
+				viewDefId: fixture.defaultViewId,
+				limit: 25,
+			}
+		)) as TableQueryResult;
+
+		expect(result.totalCount).toBe(1);
+		expect(result.rows[0]?.fields.status).toBe("new");
 	});
 });

--- a/convex/crm/__tests__/viewEngine.test.ts
+++ b/convex/crm/__tests__/viewEngine.test.ts
@@ -590,6 +590,66 @@ describe("View Engine", () => {
 			expect(result.events.length).toBe(2);
 			expect(result.events[0].rows[0].record.fields.company_name).toBeDefined();
 		});
+
+		it("parses legacy comma-delimited between filters for calendar views", async () => {
+			const fixture = await seedLeadFixture(t);
+
+			const jan15 = new Date("2026-01-15T00:00:00Z").getTime();
+			const feb10 = new Date("2026-02-10T00:00:00Z").getTime();
+			const mar20 = new Date("2026-03-20T00:00:00Z").getTime();
+			const rangeStart = new Date("2026-01-01T00:00:00Z").getTime();
+			const febEnd = new Date("2026-02-28T23:59:59Z").getTime();
+			const rangeEnd = new Date("2026-12-31T23:59:59Z").getTime();
+
+			await seedRecord(t, fixture.objectDefId, {
+				company_name: "Jan Corp",
+				next_followup: jan15,
+			});
+			await seedRecord(t, fixture.objectDefId, {
+				company_name: "Feb Corp",
+				next_followup: feb10,
+			});
+			await seedRecord(t, fixture.objectDefId, {
+				company_name: "Mar Corp",
+				next_followup: mar20,
+			});
+
+			const calendarViewId = await asAdmin(t).mutation(
+				api.crm.viewDefs.createView,
+				{
+					objectDefId: fixture.objectDefId,
+					name: "Follow-up Calendar",
+					viewType: "calendar",
+					boundFieldId: fixture.fieldDefs.next_followup,
+				}
+			);
+
+			await t.run(async (ctx) => {
+				await ctx.db.insert("viewFilters", {
+					viewDefId: calendarViewId,
+					fieldDefId: fixture.fieldDefs.next_followup,
+					operator: "between",
+					value: `${String(rangeStart)},${String(febEnd)}`,
+				});
+			});
+
+			const result = await asAdmin(t).query(
+				api.crm.calendarQuery.queryCalendarRecords,
+				{
+					viewDefId: calendarViewId,
+					rangeStart,
+					rangeEnd,
+				}
+			);
+
+			const companyNames = result.events.flatMap(
+				(event: { records: Array<{ fields: Record<string, unknown> }> }) =>
+					event.records.map((record) => record.fields.company_name)
+			);
+			expect(companyNames).toContain("Jan Corp");
+			expect(companyNames).toContain("Feb Corp");
+			expect(companyNames).not.toContain("Mar Corp");
+		});
 	});
 
 	// ── View filters ────────────────────────────────────────────────
@@ -996,7 +1056,6 @@ describe("View Engine", () => {
 					limit: 25,
 				}
 			);
-
 			const { rows, totalCount } = result as {
 				rows: Array<{ fields: Record<string, unknown> }>;
 				totalCount: number;
@@ -1006,26 +1065,50 @@ describe("View Engine", () => {
 			expect(rows[0]?.fields.status).toBe("new");
 		});
 
-		it("between filter throws a clear error for table views", async () => {
+		it("logicalOperator OR combines view filters left-to-right", async () => {
 			const fixture = await seedLeadFixture(t);
+
+			await seedRecord(t, fixture.objectDefId, {
+				company_name: "A",
+				status: "new",
+			});
+			await seedRecord(t, fixture.objectDefId, {
+				company_name: "B",
+				status: "contacted",
+			});
+			await seedRecord(t, fixture.objectDefId, {
+				company_name: "C",
+				status: "qualified",
+			});
 
 			await t.run(async (ctx) => {
 				await ctx.db.insert("viewFilters", {
 					viewDefId: fixture.defaultViewId,
-					fieldDefId: fixture.fieldDefs.deal_value,
-					operator: "between",
-					value: JSON.stringify([10_000, 50_000]),
+					fieldDefId: fixture.fieldDefs.status,
+					operator: "is",
+					value: "new",
 				});
+				await ctx.db.insert("viewFilters", {
+					viewDefId: fixture.defaultViewId,
+					fieldDefId: fixture.fieldDefs.status,
+					logicalOperator: "or",
+					operator: "is",
+					value: "qualified",
+				})
 			});
 
-			await expect(
-				asAdmin(t).query(api.crm.viewQueries.queryViewRecords, {
-					viewDefId: fixture.defaultViewId,
-					limit: 25,
-				})
-			).rejects.toThrow(
-				'Operator "between" is not supported by table or kanban view filtering yet'
+			const result = await asAdmin(t).query(
+				api.crm.viewQueries.queryViewRecords,
+				{ viewDefId: fixture.defaultViewId, limit: 25 }
 			);
+			const { rows, totalCount } = result as {
+				rows: Array<{ fields: Record<string, unknown> }>;
+				totalCount: number;
+			};
+			expect(totalCount).toBe(2);
+			for (const row of rows) {
+				expect(["new", "qualified"]).toContain(row.fields.status);
+			}
 		});
 	});
 
@@ -1134,6 +1217,26 @@ describe("View Engine", () => {
 			expect(schema.adapterContract.fieldOverrides).toEqual([]);
 			expect(schema.adapterContract.computedFields).toEqual([]);
 			expect(schema.view.disabledLayoutMessages).toBeUndefined();
+		});
+
+		it("derives disabled layout messages when no persisted messages exist", async () => {
+			const fixture = await seedObjectWithFields(t, {
+				name: "notes_only",
+				fields: [{ name: "title", fieldType: "text" }],
+			});
+
+			const schema = await asAdmin(t).query(api.crm.viewQueries.getViewSchema, {
+				viewDefId: fixture.defaultViewId,
+			});
+
+			expect(schema.systemView.disabledLayoutMessages).toMatchObject({
+				calendar: "Add a date or datetime field to unlock calendar layouts.",
+				kanban: "Add a select or multi-select field to unlock kanban layouts.",
+			});
+			expect(schema.view.disabledLayoutMessages).toMatchObject({
+				calendar: "Add a date or datetime field to unlock calendar layouts.",
+				kanban: "Add a select or multi-select field to unlock kanban layouts.",
+			});
 		});
 	});
 

--- a/convex/crm/__tests__/viewEngine.test.ts
+++ b/convex/crm/__tests__/viewEngine.test.ts
@@ -281,13 +281,13 @@ describe("View Engine", () => {
 						fixture.fieldDefs.deal_value,
 						fixture.fieldDefs.company_name,
 					],
-					filtersJson: JSON.stringify([
+					filters: [
 						{
 							fieldDefId: fixture.fieldDefs.status,
 							operator: "eq",
 							value: "qualified",
 						},
-					]),
+					],
 					groupByFieldId: undefined,
 					aggregatePresets: [
 						{

--- a/convex/crm/calendarQuery.ts
+++ b/convex/crm/calendarQuery.ts
@@ -8,6 +8,7 @@ import {
 	FILTERED_QUERY_CAP,
 	loadActiveFieldDefs,
 	matchesFilter,
+	normalizeFilterValue,
 } from "./recordQueries";
 import type {
 	EntityViewAdapterContract,
@@ -53,13 +54,7 @@ type Granularity = "day" | "week" | "month";
 type FieldDef = Doc<"fieldDefs">;
 type ViewFilter = RecordFilter;
 type CrmQueryCtx = QueryCtx & { viewer: Viewer };
-
-interface ParsedViewFilter {
-	fieldDefId: Id<"fieldDefs">;
-	logicalOperator?: ViewFilter["logicalOperator"];
-	operator: ViewFilter["operator"];
-	value: unknown;
-}
+type ParsedViewFilter = RecordFilter;
 
 // ── Date Truncation Helpers ──────────────────────────────────────────
 
@@ -100,121 +95,6 @@ function truncateDate(unixMs: number, granularity: Granularity): number {
 
 // ── View Filter Parsing + Evaluation ─────────────────────────────────
 
-function parseScalarFilterValue(
-	rawValue: unknown,
-	fieldDef: FieldDef
-): unknown {
-	if (rawValue === undefined || rawValue === null || rawValue === "") {
-		return undefined;
-	}
-
-	switch (fieldDef.fieldType) {
-		case "number":
-		case "currency":
-		case "percentage":
-		case "date":
-		case "datetime": {
-			if (typeof rawValue === "number") {
-				return Number.isFinite(rawValue) ? rawValue : undefined;
-			}
-			const n = Number.parseFloat(String(rawValue));
-			return Number.isFinite(n) ? n : undefined;
-		}
-		case "boolean":
-			return typeof rawValue === "boolean" ? rawValue : rawValue === "true";
-		default:
-			return rawValue;
-	}
-}
-
-function parseRangeBoundary(value: unknown, fieldDef: FieldDef): unknown {
-	return parseScalarFilterValue(String(value), fieldDef);
-}
-
-function parseBetweenFilterValue(
-	rawValue: unknown,
-	fieldDef: FieldDef
-): [unknown, unknown] | undefined {
-	if (Array.isArray(rawValue) && rawValue.length === 2) {
-		const start = parseRangeBoundary(rawValue[0], fieldDef);
-		const end = parseRangeBoundary(rawValue[1], fieldDef);
-		return start !== undefined && end !== undefined ? [start, end] : undefined;
-	}
-
-	if (typeof rawValue !== "string") {
-		return undefined;
-	}
-
-	try {
-		const parsed: unknown = JSON.parse(rawValue);
-		if (Array.isArray(parsed) && parsed.length === 2) {
-			const start = parseRangeBoundary(parsed[0], fieldDef);
-			const end = parseRangeBoundary(parsed[1], fieldDef);
-			return start !== undefined && end !== undefined
-				? [start, end]
-				: undefined;
-		}
-	} catch {
-		// Fall through to lenient legacy parsing below.
-	}
-
-	const [startRaw, endRaw, ...rest] = rawValue
-		.split(",")
-		.map((part) => part.trim());
-	if (!(startRaw && endRaw) || rest.length > 0) {
-		return undefined;
-	}
-	const start = parseScalarFilterValue(startRaw, fieldDef);
-	const end = parseScalarFilterValue(endRaw, fieldDef);
-	return start !== undefined && end !== undefined ? [start, end] : undefined;
-}
-
-function parseIsAnyOfFilterValue(rawValue: unknown): unknown[] {
-	if (Array.isArray(rawValue)) {
-		return rawValue;
-	}
-
-	if (typeof rawValue !== "string") {
-		return rawValue === undefined || rawValue === null ? [] : [rawValue];
-	}
-
-	try {
-		const parsed: unknown = JSON.parse(rawValue);
-		if (Array.isArray(parsed)) {
-			return parsed;
-		}
-	} catch {
-		// Fall back to a single-value array for leniency.
-	}
-	return [rawValue];
-}
-
-function parseFilterValue(
-	rawValue: unknown,
-	fieldDef: FieldDef,
-	operator: ViewFilter["operator"]
-): unknown {
-	if (operator === "is_true" || operator === "is_false") {
-		return undefined;
-	}
-
-	if (operator === "between") {
-		if (rawValue === undefined || rawValue === "") {
-			return undefined;
-		}
-		return parseBetweenFilterValue(rawValue, fieldDef);
-	}
-
-	if (operator === "is_any_of") {
-		if (rawValue === undefined || rawValue === "") {
-			return undefined;
-		}
-		return parseIsAnyOfFilterValue(rawValue);
-	}
-
-	return parseScalarFilterValue(rawValue, fieldDef);
-}
-
 function parseViewFilters(
 	viewFilters: ViewFilter[],
 	fieldDefsById: Map<string, FieldDef>
@@ -229,9 +109,13 @@ function parseViewFilters(
 			continue;
 		}
 
-		const value = parseFilterValue(vf.value, fieldDef, vf.operator);
+		const normalizedValue = normalizeFilterValue(
+			vf.value,
+			fieldDef,
+			vf.operator
+		);
 		if (
-			value === undefined &&
+			normalizedValue === undefined &&
 			vf.operator !== "is_true" &&
 			vf.operator !== "is_false"
 		) {
@@ -240,10 +124,8 @@ function parseViewFilters(
 		}
 
 		result.push({
-			fieldDefId: vf.fieldDefId,
-			logicalOperator: vf.logicalOperator,
-			operator: vf.operator,
-			value,
+			...vf,
+			value: normalizedValue,
 		});
 	}
 

--- a/convex/crm/calendarQuery.ts
+++ b/convex/crm/calendarQuery.ts
@@ -13,6 +13,7 @@ import type {
 	EntityViewAdapterContract,
 	EntityViewRow,
 	NormalizedFieldDefinition,
+	RecordFilter,
 	SystemViewDefinition,
 	UnifiedRecord,
 	ViewAggregateResult,
@@ -50,7 +51,7 @@ interface CalendarData {
 
 type Granularity = "day" | "week" | "month";
 type FieldDef = Doc<"fieldDefs">;
-type ViewFilter = Doc<"viewFilters">;
+type ViewFilter = RecordFilter;
 type CrmQueryCtx = QueryCtx & { viewer: Viewer };
 
 interface ParsedViewFilter {
@@ -100,10 +101,10 @@ function truncateDate(unixMs: number, granularity: Granularity): number {
 // ── View Filter Parsing + Evaluation ─────────────────────────────────
 
 function parseScalarFilterValue(
-	rawValue: string | undefined,
+	rawValue: unknown,
 	fieldDef: FieldDef
 ): unknown {
-	if (rawValue === undefined || rawValue === "") {
+	if (rawValue === undefined || rawValue === null || rawValue === "") {
 		return undefined;
 	}
 
@@ -113,11 +114,14 @@ function parseScalarFilterValue(
 		case "percentage":
 		case "date":
 		case "datetime": {
-			const n = Number.parseFloat(rawValue);
+			if (typeof rawValue === "number") {
+				return Number.isFinite(rawValue) ? rawValue : undefined;
+			}
+			const n = Number.parseFloat(String(rawValue));
 			return Number.isFinite(n) ? n : undefined;
 		}
 		case "boolean":
-			return rawValue === "true";
+			return typeof rawValue === "boolean" ? rawValue : rawValue === "true";
 		default:
 			return rawValue;
 	}
@@ -128,9 +132,19 @@ function parseRangeBoundary(value: unknown, fieldDef: FieldDef): unknown {
 }
 
 function parseBetweenFilterValue(
-	rawValue: string,
+	rawValue: unknown,
 	fieldDef: FieldDef
 ): [unknown, unknown] | undefined {
+	if (Array.isArray(rawValue) && rawValue.length === 2) {
+		const start = parseRangeBoundary(rawValue[0], fieldDef);
+		const end = parseRangeBoundary(rawValue[1], fieldDef);
+		return start !== undefined && end !== undefined ? [start, end] : undefined;
+	}
+
+	if (typeof rawValue !== "string") {
+		return undefined;
+	}
+
 	try {
 		const parsed: unknown = JSON.parse(rawValue);
 		if (Array.isArray(parsed) && parsed.length === 2) {
@@ -155,7 +169,15 @@ function parseBetweenFilterValue(
 	return start !== undefined && end !== undefined ? [start, end] : undefined;
 }
 
-function parseIsAnyOfFilterValue(rawValue: string): unknown[] {
+function parseIsAnyOfFilterValue(rawValue: unknown): unknown[] {
+	if (Array.isArray(rawValue)) {
+		return rawValue;
+	}
+
+	if (typeof rawValue !== "string") {
+		return rawValue === undefined || rawValue === null ? [] : [rawValue];
+	}
+
 	try {
 		const parsed: unknown = JSON.parse(rawValue);
 		if (Array.isArray(parsed)) {
@@ -168,7 +190,7 @@ function parseIsAnyOfFilterValue(rawValue: string): unknown[] {
 }
 
 function parseFilterValue(
-	rawValue: string | undefined,
+	rawValue: unknown,
 	fieldDef: FieldDef,
 	operator: ViewFilter["operator"]
 ): unknown {
@@ -342,9 +364,10 @@ interface ValidatedCalendarContext {
 async function validateCalendarView(
 	ctx: CrmQueryCtx,
 	viewDefId: Id<"viewDefs">,
+	userSavedViewId: Id<"userSavedViews"> | undefined,
 	orgId: string
 ): Promise<ValidatedCalendarContext> {
-	const viewState = await resolveViewState(ctx, viewDefId);
+	const viewState = await resolveViewState(ctx, viewDefId, userSavedViewId);
 	const { viewDef } = viewState;
 	if (!viewDef || viewDef.orgId !== orgId) {
 		throw new ConvexError("View not found or access denied");
@@ -437,6 +460,7 @@ export async function queryCalendarViewData(
 		granularity?: Granularity;
 		rangeEnd: number;
 		rangeStart: number;
+		userSavedViewId?: Id<"userSavedViews">;
 		viewDefId: Id<"viewDefs">;
 	}
 ): Promise<CalendarData> {
@@ -452,6 +476,7 @@ export async function queryCalendarViewData(
 	const { objectDefId, boundFieldId, viewState } = await validateCalendarView(
 		ctx,
 		args.viewDefId,
+		args.userSavedViewId,
 		orgId
 	);
 
@@ -493,14 +518,8 @@ export async function queryCalendarViewData(
 	);
 	const assembled = await assembleRecords(ctx, recordDocs, activeFieldDefs);
 
-	// Load view-level filters and apply as second pass
-	const viewFilterRows = await ctx.db
-		.query("viewFilters")
-		.withIndex("by_view", (q) => q.eq("viewDefId", args.viewDefId))
-		.collect();
-
 	const { filters: parsedFilters, skippedCount: skippedFilters } =
-		parseViewFilters(viewFilterRows, fieldDefsById);
+		parseViewFilters(viewState.view.filters, fieldDefsById);
 	const filtered = applyViewFilters(assembled, parsedFilters, fieldDefsById);
 
 	// Group records by truncated date and sort ascending
@@ -534,6 +553,7 @@ export async function queryCalendarViewData(
 export const queryCalendarRecords = crmQuery
 	.input({
 		viewDefId: v.id("viewDefs"),
+		userSavedViewId: v.optional(v.id("userSavedViews")),
 		rangeStart: v.number(),
 		rangeEnd: v.number(),
 		granularity: v.optional(

--- a/convex/crm/recordQueries.ts
+++ b/convex/crm/recordQueries.ts
@@ -178,15 +178,21 @@ export function matchesFilter(
 	filterValue: unknown
 ): boolean {
 	switch (operator) {
+		case "equals":
+		case "is":
 		case "eq":
 			return fieldValue === filterValue;
+		case "is_not":
+			return fieldValue !== filterValue;
 		case "gt":
+		case "after":
 			return (
 				typeof fieldValue === "number" &&
 				typeof filterValue === "number" &&
 				fieldValue > filterValue
 			);
 		case "lt":
+		case "before":
 			return (
 				typeof fieldValue === "number" &&
 				typeof filterValue === "number" &&
@@ -204,6 +210,22 @@ export function matchesFilter(
 				typeof filterValue === "number" &&
 				fieldValue <= filterValue
 			);
+		case "between": {
+			if (
+				typeof fieldValue !== "number" ||
+				!Array.isArray(filterValue) ||
+				filterValue.length !== 2
+			) {
+				return false;
+			}
+			const [start, end] = filterValue;
+			return (
+				typeof start === "number" &&
+				typeof end === "number" &&
+				fieldValue >= start &&
+				fieldValue <= end
+			);
+		}
 		case "contains":
 			return (
 				typeof fieldValue === "string" &&

--- a/convex/crm/recordQueries.ts
+++ b/convex/crm/recordQueries.ts
@@ -1,6 +1,6 @@
 import { ConvexError, v } from "convex/values";
 import type { Doc, Id } from "../_generated/dataModel";
-import type { QueryCtx } from "../_generated/server";
+import type { MutationCtx, QueryCtx } from "../_generated/server";
 import { crmQuery } from "../fluent";
 import {
 	getNativeRecordById,
@@ -14,10 +14,11 @@ import type {
 	RecordSort,
 	UnifiedRecord,
 } from "./types";
-import { entityKindValidator } from "./validators";
+import { entityKindValidator, logicalOperatorValidator } from "./validators";
 import { fieldTypeToTable, type ValueTableName } from "./valueRouter";
 
 type FieldDef = Doc<"fieldDefs">;
+type DbCtx = Pick<QueryCtx, "db"> | Pick<MutationCtx, "db">;
 const OFFSET_CURSOR_PATTERN = /^[0-9]+$/;
 
 interface QueryPaginationOpts {
@@ -258,9 +259,132 @@ export function matchesFilter(
 	}
 }
 
+function parseScalarFilterValue(
+	rawValue: unknown,
+	fieldDef: FieldDef
+): unknown {
+	if (rawValue === undefined || rawValue === null || rawValue === "") {
+		return undefined;
+	}
+
+	if (typeof rawValue !== "string") {
+		return rawValue;
+	}
+
+	switch (fieldDef.fieldType) {
+		case "number":
+		case "currency":
+		case "percentage":
+		case "date":
+		case "datetime": {
+			const parsedNumber = Number.parseFloat(rawValue);
+			return Number.isFinite(parsedNumber) ? parsedNumber : undefined;
+		}
+		case "boolean":
+			return rawValue === "true";
+		default:
+			return rawValue;
+	}
+}
+
+function parseRangeBoundary(value: unknown, fieldDef: FieldDef): unknown {
+	return parseScalarFilterValue(value, fieldDef);
+}
+
+function parseBetweenFilterValue(
+	rawValue: unknown,
+	fieldDef: FieldDef
+): [unknown, unknown] | undefined {
+	if (Array.isArray(rawValue) && rawValue.length === 2) {
+		const [start, end] = rawValue;
+		const parsedStart = parseRangeBoundary(start, fieldDef);
+		const parsedEnd = parseRangeBoundary(end, fieldDef);
+		return parsedStart !== undefined && parsedEnd !== undefined
+			? [parsedStart, parsedEnd]
+			: undefined;
+	}
+
+	if (typeof rawValue === "string") {
+		try {
+			const parsed: unknown = JSON.parse(rawValue);
+			if (Array.isArray(parsed) && parsed.length === 2) {
+				const [start, end] = parsed;
+				const parsedStart = parseRangeBoundary(start, fieldDef);
+				const parsedEnd = parseRangeBoundary(end, fieldDef);
+				return parsedStart !== undefined && parsedEnd !== undefined
+					? [parsedStart, parsedEnd]
+					: undefined;
+			}
+		} catch {
+			// Fall through to legacy comma-delimited parsing.
+		}
+
+		const [startRaw, endRaw, ...rest] = rawValue
+			.split(",")
+			.map((part) => part.trim());
+		if (!(startRaw && endRaw) || rest.length > 0) {
+			return undefined;
+		}
+
+		const parsedStart = parseScalarFilterValue(startRaw, fieldDef);
+		const parsedEnd = parseScalarFilterValue(endRaw, fieldDef);
+		return parsedStart !== undefined && parsedEnd !== undefined
+			? [parsedStart, parsedEnd]
+			: undefined;
+	}
+
+	return undefined;
+}
+
+function parseIsAnyOfFilterValue(rawValue: unknown): unknown[] | undefined {
+	if (rawValue === undefined || rawValue === null || rawValue === "") {
+		return undefined;
+	}
+
+	if (Array.isArray(rawValue)) {
+		return rawValue;
+	}
+
+	if (typeof rawValue === "string") {
+		try {
+			const parsed: unknown = JSON.parse(rawValue);
+			if (Array.isArray(parsed)) {
+				return parsed;
+			}
+		} catch {
+			// Fall back to a single-value array for leniency.
+		}
+
+		return [rawValue];
+	}
+
+	return [rawValue];
+}
+
+export function normalizeFilterValue(
+	filterValue: unknown,
+	fieldDef: FieldDef,
+	operator: RecordFilter["operator"]
+): unknown {
+	if (operator === "is_true" || operator === "is_false") {
+		return undefined;
+	}
+
+	if (operator === "between") {
+		return parseBetweenFilterValue(filterValue, fieldDef);
+	}
+
+	if (operator === "is_any_of") {
+		return parseIsAnyOfFilterValue(filterValue);
+	}
+
+	return parseScalarFilterValue(filterValue, fieldDef);
+}
+
 /**
  * Applies field-level filters in-memory.
- * All filters are AND'd together (every filter must match).
+ * Filters are evaluated left-to-right and respect each filter's logicalOperator,
+ * defaulting to AND when omitted.
  */
 export function applyFilters(
 	records: UnifiedRecord[],
@@ -272,16 +396,48 @@ export function applyFilters(
 		return records;
 	}
 
-	return records.filter((record) =>
-		filters.every((filter) => {
+	return records.filter((record) => {
+		let combined: boolean | undefined;
+
+		for (const filter of filters) {
 			const fieldDef = fieldDefsById.get(filter.fieldDefId.toString());
 			if (!fieldDef) {
-				return false; // fail-closed: unknown fieldDefId never matches
+				return false;
 			}
+
+			const normalizedValue = normalizeFilterValue(
+				filter.value,
+				fieldDef,
+				filter.operator
+			);
+			if (
+				normalizedValue === undefined &&
+				filter.operator !== "is_true" &&
+				filter.operator !== "is_false"
+			) {
+				return false;
+			}
+
 			const fieldValue = record.fields[fieldDef.name];
-			return matchesFilter(fieldValue, filter.operator, filter.value);
-		})
-	);
+			const nextMatch = matchesFilter(
+				fieldValue,
+				filter.operator,
+				normalizedValue
+			);
+
+			if (combined === undefined) {
+				combined = nextMatch;
+				continue;
+			}
+
+			combined =
+				filter.logicalOperator === "or"
+					? combined || nextMatch
+					: combined && nextMatch;
+		}
+
+		return combined ?? true;
+	});
 }
 
 // ── Helpers: Sorting ─────────────────────────────────────────────────
@@ -328,7 +484,7 @@ export function applySort(
 // ── Helpers: Shared ──────────────────────────────────────────────────
 
 export async function loadActiveFieldDefs(
-	ctx: QueryCtx,
+	ctx: DbCtx,
 	objectDefId: Id<"objectDefs">
 ): Promise<FieldDef[]> {
 	const allFieldDefs = await ctx.db
@@ -593,6 +749,7 @@ export const queryRecords = crmQuery
 			v.array(
 				v.object({
 					fieldDefId: v.id("fieldDefs"),
+					logicalOperator: v.optional(logicalOperatorValidator),
 					operator: v.union(
 						v.literal("eq"),
 						v.literal("gt"),

--- a/convex/crm/types.ts
+++ b/convex/crm/types.ts
@@ -1,5 +1,4 @@
 import type { Doc, Id } from "../_generated/dataModel";
-import type { FilterOperator, LogicalOperator } from "./filterConstants";
 
 export type ViewLayout = "table" | "kanban" | "calendar";
 export type NormalizedFieldKind =
@@ -67,11 +66,11 @@ export interface AggregatePreset {
 	label?: string;
 }
 
-export interface ViewFilterDefinition {
+export interface SavedViewFilterDefinition {
 	fieldDefId: Id<"fieldDefs">;
-	logicalOperator?: LogicalOperator;
-	operator: FilterOperator;
-	value: unknown;
+	logicalOperator?: "and" | "or";
+	operator: RecordFilter["operator"];
+	value?: string;
 }
 
 export interface EntityViewComputedFieldContract {
@@ -117,17 +116,24 @@ export interface UnifiedRecord {
 /** A single field-level filter condition. */
 export interface RecordFilter {
 	fieldDefId: Id<"fieldDefs">;
+	logicalOperator?: "and" | "or";
 	operator:
+		| "after"
+		| "before"
+		| "between"
+		| "equals"
 		| "eq"
 		| "gt"
-		| "lt"
 		| "gte"
+		| "is"
+		| "is_any_of"
+		| "is_false"
+		| "is_not"
+		| "is_true"
+		| "lt"
 		| "lte"
 		| "contains"
-		| "starts_with"
-		| "is_any_of"
-		| "is_true"
-		| "is_false";
+		| "starts_with";
 	value: unknown;
 }
 
@@ -172,7 +178,7 @@ export interface SystemViewDefinition {
 		table?: string;
 	};
 	fieldOrder: Id<"fieldDefs">[];
-	filters: ViewFilterDefinition[];
+	filters: RecordFilter[];
 	groupByFieldId?: Id<"fieldDefs">;
 	isDefault: boolean;
 	layout: ViewLayout;
@@ -186,14 +192,31 @@ export interface SystemViewDefinition {
 export interface UserSavedViewDefinition {
 	aggregatePresets: AggregatePreset[];
 	fieldOrder: Id<"fieldDefs">[];
-	filters: ViewFilterDefinition[];
+	filters: SavedViewFilterDefinition[];
 	groupByFieldId?: Id<"fieldDefs">;
 	isDefault: boolean;
-	layout: ViewLayout;
 	name: string;
 	objectDefId: Id<"objectDefs">;
 	ownerAuthId: string;
 	sourceViewDefId?: Id<"viewDefs">;
+	userSavedViewId: Id<"userSavedViews">;
+	viewType: ViewLayout;
+	visibleFieldIds: Id<"fieldDefs">[];
+}
+
+export interface EffectiveViewDefinition {
+	activeSavedViewId?: Id<"userSavedViews">;
+	aggregatePresets: AggregatePreset[];
+	boundFieldId?: Id<"fieldDefs">;
+	disabledLayoutMessages?: SystemViewDefinition["disabledLayoutMessages"];
+	fieldOrder: Id<"fieldDefs">[];
+	filters: RecordFilter[];
+	groupByFieldId?: Id<"fieldDefs">;
+	isDefault: boolean;
+	name: string;
+	objectDefId: Id<"objectDefs">;
+	sourceViewDefId: Id<"viewDefs">;
+	viewType: ViewLayout;
 	visibleFieldIds: Id<"fieldDefs">[];
 }
 

--- a/convex/crm/userSavedViews.ts
+++ b/convex/crm/userSavedViews.ts
@@ -156,13 +156,13 @@ async function clearExistingDefaultSavedViews(
 ) {
 	const existingDefaults = await ctx.db
 		.query("userSavedViews")
-		.withIndex("by_owner_object_default", (query) =>
+		.withIndex("by_org_owner_object_default", (query) =>
 			query
+				.eq("orgId", args.orgId)
 				.eq("ownerAuthId", args.ownerAuthId)
 				.eq("objectDefId", args.objectDefId)
 				.eq("isDefault", true)
 		)
-		.filter((query) => query.eq(query.field("orgId"), args.orgId))
 		.collect();
 
 	for (const savedView of existingDefaults) {
@@ -195,12 +195,12 @@ export const listUserSavedViews = crmQuery
 
 		const rows = await ctx.db
 			.query("userSavedViews")
-			.withIndex("by_owner_object", (query) =>
+			.withIndex("by_org_owner_object", (query) =>
 				query
+					.eq("orgId", orgId)
 					.eq("ownerAuthId", ctx.viewer.authId)
 					.eq("objectDefId", args.objectDefId)
 			)
-			.filter((query) => query.eq(query.field("orgId"), orgId))
 			.collect();
 
 		return rows

--- a/convex/crm/userSavedViews.ts
+++ b/convex/crm/userSavedViews.ts
@@ -1,0 +1,489 @@
+import { ConvexError, v } from "convex/values";
+import type { Id } from "../_generated/dataModel";
+import type { MutationCtx } from "../_generated/server";
+import { auditLog } from "../auditLog";
+import { crmMutation, crmQuery } from "../fluent";
+import { isValidOperatorForFieldType } from "./filterOperatorValidation";
+import {
+	aggregatePresetValidator,
+	savedViewFilterValidator,
+	viewTypeValidator,
+} from "./validators";
+import {
+	buildUserSavedViewSnapshot,
+	findDefaultUserSavedView,
+	loadBaseViewState,
+	loadOwnedUserSavedView,
+	toUserSavedViewDefinition,
+} from "./viewState";
+
+const MAX_SAVED_VIEW_NAME_LENGTH = 100;
+
+function validateSavedViewName(name: string): string {
+	const trimmed = name.trim();
+	if (trimmed.length === 0) {
+		throw new ConvexError("Saved view name cannot be empty");
+	}
+	if (trimmed.length > MAX_SAVED_VIEW_NAME_LENGTH) {
+		throw new ConvexError(
+			`Saved view name must be ${MAX_SAVED_VIEW_NAME_LENGTH} characters or fewer`
+		);
+	}
+	return trimmed;
+}
+
+async function validateObjectAccess(
+	ctx: MutationCtx,
+	objectDefId: Id<"objectDefs">,
+	orgId: string
+) {
+	const objectDef = await ctx.db.get(objectDefId);
+	if (!objectDef || objectDef.orgId !== orgId) {
+		throw new ConvexError("Object not found or access denied");
+	}
+	return objectDef;
+}
+
+async function validateFieldOwnership(
+	ctx: MutationCtx,
+	args: {
+		fieldIds: Id<"fieldDefs">[];
+		objectDefId: Id<"objectDefs">;
+	}
+) {
+	if (args.fieldIds.length === 0) {
+		return;
+	}
+
+	const fieldDefs = await ctx.db
+		.query("fieldDefs")
+		.withIndex("by_object", (query) =>
+			query.eq("objectDefId", args.objectDefId)
+		)
+		.collect();
+	const fieldIds = new Set(
+		fieldDefs.map((fieldDef) => fieldDef._id.toString())
+	);
+
+	for (const fieldId of args.fieldIds) {
+		if (!fieldIds.has(fieldId.toString())) {
+			throw new ConvexError(
+				`Field ${fieldId} does not belong to this object definition`
+			);
+		}
+	}
+}
+
+async function validateSavedViewFilters(
+	ctx: MutationCtx,
+	args: {
+		filters: Array<{
+			fieldDefId: Id<"fieldDefs">;
+			operator: Parameters<typeof isValidOperatorForFieldType>[0];
+		}>;
+		objectDefId: Id<"objectDefs">;
+	}
+) {
+	if (args.filters.length === 0) {
+		return;
+	}
+
+	const fieldDefs = await ctx.db
+		.query("fieldDefs")
+		.withIndex("by_object", (query) =>
+			query.eq("objectDefId", args.objectDefId)
+		)
+		.collect();
+	const fieldDefsById = new Map(
+		fieldDefs.map((fieldDef) => [fieldDef._id.toString(), fieldDef])
+	);
+
+	for (const filter of args.filters) {
+		const fieldDef = fieldDefsById.get(filter.fieldDefId.toString());
+		if (!fieldDef) {
+			throw new ConvexError(
+				`Field ${filter.fieldDefId} does not belong to this object definition`
+			);
+		}
+
+		if (!isValidOperatorForFieldType(filter.operator, fieldDef.fieldType)) {
+			throw new ConvexError(
+				`Operator "${filter.operator}" is not valid for field type "${fieldDef.fieldType}"`
+			);
+		}
+	}
+}
+
+async function requireSourceView(
+	ctx: MutationCtx,
+	args: {
+		objectDefId: Id<"objectDefs">;
+		orgId: string;
+		sourceViewDefId?: Id<"viewDefs">;
+		viewType: "table" | "kanban" | "calendar";
+	}
+) {
+	if (!args.sourceViewDefId) {
+		throw new ConvexError("Personal saved views require a source system view");
+	}
+
+	const sourceView = await ctx.db.get(args.sourceViewDefId);
+	if (!sourceView || sourceView.orgId !== args.orgId) {
+		throw new ConvexError("Source view not found or access denied");
+	}
+	if (sourceView.objectDefId !== args.objectDefId) {
+		throw new ConvexError(
+			"Source view does not belong to this object definition"
+		);
+	}
+	if (sourceView.viewType !== args.viewType) {
+		throw new ConvexError(
+			"Personal saved view layout must match the source system view layout"
+		);
+	}
+
+	return sourceView;
+}
+
+async function clearExistingDefaultSavedViews(
+	ctx: MutationCtx,
+	args: {
+		excludeId?: Id<"userSavedViews">;
+		objectDefId: Id<"objectDefs">;
+		ownerAuthId: string;
+		orgId: string;
+	}
+) {
+	const existingDefaults = await ctx.db
+		.query("userSavedViews")
+		.withIndex("by_owner_object_default", (query) =>
+			query
+				.eq("ownerAuthId", args.ownerAuthId)
+				.eq("objectDefId", args.objectDefId)
+				.eq("isDefault", true)
+		)
+		.filter((query) => query.eq(query.field("orgId"), args.orgId))
+		.collect();
+
+	for (const savedView of existingDefaults) {
+		if (
+			args.excludeId &&
+			savedView._id.toString() === args.excludeId.toString()
+		) {
+			continue;
+		}
+
+		await ctx.db.patch(savedView._id, {
+			isDefault: false,
+			updatedAt: Date.now(),
+		});
+	}
+}
+
+export const listUserSavedViews = crmQuery
+	.input({ objectDefId: v.id("objectDefs") })
+	.handler(async (ctx, args) => {
+		const orgId = ctx.viewer.orgId;
+		if (!orgId) {
+			throw new ConvexError("Org context required for CRM operations");
+		}
+
+		const objectDef = await ctx.db.get(args.objectDefId);
+		if (!objectDef || objectDef.orgId !== orgId) {
+			throw new ConvexError("Object not found or access denied");
+		}
+
+		const rows = await ctx.db
+			.query("userSavedViews")
+			.withIndex("by_owner_object", (query) =>
+				query
+					.eq("ownerAuthId", ctx.viewer.authId)
+					.eq("objectDefId", args.objectDefId)
+			)
+			.filter((query) => query.eq(query.field("orgId"), orgId))
+			.collect();
+
+		return rows
+			.sort((left, right) => {
+				if (left.isDefault && !right.isDefault) {
+					return -1;
+				}
+				if (!left.isDefault && right.isDefault) {
+					return 1;
+				}
+				return right.updatedAt - left.updatedAt;
+			})
+			.map(toUserSavedViewDefinition);
+	})
+	.public();
+
+export const getDefaultUserSavedView = crmQuery
+	.input({ objectDefId: v.id("objectDefs") })
+	.handler(async (ctx, args) => {
+		const orgId = ctx.viewer.orgId;
+		if (!orgId) {
+			throw new ConvexError("Org context required for CRM operations");
+		}
+
+		const defaultView = await findDefaultUserSavedView(ctx, {
+			objectDefId: args.objectDefId,
+			ownerAuthId: ctx.viewer.authId,
+			orgId,
+		});
+
+		return defaultView ? toUserSavedViewDefinition(defaultView) : null;
+	})
+	.public();
+
+export const createUserSavedView = crmMutation
+	.input({
+		objectDefId: v.id("objectDefs"),
+		sourceViewDefId: v.optional(v.id("viewDefs")),
+		name: v.string(),
+		viewType: viewTypeValidator,
+		visibleFieldIds: v.optional(v.array(v.id("fieldDefs"))),
+		fieldOrder: v.optional(v.array(v.id("fieldDefs"))),
+		filters: v.optional(v.array(savedViewFilterValidator)),
+		groupByFieldId: v.optional(v.id("fieldDefs")),
+		aggregatePresets: v.optional(v.array(aggregatePresetValidator)),
+		isDefault: v.optional(v.boolean()),
+	})
+	.handler(async (ctx, args) => {
+		const orgId = ctx.viewer.orgId;
+		if (!orgId) {
+			throw new ConvexError("Org context required for CRM operations");
+		}
+
+		await validateObjectAccess(ctx, args.objectDefId, orgId);
+		await requireSourceView(ctx, {
+			objectDefId: args.objectDefId,
+			orgId,
+			sourceViewDefId: args.sourceViewDefId,
+			viewType: args.viewType,
+		});
+
+		const snapshot = await loadBaseViewState(
+			ctx,
+			args.sourceViewDefId as Id<"viewDefs">,
+			orgId
+		);
+		const baseSavedView = buildUserSavedViewSnapshot({
+			viewDef: snapshot.viewDef,
+			viewFields: snapshot.viewFields,
+			viewFilters: snapshot.viewFilters,
+		});
+
+		const visibleFieldIds =
+			args.visibleFieldIds ?? baseSavedView.visibleFieldIds;
+		const fieldOrder = args.fieldOrder ?? baseSavedView.fieldOrder;
+		await validateFieldOwnership(ctx, {
+			objectDefId: args.objectDefId,
+			fieldIds: [...visibleFieldIds, ...fieldOrder],
+		});
+		await validateSavedViewFilters(ctx, {
+			objectDefId: args.objectDefId,
+			filters: args.filters ?? baseSavedView.filters,
+		});
+
+		if (args.groupByFieldId) {
+			await validateFieldOwnership(ctx, {
+				objectDefId: args.objectDefId,
+				fieldIds: [args.groupByFieldId],
+			});
+		}
+
+		const isDefault = args.isDefault ?? false;
+		if (isDefault) {
+			await clearExistingDefaultSavedViews(ctx, {
+				objectDefId: args.objectDefId,
+				ownerAuthId: ctx.viewer.authId,
+				orgId,
+			});
+		}
+
+		const now = Date.now();
+		const userSavedViewId = await ctx.db.insert("userSavedViews", {
+			orgId,
+			objectDefId: args.objectDefId,
+			ownerAuthId: ctx.viewer.authId,
+			sourceViewDefId: args.sourceViewDefId,
+			name: validateSavedViewName(args.name),
+			viewType: args.viewType,
+			visibleFieldIds,
+			fieldOrder,
+			filters: args.filters ?? baseSavedView.filters,
+			groupByFieldId: args.groupByFieldId ?? baseSavedView.groupByFieldId,
+			aggregatePresets: args.aggregatePresets ?? baseSavedView.aggregatePresets,
+			isDefault,
+			createdAt: now,
+			updatedAt: now,
+		});
+
+		await auditLog.log(ctx, {
+			action: "crm.userSavedView.created",
+			actorId: ctx.viewer.authId,
+			resourceType: "userSavedViews",
+			resourceId: userSavedViewId,
+			severity: "info",
+			metadata: {
+				objectDefId: args.objectDefId,
+				sourceViewDefId: args.sourceViewDefId,
+				viewType: args.viewType,
+				orgId,
+				isDefault,
+			},
+		});
+
+		return userSavedViewId;
+	})
+	.public();
+
+export const updateUserSavedView = crmMutation
+	.input({
+		userSavedViewId: v.id("userSavedViews"),
+		name: v.optional(v.string()),
+		visibleFieldIds: v.optional(v.array(v.id("fieldDefs"))),
+		fieldOrder: v.optional(v.array(v.id("fieldDefs"))),
+		filters: v.optional(v.array(savedViewFilterValidator)),
+		groupByFieldId: v.optional(v.id("fieldDefs")),
+		aggregatePresets: v.optional(v.array(aggregatePresetValidator)),
+		isDefault: v.optional(v.boolean()),
+	})
+	.handler(async (ctx, args) => {
+		const orgId = ctx.viewer.orgId;
+		if (!orgId) {
+			throw new ConvexError("Org context required for CRM operations");
+		}
+
+		const before = await loadOwnedUserSavedView(ctx, {
+			userSavedViewId: args.userSavedViewId,
+			viewer: ctx.viewer,
+		});
+
+		await validateFieldOwnership(ctx, {
+			objectDefId: before.objectDefId,
+			fieldIds: [...(args.visibleFieldIds ?? []), ...(args.fieldOrder ?? [])],
+		});
+		await validateSavedViewFilters(ctx, {
+			objectDefId: before.objectDefId,
+			filters: args.filters ?? [],
+		});
+
+		if (args.groupByFieldId) {
+			await validateFieldOwnership(ctx, {
+				objectDefId: before.objectDefId,
+				fieldIds: [args.groupByFieldId],
+			});
+		}
+
+		if (args.isDefault === true) {
+			await clearExistingDefaultSavedViews(ctx, {
+				excludeId: args.userSavedViewId,
+				objectDefId: before.objectDefId,
+				ownerAuthId: ctx.viewer.authId,
+				orgId,
+			});
+		}
+
+		const patch: Partial<typeof before> = {
+			updatedAt: Date.now(),
+		};
+		if (args.name !== undefined) {
+			patch.name = validateSavedViewName(args.name);
+		}
+		if (args.visibleFieldIds !== undefined) {
+			patch.visibleFieldIds = args.visibleFieldIds;
+		}
+		if (args.fieldOrder !== undefined) {
+			patch.fieldOrder = args.fieldOrder;
+		}
+		if (args.filters !== undefined) {
+			patch.filters = args.filters;
+		}
+		if (args.groupByFieldId !== undefined) {
+			patch.groupByFieldId = args.groupByFieldId;
+		}
+		if (args.aggregatePresets !== undefined) {
+			patch.aggregatePresets = args.aggregatePresets;
+		}
+		if (args.isDefault !== undefined) {
+			patch.isDefault = args.isDefault;
+		}
+
+		await ctx.db.patch(args.userSavedViewId, patch);
+		const after = await ctx.db.get(args.userSavedViewId);
+
+		await auditLog.logChange(ctx, {
+			action: "crm.userSavedView.updated",
+			actorId: ctx.viewer.authId,
+			resourceType: "userSavedViews",
+			resourceId: args.userSavedViewId,
+			before,
+			after,
+			generateDiff: true,
+			severity: "info",
+		});
+	})
+	.public();
+
+export const deleteUserSavedView = crmMutation
+	.input({ userSavedViewId: v.id("userSavedViews") })
+	.handler(async (ctx, args) => {
+		const before = await loadOwnedUserSavedView(ctx, {
+			userSavedViewId: args.userSavedViewId,
+			viewer: ctx.viewer,
+		});
+
+		await ctx.db.delete(args.userSavedViewId);
+		await auditLog.log(ctx, {
+			action: "crm.userSavedView.deleted",
+			actorId: ctx.viewer.authId,
+			resourceType: "userSavedViews",
+			resourceId: args.userSavedViewId,
+			severity: "info",
+			metadata: {
+				objectDefId: before.objectDefId,
+				orgId: before.orgId,
+			},
+		});
+	})
+	.public();
+
+export const setDefaultUserSavedView = crmMutation
+	.input({ userSavedViewId: v.id("userSavedViews") })
+	.handler(async (ctx, args) => {
+		const orgId = ctx.viewer.orgId;
+		if (!orgId) {
+			throw new ConvexError("Org context required for CRM operations");
+		}
+
+		const before = await loadOwnedUserSavedView(ctx, {
+			userSavedViewId: args.userSavedViewId,
+			viewer: ctx.viewer,
+		});
+
+		await clearExistingDefaultSavedViews(ctx, {
+			excludeId: args.userSavedViewId,
+			objectDefId: before.objectDefId,
+			ownerAuthId: ctx.viewer.authId,
+			orgId,
+		});
+
+		await ctx.db.patch(args.userSavedViewId, {
+			isDefault: true,
+			updatedAt: Date.now(),
+		});
+
+		const after = await ctx.db.get(args.userSavedViewId);
+		await auditLog.logChange(ctx, {
+			action: "crm.userSavedView.default.updated",
+			actorId: ctx.viewer.authId,
+			resourceType: "userSavedViews",
+			resourceId: args.userSavedViewId,
+			before,
+			after,
+			generateDiff: true,
+			severity: "info",
+		});
+	})
+	.public();

--- a/convex/crm/validators.ts
+++ b/convex/crm/validators.ts
@@ -161,6 +161,13 @@ export const logicalOperatorValidator = v.union(
 	v.literal("or")
 );
 
+export const savedViewFilterValidator = v.object({
+	fieldDefId: v.id("fieldDefs"),
+	operator: filterOperatorValidator,
+	value: v.optional(v.string()),
+	logicalOperator: v.optional(logicalOperatorValidator),
+});
+
 // ── Select Option (reused in fieldDefs) ──
 export const selectOptionValidator = v.object({
 	value: v.string(),

--- a/convex/crm/viewQueries.ts
+++ b/convex/crm/viewQueries.ts
@@ -17,6 +17,7 @@ import {
 	queryNativeTable,
 } from "./systemAdapters/queryAdapter";
 import type {
+	EffectiveViewDefinition,
 	EntityViewAdapterContract,
 	EntityViewPageResult,
 	EntityViewRow,
@@ -24,8 +25,8 @@ import type {
 	RecordFilter,
 	SystemViewDefinition,
 	UnifiedRecord,
+	UserSavedViewDefinition,
 	ViewAggregateResult,
-	ViewFilterDefinition,
 	ViewLayout,
 } from "./types";
 import { KANBAN_NO_VALUE_SENTINEL } from "./viewDefs";
@@ -113,8 +114,11 @@ interface ViewSchemaColumn extends ViewColumnDefinition {
 interface ViewSchemaResult {
 	adapterContract: EntityViewAdapterContract;
 	columns: ViewSchemaColumn[];
+	effectiveView: EffectiveViewDefinition;
 	fields: NormalizedFieldDefinition[];
 	needsRepair: boolean;
+	savedView: UserSavedViewDefinition | null;
+	systemView: SystemViewDefinition;
 	view: SystemViewDefinition;
 	viewType: ViewLayout;
 }
@@ -162,10 +166,11 @@ function normalizeViewFilterOperator(
  * used by table and kanban queries.
  */
 function convertViewFiltersToRecordFilters(
-	viewFilters: ViewFilterDefinition[]
+	viewFilters: RecordFilter[]
 ): RecordFilter[] {
 	return viewFilters.map((filter) => ({
 		fieldDefId: filter.fieldDefId,
+		logicalOperator: filter.logicalOperator,
 		operator: normalizeViewFilterOperator(filter.operator),
 		value: filter.value,
 	}));
@@ -667,6 +672,7 @@ async function queryKanbanView(
 export const queryViewRecords = crmQuery
 	.input({
 		viewDefId: v.id("viewDefs"),
+		userSavedViewId: v.optional(v.id("userSavedViews")),
 		cursor: v.optional(v.union(v.string(), v.null())),
 		limit: v.optional(v.number()),
 		rangeStart: v.optional(v.number()),
@@ -676,7 +682,11 @@ export const queryViewRecords = crmQuery
 		),
 	})
 	.handler(async (ctx, args) => {
-		const state = await resolveViewState(ctx, args.viewDefId);
+		const state = await resolveViewState(
+			ctx,
+			args.viewDefId,
+			args.userSavedViewId
+		);
 		if (state.viewDef.needsRepair) {
 			throw new ConvexError(
 				"This view needs repair before it can be queried. Please update the view configuration."
@@ -702,6 +712,7 @@ export const queryViewRecords = crmQuery
 				}
 				return queryCalendarViewData(ctx, {
 					viewDefId: args.viewDefId,
+					userSavedViewId: args.userSavedViewId,
 					rangeStart: args.rangeStart,
 					rangeEnd: args.rangeEnd,
 					granularity: args.granularity,
@@ -719,9 +730,14 @@ export const queryViewRecords = crmQuery
 export const getViewSchema = crmQuery
 	.input({
 		viewDefId: v.id("viewDefs"),
+		userSavedViewId: v.optional(v.id("userSavedViews")),
 	})
 	.handler(async (ctx, args): Promise<ViewSchemaResult> => {
-		const state = await resolveViewState(ctx, args.viewDefId);
+		const state = await resolveViewState(
+			ctx,
+			args.viewDefId,
+			args.userSavedViewId
+		);
 
 		// 4. Load fieldCapabilities where capability === "sort"
 		const sortCapabilities = await ctx.db
@@ -758,10 +774,13 @@ export const getViewSchema = crmQuery
 		return {
 			adapterContract: state.adapterContract,
 			columns,
+			effectiveView: state.effectiveView,
 			fields: state.fields,
 			viewType: state.view.layout,
 			needsRepair: state.view.needsRepair,
-			view: state.view,
+			savedView: state.savedView,
+			systemView: state.systemView,
+			view: state.systemView,
 		};
 	})
 	.public();

--- a/convex/crm/viewState.ts
+++ b/convex/crm/viewState.ts
@@ -1,21 +1,41 @@
 import { ConvexError } from "convex/values";
 import type { Doc, Id } from "../_generated/dataModel";
-import type { QueryCtx } from "../_generated/server";
+import type { MutationCtx, QueryCtx } from "../_generated/server";
 import type { Viewer } from "../fluent";
 import { resolveEntityViewAdapterContract } from "./entityAdapterRegistry";
+import { loadActiveFieldDefs } from "./recordQueries";
 import type {
 	AggregatePreset,
+	EffectiveViewDefinition,
 	EntityViewAdapterContract,
 	EntityViewRow,
 	NormalizedFieldDefinition,
+	RecordFilter,
+	SavedViewFilterDefinition,
 	SystemViewDefinition,
+	UserSavedViewDefinition,
 	ViewAggregateResult,
-	ViewFilterDefinition,
 } from "./types";
 
 type FieldDef = Doc<"fieldDefs">;
 type ViewField = Doc<"viewFields">;
 type CrmQueryCtx = QueryCtx & { viewer: Viewer };
+type DbCtx = Pick<QueryCtx, "db"> | Pick<MutationCtx, "db">;
+type FieldDefId = Id<"fieldDefs">;
+type ViewDefDoc = Doc<"viewDefs">;
+type ViewFieldDoc = Doc<"viewFields">;
+type ViewFilterDoc = Doc<"viewFilters">;
+type UserSavedViewDoc = Doc<"userSavedViews">;
+
+interface SavedViewFilterSource {
+	filters?: SavedViewFilterDefinition[];
+	filtersJson?: string;
+}
+
+type UserSavedViewSnapshot = Omit<
+	UserSavedViewDefinition,
+	"ownerAuthId" | "userSavedViewId"
+>;
 
 export interface ViewColumnDefinition {
 	displayOrder: number;
@@ -27,15 +47,26 @@ export interface ViewColumnDefinition {
 	width: number | undefined;
 }
 
+export interface EffectiveViewState {
+	effectiveView: EffectiveViewDefinition;
+	savedView: UserSavedViewDefinition | null;
+	systemView: SystemViewDefinition;
+	viewDef: ViewDefDoc;
+	viewFields: ViewFieldDoc[];
+}
+
 export interface ResolvedViewState {
 	activeFieldDefs: FieldDef[];
 	adapterContract: EntityViewAdapterContract;
 	columns: ViewColumnDefinition[];
+	effectiveView: EffectiveViewDefinition;
 	fieldDefsById: Map<string, FieldDef>;
 	fields: NormalizedFieldDefinition[];
 	objectDef: Doc<"objectDefs">;
+	savedView: UserSavedViewDefinition | null;
+	systemView: SystemViewDefinition;
 	view: SystemViewDefinition;
-	viewDef: Doc<"viewDefs">;
+	viewDef: ViewDefDoc;
 }
 
 function toNormalizedFieldDefinition(
@@ -68,8 +99,60 @@ function toNormalizedFieldDefinition(
 	};
 }
 
+function parseStoredFilterValue(value: string | undefined): unknown {
+	if (value === undefined) {
+		return undefined;
+	}
+
+	try {
+		return JSON.parse(value);
+	} catch {
+		return value;
+	}
+}
+
+function normalizeFieldOrder(
+	preferred: FieldDefId[] | undefined,
+	fallback: FieldDefId[]
+): FieldDefId[] {
+	const orderedIds = preferred && preferred.length > 0 ? preferred : fallback;
+	const uniqueIds = new Set<string>();
+	const normalized: FieldDefId[] = [];
+
+	for (const fieldId of [...orderedIds, ...fallback]) {
+		const key = fieldId.toString();
+		if (uniqueIds.has(key)) {
+			continue;
+		}
+		uniqueIds.add(key);
+		normalized.push(fieldId);
+	}
+
+	return normalized;
+}
+
+function normalizeVisibleFieldIds(
+	preferred: FieldDefId[] | undefined,
+	fallback: FieldDefId[]
+): FieldDefId[] {
+	const sourceIds = preferred ?? fallback;
+	const uniqueIds = new Set<string>();
+	const normalized: FieldDefId[] = [];
+
+	for (const fieldId of sourceIds) {
+		const key = fieldId.toString();
+		if (uniqueIds.has(key)) {
+			continue;
+		}
+		uniqueIds.add(key);
+		normalized.push(fieldId);
+	}
+
+	return normalized;
+}
+
 function deriveDisabledLayoutMessages(
-	fieldDefs: FieldDef[]
+	fieldDefs: Pick<Doc<"fieldDefs">, "layoutEligibility">[]
 ): SystemViewDefinition["disabledLayoutMessages"] | undefined {
 	const messages: NonNullable<SystemViewDefinition["disabledLayoutMessages"]> =
 		{};
@@ -98,7 +181,7 @@ function deriveDisabledLayoutMessages(
 function buildAdapterContract(args: {
 	fieldDefs: FieldDef[];
 	objectDef: Doc<"objectDefs">;
-	viewDef: Doc<"viewDefs">;
+	viewDef: ViewDefDoc;
 }): EntityViewAdapterContract {
 	return resolveEntityViewAdapterContract({
 		currentLayout: args.viewDef.viewType,
@@ -271,10 +354,10 @@ function compareSchemaOrderedEntries(args: {
 	return args.left.name.localeCompare(args.right.name);
 }
 
-function parseViewFiltersJson(
+function parseLegacySavedViewFiltersJson(
 	filtersJson: string | undefined
-): ViewFilterDefinition[] | undefined {
-	if (!(filtersJson && filtersJson.trim().length > 0)) {
+): SavedViewFilterDefinition[] | undefined {
+	if (!filtersJson) {
 		return undefined;
 	}
 
@@ -284,34 +367,59 @@ function parseViewFiltersJson(
 			return undefined;
 		}
 
-		return parsed.flatMap((candidate) => {
-			if (!(candidate && typeof candidate === "object")) {
+		return parsed.flatMap((entry) => {
+			if (entry === null || typeof entry !== "object") {
 				return [];
 			}
 
-			const filter = candidate as Partial<ViewFilterDefinition>;
+			const candidate = entry as Partial<SavedViewFilterDefinition>;
 			if (
-				typeof filter.fieldDefId !== "string" ||
-				typeof filter.operator !== "string"
+				candidate.fieldDefId === undefined ||
+				candidate.operator === undefined
 			) {
 				return [];
 			}
 
 			return [
 				{
-					fieldDefId: filter.fieldDefId as Id<"fieldDefs">,
-					logicalOperator:
-						typeof filter.logicalOperator === "string"
-							? filter.logicalOperator
-							: undefined,
-					operator: filter.operator as ViewFilterDefinition["operator"],
-					value: filter.value,
+					fieldDefId: candidate.fieldDefId,
+					operator: candidate.operator,
+					value: candidate.value,
+					logicalOperator: candidate.logicalOperator,
 				},
 			];
 		});
 	} catch {
 		return undefined;
 	}
+}
+
+function getStoredSavedViewFilters(
+	doc: SavedViewFilterSource
+): SavedViewFilterDefinition[] {
+	return doc.filters ?? parseLegacySavedViewFiltersJson(doc.filtersJson) ?? [];
+}
+
+function toSavedViewFilters(
+	viewFilters: ViewFilterDoc[]
+): SavedViewFilterDefinition[] {
+	return viewFilters.map((viewFilter) => ({
+		fieldDefId: viewFilter.fieldDefId,
+		operator: viewFilter.operator,
+		value: viewFilter.value,
+		logicalOperator: viewFilter.logicalOperator,
+	}));
+}
+
+function toRuntimeFilters(
+	filters: SavedViewFilterDefinition[]
+): RecordFilter[] {
+	return filters.map((filter) => ({
+		fieldDefId: filter.fieldDefId,
+		logicalOperator: filter.logicalOperator,
+		operator: filter.operator,
+		value: parseStoredFilterValue(filter.value),
+	}));
 }
 
 function sanitizeFieldIdList(
@@ -333,99 +441,34 @@ function sanitizeFieldIdList(
 	return sanitized;
 }
 
-function buildBaseViewDefinition(args: {
-	fieldDefsById: Map<string, FieldDef>;
-	objectDefId: Id<"objectDefs">;
-	viewDef: Doc<"viewDefs">;
-	viewFields: ViewField[];
-	viewFilters: Doc<"viewFilters">[];
+function toSystemViewDefinition(args: {
+	disabledLayoutMessages: SystemViewDefinition["disabledLayoutMessages"];
+	viewDef: ViewDefDoc;
+	viewFields: ViewFieldDoc[];
+	viewFilters: ViewFilterDoc[];
 }): SystemViewDefinition {
-	const orderedFields = [...args.viewFields].sort(
-		(a, b) => a.displayOrder - b.displayOrder
+	const orderedViewFields = [...args.viewFields].sort(
+		(left, right) => left.displayOrder - right.displayOrder
 	);
-	const fieldOrder = orderedFields
-		.filter((viewField) =>
-			args.fieldDefsById.has(viewField.fieldDefId.toString())
-		)
-		.map((viewField) => viewField.fieldDefId);
-	const visibleFieldIds = orderedFields
-		.filter(
-			(viewField) =>
-				viewField.isVisible &&
-				args.fieldDefsById.has(viewField.fieldDefId.toString())
-		)
+	const fieldOrder = orderedViewFields.map((viewField) => viewField.fieldDefId);
+	const visibleFieldIds = orderedViewFields
+		.filter((viewField) => viewField.isVisible)
 		.map((viewField) => viewField.fieldDefId);
 
 	return {
 		viewDefId: args.viewDef._id,
-		objectDefId: args.objectDefId,
+		objectDefId: args.viewDef.objectDefId,
 		name: args.viewDef.name,
 		layout: args.viewDef.viewType,
 		boundFieldId: args.viewDef.boundFieldId,
 		fieldOrder,
 		visibleFieldIds,
-		filters: args.viewFilters.map((viewFilter) => {
-			let parsedValue: unknown = viewFilter.value;
-			if (viewFilter.value !== undefined) {
-				try {
-					parsedValue = JSON.parse(viewFilter.value);
-				} catch {
-					parsedValue = viewFilter.value;
-				}
-			}
-
-			return {
-				fieldDefId: viewFilter.fieldDefId,
-				logicalOperator: viewFilter.logicalOperator,
-				operator: viewFilter.operator,
-				value: parsedValue,
-			};
-		}),
+		filters: toRuntimeFilters(toSavedViewFilters(args.viewFilters)),
 		groupByFieldId: args.viewDef.groupByFieldId,
 		aggregatePresets: args.viewDef.aggregatePresets ?? [],
-		disabledLayoutMessages:
-			args.viewDef.disabledLayoutMessages ??
-			deriveDisabledLayoutMessages([...args.fieldDefsById.values()]),
+		disabledLayoutMessages: args.disabledLayoutMessages,
 		isDefault: args.viewDef.isDefault,
 		needsRepair: args.viewDef.needsRepair,
-	};
-}
-
-function buildEffectiveViewDefinition(args: {
-	baseView: SystemViewDefinition;
-	fieldDefsById: Map<string, FieldDef>;
-	savedView?: Doc<"userSavedViews">;
-}): SystemViewDefinition {
-	if (!args.savedView) {
-		return args.baseView;
-	}
-
-	const savedFieldOrder = sanitizeFieldIdList(
-		args.savedView.fieldOrder,
-		args.fieldDefsById
-	);
-	const savedVisibleFieldIds = sanitizeFieldIdList(
-		args.savedView.visibleFieldIds,
-		args.fieldDefsById
-	);
-	const savedFilters = parseViewFiltersJson(args.savedView.filtersJson);
-
-	return {
-		...args.baseView,
-		name: args.savedView.name,
-		layout: args.savedView.viewType,
-		fieldOrder:
-			savedFieldOrder.length > 0 ? savedFieldOrder : args.baseView.fieldOrder,
-		visibleFieldIds:
-			savedVisibleFieldIds.length > 0
-				? savedVisibleFieldIds
-				: args.baseView.visibleFieldIds,
-		filters: savedFilters ?? args.baseView.filters,
-		groupByFieldId:
-			args.savedView.groupByFieldId ?? args.baseView.groupByFieldId,
-		aggregatePresets:
-			args.savedView.aggregatePresets ?? args.baseView.aggregatePresets,
-		isDefault: args.savedView.isDefault,
 	};
 }
 
@@ -519,89 +562,370 @@ function buildEffectiveColumns(args: {
 		);
 }
 
-async function loadSavedViewOverlay(
-	ctx: CrmQueryCtx,
-	viewDef: Doc<"viewDefs">
-): Promise<Doc<"userSavedViews"> | undefined> {
-	const savedViews = await ctx.db
-		.query("userSavedViews")
-		.withIndex("by_owner_object", (q) =>
-			q
-				.eq("ownerAuthId", ctx.viewer.authId)
-				.eq("objectDefId", viewDef.objectDefId)
-		)
+export function toUserSavedViewDefinition(
+	doc: UserSavedViewDoc
+): UserSavedViewDefinition {
+	return {
+		userSavedViewId: doc._id,
+		objectDefId: doc.objectDefId,
+		ownerAuthId: doc.ownerAuthId,
+		sourceViewDefId: doc.sourceViewDefId,
+		name: doc.name,
+		viewType: doc.viewType,
+		visibleFieldIds: doc.visibleFieldIds,
+		fieldOrder: doc.fieldOrder,
+		filters: getStoredSavedViewFilters(doc as SavedViewFilterSource),
+		groupByFieldId: doc.groupByFieldId,
+		aggregatePresets: doc.aggregatePresets ?? [],
+		isDefault: doc.isDefault,
+	};
+}
+
+export function buildUserSavedViewSnapshot(args: {
+	savedView?: UserSavedViewDoc | null;
+	viewDef: ViewDefDoc;
+	viewFields: ViewFieldDoc[];
+	viewFilters: ViewFilterDoc[];
+}): UserSavedViewSnapshot {
+	if (args.savedView) {
+		const savedView = toUserSavedViewDefinition(args.savedView);
+		return {
+			objectDefId: savedView.objectDefId,
+			sourceViewDefId: savedView.sourceViewDefId,
+			name: savedView.name,
+			viewType: savedView.viewType,
+			visibleFieldIds: savedView.visibleFieldIds,
+			fieldOrder: savedView.fieldOrder,
+			filters: savedView.filters,
+			groupByFieldId: savedView.groupByFieldId,
+			aggregatePresets: savedView.aggregatePresets,
+			isDefault: savedView.isDefault,
+		};
+	}
+
+	const orderedViewFields = [...args.viewFields].sort(
+		(left, right) => left.displayOrder - right.displayOrder
+	);
+
+	return {
+		objectDefId: args.viewDef.objectDefId,
+		sourceViewDefId: args.viewDef._id,
+		name: args.viewDef.name,
+		viewType: args.viewDef.viewType,
+		visibleFieldIds: orderedViewFields
+			.filter((viewField) => viewField.isVisible)
+			.map((viewField) => viewField.fieldDefId),
+		fieldOrder: orderedViewFields.map((viewField) => viewField.fieldDefId),
+		filters: toSavedViewFilters(args.viewFilters),
+		groupByFieldId: args.viewDef.groupByFieldId,
+		aggregatePresets: args.viewDef.aggregatePresets ?? [],
+		isDefault: args.viewDef.isDefault,
+	};
+}
+
+async function loadActiveFieldDefsFromDb(
+	ctx: DbCtx,
+	objectDefId: Id<"objectDefs">
+): Promise<FieldDef[]> {
+	const allFieldDefs = await ctx.db
+		.query("fieldDefs")
+		.withIndex("by_object", (query) => query.eq("objectDefId", objectDefId))
 		.collect();
 
-	return savedViews
-		.filter(
-			(savedView) =>
-				savedView.sourceViewDefId?.toString() === viewDef._id.toString() &&
-				savedView.viewType === viewDef.viewType &&
-				savedView.isDefault
+	return allFieldDefs.filter((fieldDef) => fieldDef.isActive);
+}
+
+export async function loadBaseViewState(
+	ctx: DbCtx,
+	viewDefId: Id<"viewDefs">,
+	orgId: string
+): Promise<{
+	viewDef: ViewDefDoc;
+	viewFields: ViewFieldDoc[];
+	viewFilters: ViewFilterDoc[];
+}> {
+	const viewDef = await ctx.db.get(viewDefId);
+	if (!viewDef || viewDef.orgId !== orgId) {
+		throw new ConvexError("View not found or access denied");
+	}
+
+	const [viewFields, viewFilters] = await Promise.all([
+		ctx.db
+			.query("viewFields")
+			.withIndex("by_view", (query) => query.eq("viewDefId", viewDefId))
+			.collect(),
+		ctx.db
+			.query("viewFilters")
+			.withIndex("by_view", (query) => query.eq("viewDefId", viewDefId))
+			.collect(),
+	]);
+
+	return { viewDef, viewFields, viewFilters };
+}
+
+export async function findDefaultUserSavedView(
+	ctx: DbCtx,
+	args: {
+		objectDefId: Id<"objectDefs">;
+		ownerAuthId: string;
+		orgId: string;
+	}
+): Promise<UserSavedViewDoc | null> {
+	return await ctx.db
+		.query("userSavedViews")
+		.withIndex("by_owner_object_default", (query) =>
+			query
+				.eq("ownerAuthId", args.ownerAuthId)
+				.eq("objectDefId", args.objectDefId)
+				.eq("isDefault", true)
 		)
-		.sort((left, right) => right.updatedAt - left.updatedAt)[0];
+		.filter((query) => query.eq(query.field("orgId"), args.orgId))
+		.first();
+}
+
+export async function loadOwnedUserSavedView(
+	ctx: DbCtx,
+	args: {
+		userSavedViewId: Id<"userSavedViews">;
+		viewer: Pick<Viewer, "authId" | "orgId">;
+	}
+): Promise<UserSavedViewDoc> {
+	const orgId = args.viewer.orgId;
+	if (!orgId) {
+		throw new ConvexError("Org context required");
+	}
+
+	const savedView = await ctx.db.get(args.userSavedViewId);
+	if (
+		!savedView ||
+		savedView.orgId !== orgId ||
+		savedView.ownerAuthId !== args.viewer.authId
+	) {
+		throw new ConvexError("Saved view not found or access denied");
+	}
+
+	return savedView;
+}
+
+async function loadRequestedView(
+	ctx: DbCtx,
+	args: {
+		orgId: string;
+		requestedViewDefId: Id<"viewDefs">;
+	}
+): Promise<ViewDefDoc> {
+	const requestedView = await ctx.db.get(args.requestedViewDefId);
+	if (!requestedView || requestedView.orgId !== args.orgId) {
+		throw new ConvexError("View not found or access denied");
+	}
+
+	return requestedView;
+}
+
+async function resolveRequestedSavedView(
+	ctx: DbCtx,
+	args: {
+		requestedView: ViewDefDoc;
+		userSavedViewId?: Id<"userSavedViews">;
+		viewer: Pick<Viewer, "authId" | "orgId">;
+	}
+): Promise<UserSavedViewDoc | null> {
+	if (args.userSavedViewId === undefined) {
+		return null;
+	}
+
+	const requestedSavedView = await loadOwnedUserSavedView(ctx, {
+		userSavedViewId: args.userSavedViewId,
+		viewer: args.viewer,
+	});
+	if (requestedSavedView.sourceViewDefId !== args.requestedView._id) {
+		throw new ConvexError(
+			"Saved view does not belong to the requested system view"
+		);
+	}
+
+	return requestedSavedView;
+}
+
+async function resolveImplicitDefaultSavedView(
+	ctx: DbCtx,
+	args: {
+		orgId: string;
+		requestedView: ViewDefDoc;
+		viewer: Pick<Viewer, "authId">;
+	}
+): Promise<UserSavedViewDoc | null> {
+	const defaultSavedView = await findDefaultUserSavedView(ctx, {
+		objectDefId: args.requestedView.objectDefId,
+		ownerAuthId: args.viewer.authId,
+		orgId: args.orgId,
+	});
+
+	return defaultSavedView?.sourceViewDefId === args.requestedView._id
+		? defaultSavedView
+		: null;
+}
+
+function validateResolvedSavedView(
+	savedView: UserSavedViewDoc | null,
+	viewDef: ViewDefDoc
+) {
+	if (savedView && savedView.objectDefId !== viewDef.objectDefId) {
+		throw new ConvexError(
+			"Saved view does not belong to the requested entity definition"
+		);
+	}
+
+	if (savedView && savedView.viewType !== viewDef.viewType) {
+		throw new ConvexError(
+			"Saved view layout no longer matches its source system view"
+		);
+	}
+}
+
+export async function resolveEffectiveViewState(
+	ctx: DbCtx,
+	args: {
+		requestedViewDefId: Id<"viewDefs">;
+		userSavedViewId?: Id<"userSavedViews">;
+		viewer: Pick<Viewer, "authId" | "orgId">;
+	}
+): Promise<EffectiveViewState> {
+	const orgId = args.viewer.orgId;
+	if (!orgId) {
+		throw new ConvexError("Org context required");
+	}
+
+	const requestedView = await loadRequestedView(ctx, {
+		requestedViewDefId: args.requestedViewDefId,
+		orgId,
+	});
+	const requestedSavedView = await resolveRequestedSavedView(ctx, {
+		requestedView,
+		userSavedViewId: args.userSavedViewId,
+		viewer: args.viewer,
+	});
+	const savedView =
+		requestedSavedView ??
+		(await resolveImplicitDefaultSavedView(ctx, {
+			requestedView,
+			viewer: args.viewer,
+			orgId,
+		}));
+
+	const sourceViewDefId = savedView?.sourceViewDefId ?? requestedView._id;
+	const { viewDef, viewFields, viewFilters } = await loadBaseViewState(
+		ctx,
+		sourceViewDefId,
+		orgId
+	);
+	const activeFieldDefs = await loadActiveFieldDefsFromDb(
+		ctx,
+		viewDef.objectDefId
+	);
+	const disabledLayoutMessages =
+		viewDef.disabledLayoutMessages ??
+		deriveDisabledLayoutMessages(activeFieldDefs);
+
+	validateResolvedSavedView(savedView, viewDef);
+
+	const systemView = toSystemViewDefinition({
+		disabledLayoutMessages,
+		viewDef,
+		viewFields,
+		viewFilters,
+	});
+	const orderedFieldIds = normalizeFieldOrder(
+		savedView?.fieldOrder,
+		systemView.fieldOrder
+	);
+	const visibleFieldIds = normalizeVisibleFieldIds(
+		savedView?.visibleFieldIds,
+		systemView.visibleFieldIds
+	);
+
+	return {
+		viewDef,
+		viewFields,
+		systemView,
+		savedView: savedView ? toUserSavedViewDefinition(savedView) : null,
+		effectiveView: {
+			activeSavedViewId: savedView?._id,
+			objectDefId: viewDef.objectDefId,
+			sourceViewDefId: viewDef._id,
+			name: savedView?.name ?? viewDef.name,
+			viewType: savedView?.viewType ?? viewDef.viewType,
+			boundFieldId: viewDef.boundFieldId,
+			fieldOrder: orderedFieldIds,
+			visibleFieldIds,
+			filters: savedView
+				? toRuntimeFilters(
+						getStoredSavedViewFilters(savedView as SavedViewFilterSource)
+					)
+				: toRuntimeFilters(toSavedViewFilters(viewFilters)),
+			groupByFieldId: savedView?.groupByFieldId ?? viewDef.groupByFieldId,
+			aggregatePresets:
+				savedView?.aggregatePresets ?? viewDef.aggregatePresets ?? [],
+			disabledLayoutMessages,
+			isDefault: savedView?.isDefault ?? viewDef.isDefault,
+		},
+	};
+}
+
+function toResolvedSystemView(
+	effectiveState: EffectiveViewState
+): SystemViewDefinition {
+	return {
+		...effectiveState.systemView,
+		name: effectiveState.effectiveView.name,
+		layout: effectiveState.effectiveView.viewType,
+		fieldOrder: effectiveState.effectiveView.fieldOrder,
+		visibleFieldIds: effectiveState.effectiveView.visibleFieldIds,
+		filters: effectiveState.effectiveView.filters,
+		groupByFieldId: effectiveState.effectiveView.groupByFieldId,
+		aggregatePresets: effectiveState.effectiveView.aggregatePresets,
+		disabledLayoutMessages: effectiveState.effectiveView.disabledLayoutMessages,
+		isDefault: effectiveState.effectiveView.isDefault,
+	};
 }
 
 export async function resolveViewState(
 	ctx: CrmQueryCtx,
-	viewDefId: Id<"viewDefs">
+	viewDefId: Id<"viewDefs">,
+	userSavedViewId?: Id<"userSavedViews">
 ): Promise<ResolvedViewState> {
 	const orgId = ctx.viewer.orgId;
 	if (!orgId) {
 		throw new ConvexError("Org context required");
 	}
 
-	const viewDef = await ctx.db.get(viewDefId);
-	if (!viewDef || viewDef.orgId !== orgId) {
-		throw new ConvexError("View not found or access denied");
-	}
-
-	const objectDef = await ctx.db.get(viewDef.objectDefId);
+	const effectiveState = await resolveEffectiveViewState(ctx, {
+		requestedViewDefId: viewDefId,
+		userSavedViewId,
+		viewer: ctx.viewer,
+	});
+	const objectDef = await ctx.db.get(effectiveState.viewDef.objectDefId);
 	if (!objectDef || objectDef.orgId !== orgId || !objectDef.isActive) {
 		throw new ConvexError("Object not found or access denied");
 	}
 
-	const [viewFields, viewFilters, allFieldDefs, savedView] = await Promise.all([
-		ctx.db
-			.query("viewFields")
-			.withIndex("by_view", (q) => q.eq("viewDefId", viewDefId))
-			.collect(),
-		ctx.db
-			.query("viewFilters")
-			.withIndex("by_view", (q) => q.eq("viewDefId", viewDefId))
-			.collect(),
-		ctx.db
-			.query("fieldDefs")
-			.withIndex("by_object", (q) => q.eq("objectDefId", viewDef.objectDefId))
-			.collect(),
-		loadSavedViewOverlay(ctx, viewDef),
-	]);
-
-	const activeFieldDefs = allFieldDefs.filter((fieldDef) => fieldDef.isActive);
+	const activeFieldDefs = await loadActiveFieldDefs(
+		ctx,
+		effectiveState.viewDef.objectDefId
+	);
 	const fieldDefsById = new Map(
 		activeFieldDefs.map((fieldDef) => [fieldDef._id.toString(), fieldDef])
 	);
-	const baseView = buildBaseViewDefinition({
-		fieldDefsById,
-		objectDefId: viewDef.objectDefId,
-		viewDef,
-		viewFields,
-		viewFilters,
-	});
-	const view = buildEffectiveViewDefinition({
-		baseView,
-		fieldDefsById,
-		savedView,
-	});
+	const view = toResolvedSystemView(effectiveState);
 	const adapterContract = buildAdapterContract({
 		fieldDefs: activeFieldDefs,
 		objectDef,
-		viewDef,
+		viewDef: effectiveState.viewDef,
 	});
 	const fieldOverridesByName = buildFieldOverridesByName(adapterContract);
 	const schemaOrderHints = buildSchemaOrderHints({
 		adapterContract,
-		viewIsDefault: viewDef.isDefault && !savedView,
+		viewIsDefault: effectiveState.viewDef.isDefault && !effectiveState.savedView,
 	});
 	const persistedFields = activeFieldDefs.map((fieldDef) =>
 		applyFieldOverridesToDefinition({
@@ -632,19 +956,22 @@ export async function resolveViewState(
 	);
 
 	return {
-		viewDef,
+		viewDef: effectiveState.viewDef,
 		view,
 		objectDef,
 		activeFieldDefs,
+		effectiveView: effectiveState.effectiveView,
 		fieldDefsById,
 		fields,
 		adapterContract,
+		savedView: effectiveState.savedView,
+		systemView: effectiveState.systemView,
 		columns: buildEffectiveColumns({
 			adapterContract,
 			effectiveView: view,
 			fieldDefsById,
-			viewFields,
-			viewIsDefault: viewDef.isDefault && !savedView,
+			viewFields: effectiveState.viewFields,
+			viewIsDefault: effectiveState.viewDef.isDefault && !effectiveState.savedView,
 		}),
 	};
 }

--- a/convex/crm/viewState.ts
+++ b/convex/crm/viewState.ts
@@ -718,7 +718,6 @@ async function loadRequestedView(
 	if (!requestedView || requestedView.orgId !== args.orgId) {
 		throw new ConvexError("View not found or access denied");
 	}
-
 	return requestedView;
 }
 

--- a/convex/crm/viewState.ts
+++ b/convex/crm/viewState.ts
@@ -26,12 +26,10 @@ type ViewDefDoc = Doc<"viewDefs">;
 type ViewFieldDoc = Doc<"viewFields">;
 type ViewFilterDoc = Doc<"viewFilters">;
 type UserSavedViewDoc = Doc<"userSavedViews">;
-
 interface SavedViewFilterSource {
 	filters?: SavedViewFilterDefinition[];
 	filtersJson?: string;
 }
-
 type UserSavedViewSnapshot = Omit<
 	UserSavedViewDefinition,
 	"ownerAuthId" | "userSavedViewId"
@@ -399,7 +397,6 @@ function getStoredSavedViewFilters(
 ): SavedViewFilterDefinition[] {
 	return doc.filters ?? parseLegacySavedViewFiltersJson(doc.filtersJson) ?? [];
 }
-
 function toSavedViewFilters(
 	viewFilters: ViewFilterDoc[]
 ): SavedViewFilterDefinition[] {

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -15,6 +15,7 @@ import {
 	logicalOperatorValidator,
 	normalizedFieldKindValidator,
 	relationMetadataValidator,
+	savedViewFilterValidator,
 	selectOptionValidator,
 	viewLayoutMessagesValidator,
 	viewTypeValidator,
@@ -2081,7 +2082,7 @@ export default defineSchema({
 		viewType: viewTypeValidator,
 		visibleFieldIds: v.array(v.id("fieldDefs")),
 		fieldOrder: v.array(v.id("fieldDefs")),
-		filtersJson: v.optional(v.string()),
+		filters: v.array(savedViewFilterValidator),
 		groupByFieldId: v.optional(v.id("fieldDefs")),
 		aggregatePresets: v.optional(v.array(aggregatePresetValidator)),
 		isDefault: v.boolean(),
@@ -2089,6 +2090,11 @@ export default defineSchema({
 		updatedAt: v.number(),
 	})
 		.index("by_owner_object", ["ownerAuthId", "objectDefId"])
+		.index("by_owner_object_default", [
+			"ownerAuthId",
+			"objectDefId",
+			"isDefault",
+		])
 		.index("by_org", ["orgId"])
 		.index("by_source_view", ["sourceViewDefId"]),
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -2082,14 +2082,22 @@ export default defineSchema({
 		viewType: viewTypeValidator,
 		visibleFieldIds: v.array(v.id("fieldDefs")),
 		fieldOrder: v.array(v.id("fieldDefs")),
-		filters: v.array(savedViewFilterValidator),
+		filters: v.optional(v.array(savedViewFilterValidator)),
+		filtersJson: v.optional(v.string()),
 		groupByFieldId: v.optional(v.id("fieldDefs")),
 		aggregatePresets: v.optional(v.array(aggregatePresetValidator)),
 		isDefault: v.boolean(),
 		createdAt: v.number(),
 		updatedAt: v.number(),
 	})
+		.index("by_org_owner_object", ["orgId", "ownerAuthId", "objectDefId"])
 		.index("by_owner_object", ["ownerAuthId", "objectDefId"])
+		.index("by_org_owner_object_default", [
+			"orgId",
+			"ownerAuthId",
+			"objectDefId",
+			"isDefault",
+		])
 		.index("by_owner_object_default", [
 			"ownerAuthId",
 			"objectDefId",

--- a/convex/test/moduleMaps.ts
+++ b/convex/test/moduleMaps.ts
@@ -84,6 +84,8 @@ export const convexModules: ModuleMap = {
 	"/convex/crm/systemAdapters/queryAdapter.ts": async () =>
 		await import("./../crm/systemAdapters/queryAdapter.ts"),
 	"/convex/crm/types.ts": async () => await import("./../crm/types.ts"),
+	"/convex/crm/userSavedViews.ts": async () =>
+		await import("./../crm/userSavedViews.ts"),
 	"/convex/crm/validators.ts": async () =>
 		await import("./../crm/validators.ts"),
 	"/convex/crm/valueRouter.ts": async () =>
@@ -97,6 +99,7 @@ export const convexModules: ModuleMap = {
 		await import("./../crm/viewKanbanGroups.ts"),
 	"/convex/crm/viewQueries.ts": async () =>
 		await import("./../crm/viewQueries.ts"),
+	"/convex/crm/viewState.ts": async () => await import("./../crm/viewState.ts"),
 	"/convex/crons.ts": async () => await import("./../crons.ts"),
 	"/convex/dealReroutes/mutations.ts": async () =>
 		await import("./../dealReroutes/mutations.ts"),

--- a/convex/test/registerAuditLogComponent.ts
+++ b/convex/test/registerAuditLogComponent.ts
@@ -1,114 +1,102 @@
+import { readdirSync } from "node:fs";
+import { join } from "node:path";
 import type { GenericSchema, SchemaDefinition } from "convex/server";
 import type { TestConvex } from "convex-test";
 import aggregateSchema from "../../node_modules/@convex-dev/aggregate/dist/component/schema.js";
 import auditLogSchema from "../../node_modules/convex-audit-log/dist/component/schema.js";
 
-const aggregateModules = {
-	"/node_modules/@convex-dev/aggregate/dist/component/_generated/api.js":
-		async () =>
-			await import(
-				"../../node_modules/@convex-dev/aggregate/dist/component/_generated/api.js"
-			),
-	"/node_modules/@convex-dev/aggregate/dist/component/_generated/component.js":
-		async () =>
-			await import(
-				"../../node_modules/@convex-dev/aggregate/dist/component/_generated/component.js"
-			),
-	"/node_modules/@convex-dev/aggregate/dist/component/_generated/dataModel.js":
-		async () =>
-			await import(
-				"../../node_modules/@convex-dev/aggregate/dist/component/_generated/dataModel.js"
-			),
-	"/node_modules/@convex-dev/aggregate/dist/component/_generated/server.js":
-		async () =>
-			await import(
-				"../../node_modules/@convex-dev/aggregate/dist/component/_generated/server.js"
-			),
-	"/node_modules/@convex-dev/aggregate/dist/component/arbitrary.helpers.js":
-		async () =>
-			await import(
-				"../../node_modules/@convex-dev/aggregate/dist/component/arbitrary.helpers.js"
-			),
-	"/node_modules/@convex-dev/aggregate/dist/component/btree.js": async () =>
-		await import(
-			"../../node_modules/@convex-dev/aggregate/dist/component/btree.js"
-		),
-	"/node_modules/@convex-dev/aggregate/dist/component/compare.js": async () =>
-		await import(
-			"../../node_modules/@convex-dev/aggregate/dist/component/compare.js"
-		),
-	"/node_modules/@convex-dev/aggregate/dist/component/convex.config.js":
-		async () =>
-			await import(
-				"../../node_modules/@convex-dev/aggregate/dist/component/convex.config.js"
-			),
-	"/node_modules/@convex-dev/aggregate/dist/component/inspect.js": async () =>
-		await import(
-			"../../node_modules/@convex-dev/aggregate/dist/component/inspect.js"
-		),
-	"/node_modules/@convex-dev/aggregate/dist/component/public.js": async () =>
-		await import(
-			"../../node_modules/@convex-dev/aggregate/dist/component/public.js"
-		),
-	"/node_modules/@convex-dev/aggregate/dist/component/schema.js": async () =>
-		await import(
-			"../../node_modules/@convex-dev/aggregate/dist/component/schema.js"
-		),
-};
+type ConvexModuleLoader = () => Promise<unknown>;
 
-const auditLogModules = {
-	"/node_modules/convex-audit-log/dist/component/_generated/api.js": async () =>
-		await import(
-			"../../node_modules/convex-audit-log/dist/component/_generated/api.js"
+function compareModuleKeys(a: string, b: string) {
+	const aIsRootGenerated = a.startsWith("/convex/_generated/");
+	const bIsRootGenerated = b.startsWith("/convex/_generated/");
+
+	if (aIsRootGenerated !== bIsRootGenerated) {
+		return aIsRootGenerated ? -1 : 1;
+	}
+
+	return a.localeCompare(b);
+}
+
+function loadModulesFromRoot(root: URL, mountPrefix: string) {
+	const moduleEntries: [string, ConvexModuleLoader][] = [];
+
+	const walk = (dir: URL, relativePath: string) => {
+		for (const entry of readdirSync(dir, { withFileTypes: true })) {
+			const nextRelativePath = relativePath
+				? `${relativePath}/${entry.name}`
+				: entry.name;
+			const nextUrl = new URL(
+				`${entry.name}${entry.isDirectory() ? "/" : ""}`,
+				dir
+			);
+
+			if (entry.isDirectory()) {
+				if (entry.name === "__tests__") {
+					continue;
+				}
+				walk(nextUrl, nextRelativePath);
+				continue;
+			}
+
+			if (!(entry.name.endsWith(".ts") || entry.name.endsWith(".js"))) {
+				continue;
+			}
+
+			if (entry.name.endsWith(".d.ts")) {
+				continue;
+			}
+
+			const moduleKey = join(mountPrefix, nextRelativePath).replaceAll(
+				"\\",
+				"/"
+			);
+			moduleEntries.push([moduleKey, () => import(nextUrl.href)]);
+		}
+	};
+
+	walk(root, "");
+
+	return Object.fromEntries(
+		moduleEntries.sort(([leftKey], [rightKey]) =>
+			compareModuleKeys(leftKey, rightKey)
+		)
+	);
+}
+
+function loadAuditLogModules() {
+	return loadModulesFromRoot(
+		new URL(
+			"../../node_modules/convex-audit-log/dist/component/",
+			import.meta.url
 		),
-	"/node_modules/convex-audit-log/dist/component/_generated/component.js":
-		async () =>
-			await import(
-				"../../node_modules/convex-audit-log/dist/component/_generated/component.js"
-			),
-	"/node_modules/convex-audit-log/dist/component/_generated/dataModel.js":
-		async () =>
-			await import(
-				"../../node_modules/convex-audit-log/dist/component/_generated/dataModel.js"
-			),
-	"/node_modules/convex-audit-log/dist/component/_generated/server.js":
-		async () =>
-			await import(
-				"../../node_modules/convex-audit-log/dist/component/_generated/server.js"
-			),
-	"/node_modules/convex-audit-log/dist/component/aggregates.js": async () =>
-		await import(
-			"../../node_modules/convex-audit-log/dist/component/aggregates.js"
+		"/node_modules/convex-audit-log/dist/component"
+	);
+}
+
+function loadAggregateModules() {
+	return loadModulesFromRoot(
+		new URL(
+			"../../node_modules/@convex-dev/aggregate/dist/component/",
+			import.meta.url
 		),
-	"/node_modules/convex-audit-log/dist/component/convex.config.js": async () =>
-		await import(
-			"../../node_modules/convex-audit-log/dist/component/convex.config.js"
-		),
-	"/node_modules/convex-audit-log/dist/component/lib.js": async () =>
-		await import("../../node_modules/convex-audit-log/dist/component/lib.js"),
-	"/node_modules/convex-audit-log/dist/component/schema.js": async () =>
-		await import(
-			"../../node_modules/convex-audit-log/dist/component/schema.js"
-		),
-	"/node_modules/convex-audit-log/dist/component/shared.js": async () =>
-		await import(
-			"../../node_modules/convex-audit-log/dist/component/shared.js"
-		),
-};
+		"/node_modules/@convex-dev/aggregate/dist/component"
+	);
+}
 
 export function registerAuditLogComponent(
 	t: TestConvex<SchemaDefinition<GenericSchema, boolean>>,
 	name = "auditLog"
 ) {
-	t.registerComponent(name, auditLogSchema, auditLogModules);
+	t.registerComponent(name, auditLogSchema, loadAuditLogModules());
 	t.registerComponent(
 		`${name}/aggregateBySeverity`,
 		aggregateSchema,
-		aggregateModules
+		loadAggregateModules()
 	);
 	t.registerComponent(
 		`${name}/aggregateByAction`,
 		aggregateSchema,
-		aggregateModules
+		loadAggregateModules()
 	);
 }


### PR DESCRIPTION
feat(crm): add personal saved views

responding to feedback

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now create, manage, and set default personal saved views for CRM objects.
  * Saved views support custom filters, field visibility, ordering, grouping, and aggregates with proper permission isolation.
  * Expanded filter operators including date comparisons (before, after), range filtering (between), and equality operators.
  * Calendar and kanban views now integrate with personal saved views.

* **Tests**
  * Added comprehensive test coverage for user saved views creation, defaults, and permission scoping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->