### PR TITLE
collection attempt execution spine

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -203,6 +203,7 @@ import type * as payments_collectionPlan_queries from "../payments/collectionPla
 import type * as payments_collectionPlan_rules_lateFeeRule from "../payments/collectionPlan/rules/lateFeeRule.js";
 import type * as payments_collectionPlan_rules_retryRule from "../payments/collectionPlan/rules/retryRule.js";
 import type * as payments_collectionPlan_rules_scheduleRule from "../payments/collectionPlan/rules/scheduleRule.js";
+import type * as payments_collectionPlan_runner from "../payments/collectionPlan/runner.js";
 import type * as payments_collectionPlan_seed from "../payments/collectionPlan/seed.js";
 import type * as payments_collectionPlan_stubs from "../payments/collectionPlan/stubs.js";
 import type * as payments_dispersal_stubs from "../payments/dispersal/stubs.js";
@@ -468,6 +469,7 @@ declare const fullApi: ApiFromModules<{
   "payments/collectionPlan/rules/lateFeeRule": typeof payments_collectionPlan_rules_lateFeeRule;
   "payments/collectionPlan/rules/retryRule": typeof payments_collectionPlan_rules_retryRule;
   "payments/collectionPlan/rules/scheduleRule": typeof payments_collectionPlan_rules_scheduleRule;
+  "payments/collectionPlan/runner": typeof payments_collectionPlan_runner;
   "payments/collectionPlan/seed": typeof payments_collectionPlan_seed;
   "payments/collectionPlan/stubs": typeof payments_collectionPlan_stubs;
   "payments/dispersal/stubs": typeof payments_dispersal_stubs;

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -194,10 +194,12 @@ import type * as payments_cashLedger_transferReconciliationCron from "../payment
 import type * as payments_cashLedger_types from "../payments/cashLedger/types.js";
 import type * as payments_cashLedger_validators from "../payments/cashLedger/validators.js";
 import type * as payments_cashLedger_waiveObligationBalanceHandler from "../payments/cashLedger/waiveObligationBalanceHandler.js";
+import type * as payments_collectionPlan_defaultRules from "../payments/collectionPlan/defaultRules.js";
 import type * as payments_collectionPlan_engine from "../payments/collectionPlan/engine.js";
 import type * as payments_collectionPlan_execution from "../payments/collectionPlan/execution.js";
 import type * as payments_collectionPlan_executionContract from "../payments/collectionPlan/executionContract.js";
 import type * as payments_collectionPlan_executionGuards from "../payments/collectionPlan/executionGuards.js";
+import type * as payments_collectionPlan_initialScheduling from "../payments/collectionPlan/initialScheduling.js";
 import type * as payments_collectionPlan_mutations from "../payments/collectionPlan/mutations.js";
 import type * as payments_collectionPlan_queries from "../payments/collectionPlan/queries.js";
 import type * as payments_collectionPlan_rules_lateFeeRule from "../payments/collectionPlan/rules/lateFeeRule.js";
@@ -224,6 +226,7 @@ import type * as payments_payout_mutations from "../payments/payout/mutations.js
 import type * as payments_payout_queries from "../payments/payout/queries.js";
 import type * as payments_payout_refs from "../payments/payout/refs.js";
 import type * as payments_payout_validators from "../payments/payout/validators.js";
+import type * as payments_transfers_collectionAttemptReconciliation from "../payments/transfers/collectionAttemptReconciliation.js";
 import type * as payments_transfers_depositCollection from "../payments/transfers/depositCollection.js";
 import type * as payments_transfers_interface from "../payments/transfers/interface.js";
 import type * as payments_transfers_mockProviders from "../payments/transfers/mockProviders.js";
@@ -460,10 +463,12 @@ declare const fullApi: ApiFromModules<{
   "payments/cashLedger/types": typeof payments_cashLedger_types;
   "payments/cashLedger/validators": typeof payments_cashLedger_validators;
   "payments/cashLedger/waiveObligationBalanceHandler": typeof payments_cashLedger_waiveObligationBalanceHandler;
+  "payments/collectionPlan/defaultRules": typeof payments_collectionPlan_defaultRules;
   "payments/collectionPlan/engine": typeof payments_collectionPlan_engine;
   "payments/collectionPlan/execution": typeof payments_collectionPlan_execution;
   "payments/collectionPlan/executionContract": typeof payments_collectionPlan_executionContract;
   "payments/collectionPlan/executionGuards": typeof payments_collectionPlan_executionGuards;
+  "payments/collectionPlan/initialScheduling": typeof payments_collectionPlan_initialScheduling;
   "payments/collectionPlan/mutations": typeof payments_collectionPlan_mutations;
   "payments/collectionPlan/queries": typeof payments_collectionPlan_queries;
   "payments/collectionPlan/rules/lateFeeRule": typeof payments_collectionPlan_rules_lateFeeRule;
@@ -490,6 +495,7 @@ declare const fullApi: ApiFromModules<{
   "payments/payout/queries": typeof payments_payout_queries;
   "payments/payout/refs": typeof payments_payout_refs;
   "payments/payout/validators": typeof payments_payout_validators;
+  "payments/transfers/collectionAttemptReconciliation": typeof payments_transfers_collectionAttemptReconciliation;
   "payments/transfers/depositCollection": typeof payments_transfers_depositCollection;
   "payments/transfers/interface": typeof payments_transfers_interface;
   "payments/transfers/mockProviders": typeof payments_transfers_mockProviders;

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -202,6 +202,7 @@ import type * as payments_collectionPlan_executionGuards from "../payments/colle
 import type * as payments_collectionPlan_initialScheduling from "../payments/collectionPlan/initialScheduling.js";
 import type * as payments_collectionPlan_mutations from "../payments/collectionPlan/mutations.js";
 import type * as payments_collectionPlan_queries from "../payments/collectionPlan/queries.js";
+import type * as payments_collectionPlan_ruleContract from "../payments/collectionPlan/ruleContract.js";
 import type * as payments_collectionPlan_rules_lateFeeRule from "../payments/collectionPlan/rules/lateFeeRule.js";
 import type * as payments_collectionPlan_rules_retryRule from "../payments/collectionPlan/rules/retryRule.js";
 import type * as payments_collectionPlan_rules_scheduleRule from "../payments/collectionPlan/rules/scheduleRule.js";
@@ -471,6 +472,7 @@ declare const fullApi: ApiFromModules<{
   "payments/collectionPlan/initialScheduling": typeof payments_collectionPlan_initialScheduling;
   "payments/collectionPlan/mutations": typeof payments_collectionPlan_mutations;
   "payments/collectionPlan/queries": typeof payments_collectionPlan_queries;
+  "payments/collectionPlan/ruleContract": typeof payments_collectionPlan_ruleContract;
   "payments/collectionPlan/rules/lateFeeRule": typeof payments_collectionPlan_rules_lateFeeRule;
   "payments/collectionPlan/rules/retryRule": typeof payments_collectionPlan_rules_retryRule;
   "payments/collectionPlan/rules/scheduleRule": typeof payments_collectionPlan_rules_scheduleRule;

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -45,6 +45,7 @@ import type * as crm_systemAdapters_bootstrap from "../crm/systemAdapters/bootst
 import type * as crm_systemAdapters_columnResolver from "../crm/systemAdapters/columnResolver.js";
 import type * as crm_systemAdapters_queryAdapter from "../crm/systemAdapters/queryAdapter.js";
 import type * as crm_types from "../crm/types.js";
+import type * as crm_userSavedViews from "../crm/userSavedViews.js";
 import type * as crm_validators from "../crm/validators.js";
 import type * as crm_valueRouter from "../crm/valueRouter.js";
 import type * as crm_viewDefs from "../crm/viewDefs.js";
@@ -315,6 +316,7 @@ declare const fullApi: ApiFromModules<{
   "crm/systemAdapters/columnResolver": typeof crm_systemAdapters_columnResolver;
   "crm/systemAdapters/queryAdapter": typeof crm_systemAdapters_queryAdapter;
   "crm/types": typeof crm_types;
+  "crm/userSavedViews": typeof crm_userSavedViews;
   "crm/validators": typeof crm_validators;
   "crm/valueRouter": typeof crm_valueRouter;
   "crm/viewDefs": typeof crm_viewDefs;

--- a/convex/crm/__tests__/helpers.ts
+++ b/convex/crm/__tests__/helpers.ts
@@ -135,7 +135,7 @@ export async function seedObjectWithFields(
 	const views = await admin.query(api.crm.viewDefs.listViews, {
 		objectDefId,
 	});
-	const defaultView = views.find((v) => v.isDefault);
+	const defaultView = views.find((v: (typeof views)[number]) => v.isDefault);
 	if (!defaultView) {
 		throw new Error("Expected auto-created default view, but none found");
 	}

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -24,6 +24,17 @@ crons.daily(
 	internal.payments.obligations.crons.processObligationTransitions
 );
 
+// Collection plan execution spine: discover due planned entries and execute
+// them through the canonical page-02 contract. Runs in bounded batches and
+// relies on plan-entry consumption plus business-layer idempotency for replay
+// safety across cron reruns.
+crons.interval(
+	"collection plan execution spine",
+	{ minutes: 15 },
+	internal.payments.collectionPlan.runner.processDuePlanEntries,
+	{}
+);
+
 // Dispersal self-healing: detect settled obligations missing dispersal entries.
 // Runs every 15 minutes to catch scheduler.runAfter(0) failures quickly.
 // See Tech Design §6.4 and Integration Foot Gun I1.

--- a/convex/engine/effects/__tests__/transfer.test.ts
+++ b/convex/engine/effects/__tests__/transfer.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it, vi } from "vitest";
+import auditLogTest from "convex-audit-log/test";
+import { afterAll, describe, expect, it, vi } from "vitest";
 import type { Id } from "../../../_generated/dataModel";
 import type { MutationCtx } from "../../../_generated/server";
 import {
@@ -9,7 +10,6 @@ import {
 	type TestHarness,
 } from "../../../payments/cashLedger/__tests__/testUtils";
 import { convexModules } from "../../../test/moduleMaps";
-import { registerAuditLogComponent } from "../../../test/registerAuditLogComponent";
 import { effectRegistry } from "../registry";
 import {
 	publishTransferConfirmed,
@@ -21,6 +21,13 @@ import {
 const modules = convexModules;
 const NO_DIRECTION_RE = /has no direction set/;
 const NO_JOURNAL_ENTRY_RE = /No journal entry found for NON-bridged transfer/;
+
+vi.useFakeTimers();
+
+afterAll(() => {
+	vi.clearAllTimers();
+	vi.useRealTimers();
+});
 
 interface TransferEffectArgs {
 	effectName: string;
@@ -47,7 +54,7 @@ const publishTransferReversedMutation =
 
 function createTransferHarness() {
 	const t = createHarness(modules);
-	registerAuditLogComponent(t, "auditLog");
+	auditLogTest.register(t, "auditLog");
 	return t;
 }
 

--- a/convex/engine/effects/collectionAttempt.ts
+++ b/convex/engine/effects/collectionAttempt.ts
@@ -59,6 +59,42 @@ async function loadAttemptAndPlanEntry(
 	return { attempt, planEntry };
 }
 
+async function scheduleCollectionFailedRuleEvaluation(
+	ctx: MutationCtx,
+	args: CollectionAttemptEffectArgs,
+	attempt: {
+		amount: number;
+		method: string;
+		planEntryId: Id<"collectionPlanEntries">;
+		machineContext?: Record<string, unknown>;
+	},
+	planEntry: { obligationIds: Id<"obligations">[] },
+	effectLabel: string
+) {
+	await ctx.scheduler.runAfter(
+		0,
+		internal.payments.collectionPlan.engine.evaluateRules,
+		{
+			trigger: "event" as const,
+			eventType: "COLLECTION_FAILED",
+			eventPayload: {
+				planEntryId: attempt.planEntryId,
+				obligationIds: planEntry.obligationIds,
+				amount: attempt.amount,
+				method: attempt.method,
+				retryCount:
+					typeof attempt.machineContext?.retryCount === "number"
+						? attempt.machineContext.retryCount
+						: 0,
+			},
+		}
+	);
+
+	console.info(
+		`[${effectLabel}] Scheduled COLLECTION_FAILED rules evaluation for attempt=${args.entityId}`
+	);
+}
+
 /**
  * Cross-entity effect: fires PAYMENT_APPLIED at each linked obligation.
  * Triggered when a collection attempt transitions to `confirmed` via FUNDS_SETTLED.
@@ -147,65 +183,71 @@ export const emitPaymentReceived = internalMutation({
 		// Decision D4: Bridged transfers skip cash posting in publishTransferConfirmed
 		// because the collection attempt path already posted via postCashReceiptForObligation().
 		//
-		// The bridge creates the transfer at "initiated" then immediately fires
-		// FUNDS_SETTLED via executeTransition, maintaining GT compliance:
-		// audit journal, hash chain, and effect scheduling all go through the engine.
-		const bridgeIdempotencyKey = `transfer:bridge:${args.entityId}`;
-		const existingBridge = await ctx.db
-			.query("transferRequests")
-			.withIndex("by_idempotency", (q) =>
-				q.eq("idempotencyKey", bridgeIdempotencyKey)
-			)
-			.first();
+		// The page-03 execution spine links real transfer requests directly onto the
+		// attempt. When that canonical linkage exists, skip the legacy bridge path to
+		// avoid duplicate transfer records for the same collection attempt.
+		if (attempt.transferRequestId) {
+			console.info(
+				`[emitPaymentReceived] Attempt ${args.entityId} already linked to transfer ${attempt.transferRequestId}; skipping legacy bridge transfer creation.`
+			);
+		} else {
+			const bridgeIdempotencyKey = `transfer:bridge:${args.entityId}`;
+			const existingBridge = await ctx.db
+				.query("transferRequests")
+				.withIndex("by_idempotency", (q) =>
+					q.eq("idempotencyKey", bridgeIdempotencyKey)
+				)
+				.first();
 
-		if (!existingBridge) {
-			const firstOblForBridge = await ctx.db.get(planEntry.obligationIds[0]);
-			if (firstOblForBridge?.borrowerId) {
-				const now = Date.now();
-				const bridgeOrgId =
-					firstOblForBridge.orgId ??
-					(firstOblForBridge.mortgageId
-						? await orgIdFromMortgageId(ctx, firstOblForBridge.mortgageId)
-						: undefined);
-				const bridgeTransferId = await ctx.db.insert("transferRequests", {
-					orgId: bridgeOrgId,
-					status: "initiated",
-					direction: "inbound",
-					transferType: obligationTypeToTransferType(firstOblForBridge.type),
-					amount: attempt.amount,
-					currency: "CAD",
-					counterpartyType: "borrower",
-					counterpartyId: String(firstOblForBridge.borrowerId),
-					mortgageId: firstOblForBridge.mortgageId,
-					obligationId: planEntry.obligationIds[0],
-					planEntryId: planEntry._id,
-					collectionAttemptId: args.entityId,
-					providerCode: (PROVIDER_CODES as readonly string[]).includes(
-						planEntry.method ?? ""
-					)
-						? (planEntry.method as (typeof PROVIDER_CODES)[number])
-						: "manual",
-					providerRef: attempt.providerRef ?? `bridge_${args.entityId}`,
-					idempotencyKey: bridgeIdempotencyKey,
-					source: args.source,
-					createdAt: now,
-					lastTransitionAt: now,
-				});
+			if (!existingBridge) {
+				const firstOblForBridge = await ctx.db.get(planEntry.obligationIds[0]);
+				if (firstOblForBridge?.borrowerId) {
+					const now = Date.now();
+					const bridgeOrgId =
+						firstOblForBridge.orgId ??
+						(firstOblForBridge.mortgageId
+							? await orgIdFromMortgageId(ctx, firstOblForBridge.mortgageId)
+							: undefined);
+					const bridgeTransferId = await ctx.db.insert("transferRequests", {
+						orgId: bridgeOrgId,
+						status: "initiated",
+						direction: "inbound",
+						transferType: obligationTypeToTransferType(firstOblForBridge.type),
+						amount: attempt.amount,
+						currency: "CAD",
+						counterpartyType: "borrower",
+						counterpartyId: String(firstOblForBridge.borrowerId),
+						mortgageId: firstOblForBridge.mortgageId,
+						obligationId: planEntry.obligationIds[0],
+						planEntryId: planEntry._id,
+						collectionAttemptId: args.entityId,
+						providerCode: (PROVIDER_CODES as readonly string[]).includes(
+							planEntry.method ?? ""
+						)
+							? (planEntry.method as (typeof PROVIDER_CODES)[number])
+							: "manual",
+						providerRef: attempt.providerRef ?? `bridge_${args.entityId}`,
+						idempotencyKey: bridgeIdempotencyKey,
+						source: args.source,
+						createdAt: now,
+						lastTransitionAt: now,
+					});
 
-				// Fire GT transition to reach confirmed state — creates audit journal
-				// + hash chain entry. publishTransferConfirmed will see collectionAttemptId
-				// and skip cash posting (D4 conditional).
-				await executeTransition(ctx, {
-					entityType: "transfer",
-					entityId: bridgeTransferId,
-					eventType: "FUNDS_SETTLED",
-					payload: { settledAt: now, providerData: { bridged: true } },
-					source: args.source,
-				});
-			} else {
-				console.warn(
-					`[emitPaymentReceived] Cannot create bridge transfer for attempt=${args.entityId}: no borrowerId on obligation ${planEntry.obligationIds[0]}`
-				);
+					// Fire GT transition to reach confirmed state — creates audit journal
+					// + hash chain entry. publishTransferConfirmed will see
+					// collectionAttemptId and skip cash posting (D4 conditional).
+					await executeTransition(ctx, {
+						entityType: "transfer",
+						entityId: bridgeTransferId,
+						eventType: "FUNDS_SETTLED",
+						payload: { settledAt: now, providerData: { bridged: true } },
+						source: args.source,
+					});
+				} else {
+					console.warn(
+						`[emitPaymentReceived] Cannot create bridge transfer for attempt=${args.entityId}: no borrowerId on obligation ${planEntry.obligationIds[0]}`
+					);
+				}
 			}
 		}
 	},
@@ -224,27 +266,31 @@ export const emitCollectionFailed = internalMutation({
 			"emitCollectionFailed"
 		);
 
-		await ctx.scheduler.runAfter(
-			0,
-			internal.payments.collectionPlan.engine.evaluateRules,
-			{
-				trigger: "event" as const,
-				eventType: "COLLECTION_FAILED",
-				eventPayload: {
-					planEntryId: attempt.planEntryId,
-					obligationIds: planEntry.obligationIds,
-					amount: attempt.amount,
-					method: attempt.method,
-					retryCount:
-						typeof attempt.machineContext?.retryCount === "number"
-							? attempt.machineContext.retryCount
-							: 0,
-				},
-			}
+		await scheduleCollectionFailedRuleEvaluation(
+			ctx,
+			args,
+			attempt,
+			planEntry,
+			"emitCollectionFailed"
+		);
+	},
+});
+
+export const scheduleRetryEntry = internalMutation({
+	args: collectionAttemptEffectValidator,
+	handler: async (ctx, args) => {
+		const { attempt, planEntry } = await loadAttemptAndPlanEntry(
+			ctx,
+			args,
+			"scheduleRetryEntry"
 		);
 
-		console.info(
-			`[emitCollectionFailed] Scheduled COLLECTION_FAILED rules evaluation for attempt=${args.entityId}`
+		await scheduleCollectionFailedRuleEvaluation(
+			ctx,
+			args,
+			attempt,
+			planEntry,
+			"scheduleRetryEntry"
 		);
 	},
 });

--- a/convex/engine/effects/collectionAttempt.ts
+++ b/convex/engine/effects/collectionAttempt.ts
@@ -71,11 +71,26 @@ async function scheduleCollectionFailedRuleEvaluation(
 	planEntry: { obligationIds: Id<"obligations">[] },
 	effectLabel: string
 ) {
+	const firstObligationId = planEntry.obligationIds[0];
+	if (!firstObligationId) {
+		throw new Error(
+			`[${effectLabel}] Cannot schedule COLLECTION_FAILED rules evaluation without a linked obligation (attempt=${args.entityId})`
+		);
+	}
+
+	const firstObligation = await ctx.db.get(firstObligationId);
+	if (!firstObligation) {
+		throw new Error(
+			`[${effectLabel}] Linked obligation not found for attempt=${args.entityId}: ${firstObligationId}`
+		);
+	}
+
 	await ctx.scheduler.runAfter(
 		0,
 		internal.payments.collectionPlan.engine.evaluateRules,
 		{
 			trigger: "event" as const,
+			mortgageId: firstObligation.mortgageId,
 			eventType: "COLLECTION_FAILED",
 			eventPayload: {
 				planEntryId: attempt.planEntryId,

--- a/convex/engine/effects/registry.ts
+++ b/convex/engine/effects/registry.ts
@@ -55,6 +55,8 @@ export const effectRegistry: Record<
 	// Collection Attempt effects (ENG-64)
 	emitPaymentReceived:
 		internal.engine.effects.collectionAttempt.emitPaymentReceived,
+	scheduleRetryEntry:
+		internal.engine.effects.collectionAttempt.scheduleRetryEntry,
 	emitCollectionFailed:
 		internal.engine.effects.collectionAttempt.emitCollectionFailed,
 	recordProviderRef:

--- a/convex/engine/effects/registry.ts
+++ b/convex/engine/effects/registry.ts
@@ -71,6 +71,8 @@ export const effectRegistry: Record<
 		internal.engine.effects.transfer.recordTransferProviderRef,
 	publishTransferConfirmed:
 		internal.engine.effects.transfer.publishTransferConfirmed,
+	publishTransferCancelled:
+		internal.engine.effects.transfer.publishTransferCancelled,
 	publishTransferFailed: internal.engine.effects.transfer.publishTransferFailed,
 	publishTransferReversed:
 		internal.engine.effects.transfer.publishTransferReversed,

--- a/convex/engine/effects/transfer.ts
+++ b/convex/engine/effects/transfer.ts
@@ -9,6 +9,12 @@ import {
 	postLenderPayoutForTransfer,
 	postTransferReversal,
 } from "../../payments/cashLedger/integrations";
+import {
+	reconcileAttemptLinkedInboundCancellation,
+	reconcileAttemptLinkedInboundFailure,
+	reconcileAttemptLinkedInboundReversal,
+	reconcileAttemptLinkedInboundSettlement,
+} from "../../payments/transfers/collectionAttemptReconciliation";
 import { extractLeg1Metadata } from "../../payments/transfers/pipeline.types";
 import type { ProviderCode } from "../../payments/transfers/types";
 import { PROVIDER_CODES } from "../../payments/transfers/types";
@@ -100,10 +106,21 @@ export const publishTransferConfirmed = internalMutation({
 		// Persist settledAt BEFORE posting cash so posting helpers see the authoritative timestamp.
 		await ctx.db.patch(args.entityId, { settledAt });
 
-		// D4: bridged transfer — cash posted via collection attempt path
-		if (transfer.collectionAttemptId) {
+		const reconciledAttempt = await reconcileAttemptLinkedInboundSettlement(
+			ctx,
+			{
+				transfer,
+				settledAt,
+				source: args.source,
+			}
+		);
+
+		// Attempt-linked inbound transfers keep business settlement and cash posting
+		// on the Collection Attempt path. Outbound and non-attempt-linked transfers
+		// still post directly from the transfer effect.
+		if (reconciledAttempt) {
 			console.info(
-				`[publishTransferConfirmed] Bridged transfer ${args.entityId} — cash posted via collection attempt path. Skipping.`
+				`[publishTransferConfirmed] Attempt-linked inbound transfer ${args.entityId} reconciled through collection attempt settlement. Skipping transfer-owned cash posting.`
 			);
 		} else if (transfer.direction === "inbound") {
 			await postCashReceiptForTransfer(ctx, {
@@ -368,6 +385,13 @@ export const publishTransferFailed = internalMutation({
 			failureCode: errorCode,
 		});
 
+		await reconcileAttemptLinkedInboundFailure(ctx, {
+			transfer,
+			failureCode: errorCode,
+			failureReason: reason,
+			source: args.source,
+		});
+
 		console.warn(
 			`[publishTransferFailed] Transfer ${args.entityId} failed: ${reason} (${errorCode})`
 		);
@@ -430,6 +454,36 @@ export const publishTransferFailed = internalMutation({
 			reason,
 			errorCode
 		);
+	},
+});
+
+/**
+ * Mirrors transfer cancellation back onto the linked Collection Attempt for
+ * canonical inbound collection executions.
+ */
+export const publishTransferCancelled = internalMutation({
+	args: transferEffectValidator,
+	handler: async (ctx, args) => {
+		const transfer = await loadTransfer(ctx, args, "publishTransferCancelled");
+		const reason =
+			typeof args.payload?.reason === "string"
+				? args.payload.reason
+				: "transfer_cancelled";
+
+		const reconciledAttempt = await reconcileAttemptLinkedInboundCancellation(
+			ctx,
+			{
+				transfer,
+				reason,
+				source: args.source,
+			}
+		);
+
+		if (reconciledAttempt) {
+			console.info(
+				`[publishTransferCancelled] Attempt-linked inbound transfer ${args.entityId} cancelled its linked collection attempt.`
+			);
+		}
 	},
 });
 
@@ -524,10 +578,21 @@ export const publishTransferReversed = internalMutation({
 			typeof args.payload?.reason === "string"
 				? args.payload.reason
 				: "transfer_reversed";
+		const effectiveDate =
+			typeof args.payload?.effectiveDate === "string"
+				? args.payload.effectiveDate
+				: new Date().toISOString().slice(0, 10);
 
 		await ctx.db.patch(args.entityId, {
 			reversedAt: Date.now(),
 			reversalRef,
+		});
+
+		await reconcileAttemptLinkedInboundReversal(ctx, {
+			transfer,
+			reason,
+			effectiveDate,
+			source: args.source,
 		});
 
 		// Look up original journal entry for cash reversal
@@ -539,7 +604,6 @@ export const publishTransferReversed = internalMutation({
 			.first();
 
 		if (originalEntry) {
-			const effectiveDate = new Date().toISOString().slice(0, 10);
 			const journalAmount = safeBigintToNumber(originalEntry.amount);
 			const amount = transfer.amount ?? journalAmount;
 

--- a/convex/engine/machines/__tests__/collectionAttempt.test.ts
+++ b/convex/engine/machines/__tests__/collectionAttempt.test.ts
@@ -86,9 +86,9 @@ describe("collectionAttempt machine", () => {
 		expect(collectionAttemptMachine.id).toBe("collectionAttempt");
 	});
 
-	it("has version 1.1.0", () => {
-		expect(collectionAttemptMachine.version).toBe("1.1.0");
-		expect(COLLECTION_ATTEMPT_MACHINE_VERSION).toBe("1.1.0");
+	it("has version 1.2.0", () => {
+		expect(collectionAttemptMachine.version).toBe("1.2.0");
+		expect(COLLECTION_ATTEMPT_MACHINE_VERSION).toBe("1.2.0");
 	});
 
 	it("confirmed is NOT a final state (has outbound PAYMENT_REVERSED transition)", () => {
@@ -148,14 +148,15 @@ describe("collectionAttempt machine", () => {
 			expect(actions.map((a) => a.type)).toContain("emitPaymentReceived");
 		});
 
-		it("initiated ignores DRAW_FAILED", () => {
+		it("initiated -> failed on DRAW_FAILED increments retryCount", () => {
 			const [next, actions] = transition(
 				collectionAttemptMachine,
 				snapshotAt("initiated"),
 				DRAW_FAILED
 			);
-			expect(next.value).toBe("initiated");
+			expect(next.value).toBe("failed");
 			expect(actions).toHaveLength(0);
+			expect(next.context.retryCount).toBe(1);
 		});
 
 		it("initiated ignores RETRY_ELIGIBLE", () => {

--- a/convex/engine/machines/__tests__/collectionAttempt.test.ts
+++ b/convex/engine/machines/__tests__/collectionAttempt.test.ts
@@ -568,7 +568,7 @@ describe("collectionAttempt machine", () => {
 	// ── Happy path integration tests ────────────────────────────────
 
 	describe("happy paths", () => {
-		it("ManualPaymentMethod path: initiated -> confirmed (skips pending)", () => {
+		it("legacy manual compatibility path: initiated -> confirmed (skips pending)", () => {
 			const [next, actions] = transition(
 				collectionAttemptMachine,
 				snapshotAt("initiated"),

--- a/convex/engine/machines/__tests__/transfer.machine.test.ts
+++ b/convex/engine/machines/__tests__/transfer.machine.test.ts
@@ -118,14 +118,16 @@ describe("transfer machine", () => {
 			expect(actions.map((a) => a.type)).toContain("publishTransferConfirmed");
 		});
 
-		it("initiated -> cancelled on TRANSFER_CANCELLED", () => {
+		it("initiated -> cancelled on TRANSFER_CANCELLED fires publishTransferCancelled", () => {
 			const [next, actions] = transition(
 				transferMachine,
 				snapshotAt("initiated"),
 				TRANSFER_CANCELLED
 			);
 			expect(next.value).toBe("cancelled");
-			expect(actions).toHaveLength(0);
+			expect(actions.map((action) => action.type)).toContain(
+				"publishTransferCancelled"
+			);
 		});
 
 		it("initiated ignores PROVIDER_ACKNOWLEDGED", () => {
@@ -548,7 +550,9 @@ describe("transfer machine", () => {
 				TRANSFER_CANCELLED
 			);
 			expect(next.value).toBe("cancelled");
-			expect(actions).toHaveLength(0);
+			expect(actions.map((action) => action.type)).toContain(
+				"publishTransferCancelled"
+			);
 		});
 
 		it("async reversal path: initiated -> pending -> confirmed -> reversed", () => {

--- a/convex/engine/machines/collectionAttempt.machine.ts
+++ b/convex/engine/machines/collectionAttempt.machine.ts
@@ -1,6 +1,6 @@
 import { assign, setup } from "xstate";
 
-export const COLLECTION_ATTEMPT_MACHINE_VERSION = "1.1.0";
+export const COLLECTION_ATTEMPT_MACHINE_VERSION = "1.2.0";
 
 export const collectionAttemptMachine = setup({
 	types: {
@@ -61,6 +61,10 @@ export const collectionAttemptMachine = setup({
 				DRAW_INITIATED: {
 					target: "pending",
 					actions: ["recordProviderRef"],
+				},
+				DRAW_FAILED: {
+					target: "failed",
+					actions: ["incrementRetryCount"],
 				},
 				FUNDS_SETTLED: {
 					target: "confirmed",

--- a/convex/engine/machines/transfer.machine.ts
+++ b/convex/engine/machines/transfer.machine.ts
@@ -29,6 +29,9 @@ export const transferMachine = setup({
 		publishTransferConfirmed: () => {
 			/* resolved by GT effect registry */
 		},
+		publishTransferCancelled: () => {
+			/* resolved by GT effect registry */
+		},
 		publishTransferFailed: () => {
 			/* resolved by GT effect registry */
 		},
@@ -58,6 +61,7 @@ export const transferMachine = setup({
 				},
 				TRANSFER_CANCELLED: {
 					target: "cancelled",
+					actions: ["publishTransferCancelled"],
 				},
 			},
 		},

--- a/convex/engine/transition.ts
+++ b/convex/engine/transition.ts
@@ -1,7 +1,7 @@
 import type { GenericId } from "convex/values";
 import { ConvexError } from "convex/values";
 import type { AnyStateMachine, StateValue } from "xstate";
-import { getNextSnapshot } from "xstate";
+import { transition as computeTransition } from "xstate";
 import type { TableNames } from "../_generated/dataModel";
 import type { MutationCtx } from "../_generated/server";
 import { auditLog } from "../auditLog";
@@ -30,11 +30,6 @@ function isGovernedEntityType(
 interface ScheduledEffectDescriptor {
 	actionType: string;
 	params?: Record<string, unknown>;
-}
-
-interface MachineConfigStateNode {
-	on?: Record<string, unknown>;
-	states?: Record<string, MachineConfigStateNode>;
 }
 
 function normalizeActionDescriptors(
@@ -71,86 +66,6 @@ function normalizeActionDescriptors(
 	return descriptors;
 }
 
-function getActiveStatePath(stateValue: StateValue): string[] {
-	if (typeof stateValue === "string") {
-		return [stateValue];
-	}
-
-	const entries = Object.entries(stateValue);
-	if (entries.length !== 1) {
-		throw new Error(
-			`extractScheduledEffects only supports a single active state path; got: ${Object.keys(stateValue).join(", ")}`
-		);
-	}
-
-	const [region, subState] = entries[0] as [string, StateValue];
-	if (typeof subState === "string") {
-		return [region, subState];
-	}
-
-	return [region, ...getActiveStatePath(subState)];
-}
-
-function getActiveStateNodes(
-	machine: AnyStateMachine,
-	activeStatePath: string[]
-): MachineConfigStateNode[] {
-	const nodes: MachineConfigStateNode[] = [];
-	let states = machine.config.states as
-		| Record<string, MachineConfigStateNode>
-		| undefined;
-
-	for (const segment of activeStatePath) {
-		if (!states) {
-			break;
-		}
-
-		const stateNode = states[segment];
-		if (!stateNode) {
-			break;
-		}
-
-		nodes.push(stateNode);
-		states = stateNode.states;
-	}
-
-	return nodes;
-}
-
-function extractScheduledEffects(
-	machine: AnyStateMachine,
-	previousStateValue: StateValue,
-	eventType: string
-): ScheduledEffectDescriptor[] {
-	const activeStateNodes = getActiveStateNodes(
-		machine,
-		getActiveStatePath(previousStateValue)
-	);
-	const eventConfig =
-		[...activeStateNodes]
-			.reverse()
-			.find((stateNode) => stateNode.on?.[eventType] !== undefined)?.on?.[
-			eventType
-		] ??
-		(machine.config.on as Record<string, unknown> | undefined)?.[eventType];
-	let candidates: unknown[] = [];
-	if (eventConfig) {
-		candidates = Array.isArray(eventConfig) ? eventConfig : [eventConfig];
-	}
-
-	return candidates.flatMap((candidate) => {
-		if (!candidate || typeof candidate !== "object") {
-			return [];
-		}
-
-		if (!("actions" in candidate)) {
-			return [];
-		}
-
-		return normalizeActionDescriptors(candidate.actions);
-	});
-}
-
 /**
  * Checks whether a named action resolves to an XState built-in action (assign, raise, etc.)
  * rather than an effect-marker action. Built-in actions are executed during the pure COMPUTE
@@ -165,7 +80,7 @@ function isBuiltInAction(
 		return false;
 	}
 	const impl = implementations[actionName];
-	if (!impl || typeof impl !== "object") {
+	if (!impl || (typeof impl !== "object" && typeof impl !== "function")) {
 		return false;
 	}
 	const implType = (impl as { type?: string }).type;
@@ -286,10 +201,12 @@ export async function executeTransition(
 	});
 
 	// ── 4. COMPUTE ───────────────────────────────────────────────────────
-	const event = { ...(payload ?? {}), type: eventType } as Parameters<
-		typeof getNextSnapshot<typeof machine>
-	>[2];
-	const nextSnapshot = getNextSnapshot(machine, currentSnapshot, event);
+	const event = { ...(payload ?? {}), type: eventType };
+	const [nextSnapshot, transitionActions] = computeTransition(
+		machine,
+		currentSnapshot,
+		event
+	);
 	const newStateValue = nextSnapshot.value as StateValue;
 	const newStateSerialized = serializeState(newStateValue);
 
@@ -297,11 +214,7 @@ export async function executeTransition(
 	let journalEntryId = `${entityType}:${entityId}:${eventType}:${Date.now()}-${crypto.randomUUID().slice(0, 8)}`;
 
 	// ── 5. DETECT ────────────────────────────────────────────────────────
-	const scheduledEffects = extractScheduledEffects(
-		machine,
-		previousStateValue,
-		eventType
-	);
+	const scheduledEffects = normalizeActionDescriptors(transitionActions);
 	const hasEffects = scheduledEffects.length > 0;
 
 	if (newStateSerialized === previousStateSerialized) {

--- a/convex/payments/__tests__/methods.test.ts
+++ b/convex/payments/__tests__/methods.test.ts
@@ -20,7 +20,10 @@ const MANUAL_REF_PATTERN =
 	/^manual_entry_789_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
 const MOCK_PAD_REF_PATTERN =
 	/^mock_pad_entry_789_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
-const UNKNOWN_METHOD_PATTERN = /Unknown payment method: "stripe_ach"/;
+const UNKNOWN_METHOD_PATTERN =
+	/Unknown legacy payment method: "stripe_ach".*TransferProvider/;
+const TRANSFER_ONLY_METHOD_PATTERN =
+	/Unknown legacy payment method: "mock_eft".*TransferProvider/;
 
 const sampleParams: InitiateParams = {
 	amount: 100_000, // $1000 in cents
@@ -31,10 +34,10 @@ const sampleParams: InitiateParams = {
 };
 
 // ---------------------------------------------------------------------------
-// ManualPaymentMethod
+// ManualPaymentMethod compatibility surface
 // ---------------------------------------------------------------------------
 
-describe("ManualPaymentMethod", () => {
+describe("ManualPaymentMethod compatibility surface", () => {
 	let method: ManualPaymentMethod;
 
 	beforeEach(() => {
@@ -77,10 +80,10 @@ describe("ManualPaymentMethod", () => {
 });
 
 // ---------------------------------------------------------------------------
-// MockPADMethod
+// MockPADMethod compatibility surface
 // ---------------------------------------------------------------------------
 
-describe("MockPADMethod", () => {
+describe("MockPADMethod compatibility surface", () => {
 	let scheduler: ScheduleSettlementFn;
 
 	beforeEach(() => {
@@ -237,10 +240,10 @@ describe("MockPADMethod", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Method Registry
+// PaymentMethod compatibility registry
 // ---------------------------------------------------------------------------
 
-describe("Method Registry", () => {
+describe("PaymentMethod compatibility registry", () => {
 	afterEach(() => {
 		vi.restoreAllMocks();
 	});
@@ -262,6 +265,12 @@ describe("Method Registry", () => {
 	it("error message includes the unknown method name", () => {
 		expect(() => getPaymentMethod("stripe_ach")).toThrow(
 			UNKNOWN_METHOD_PATTERN
+		);
+	});
+
+	it("rejects transfer-provider-only mock codes from the legacy registry", () => {
+		expect(() => getPaymentMethod("mock_eft")).toThrow(
+			TRANSFER_ONLY_METHOD_PATTERN
 		);
 	});
 

--- a/convex/payments/__tests__/rules.test.ts
+++ b/convex/payments/__tests__/rules.test.ts
@@ -22,8 +22,17 @@ function mockRule(
 	return {
 		_id: "rule_1" as Id<"collectionRules">,
 		_creationTime: Date.now(),
+		kind: "schedule",
+		code: "schedule_rule",
+		displayName: "Initial scheduling",
+		description:
+			"Creates initial collection plan entries for upcoming obligations.",
 		name: "schedule_rule",
+		status: "active",
+		scope: { scopeType: "global" },
 		trigger: "schedule",
+		config: { kind: "schedule", delayDays: 5 },
+		version: 1,
 		action: "create_plan_entry",
 		parameters: { delayDays: 5 },
 		priority: 10,
@@ -88,7 +97,10 @@ describe("ScheduleRule", () => {
 
 	it("uses the rule delayDays parameter when delegating", async () => {
 		await scheduleRuleHandler.evaluate(ctx, {
-			rule: mockRule({ parameters: { delayDays: 9 } }),
+			rule: mockRule({
+				config: { kind: "schedule", delayDays: 9 },
+				parameters: { delayDays: 5 },
+			}),
 			mortgageId: "mortgage_1" as Id<"mortgages">,
 		});
 
@@ -123,8 +135,17 @@ describe("RetryRule", () => {
 	): RuleEvalContext {
 		return {
 			rule: mockRule({
+				kind: "retry",
+				code: "retry_rule",
+				displayName: "Retry collection",
+				description:
+					"Schedules retry collection plan entries after failed attempts.",
 				name: "retry_rule",
+				status: "active",
+				scope: { scopeType: "global" },
 				trigger: "event",
+				config: { kind: "retry", maxRetries: 3, backoffBaseDays: 3 },
+				version: 1,
 				action: "create_retry_entry",
 				parameters: { maxRetries: 3, backoffBaseDays: 3 },
 				priority: 20,
@@ -176,8 +197,15 @@ describe("RetryRule", () => {
 	it("exponential backoff calculation: verify delay pattern", async () => {
 		const backoffBaseDays = 3;
 		const rule = mockRule({
+			kind: "retry",
+			code: "retry_rule",
+			displayName: "Retry collection",
 			name: "retry_rule",
+			status: "active",
+			scope: { scopeType: "global" },
 			trigger: "event",
+			config: { kind: "retry", maxRetries: 5, backoffBaseDays },
+			version: 1,
 			action: "create_retry_entry",
 			parameters: { maxRetries: 5, backoffBaseDays },
 			priority: 20,
@@ -258,10 +286,22 @@ describe("LateFeeRule", () => {
 	): RuleEvalContext {
 		return {
 			rule: mockRule({
+				kind: "late_fee",
+				code: "late_fee_rule",
+				displayName: "Late fee assessment",
+				description: "Creates late-fee obligations after overdue events.",
 				name: "late_fee_rule",
+				status: "active",
+				scope: { scopeType: "global" },
 				trigger: "event",
+				config: {
+					kind: "late_fee",
+					feeCode: "late_fee",
+					feeSurface: "borrower_charge",
+				},
+				version: 1,
 				action: "create_late_fee",
-				parameters: { feeAmountCents: 5000, dueDays: 30, graceDays: 45 },
+				parameters: {},
 				priority: 30,
 			}),
 			eventType: "OBLIGATION_OVERDUE",

--- a/convex/payments/__tests__/rules.test.ts
+++ b/convex/payments/__tests__/rules.test.ts
@@ -59,101 +59,47 @@ function mockObligation(
 // ---------------------------------------------------------------------------
 
 describe("ScheduleRule", () => {
-	let runQuery: ReturnType<typeof vi.fn>;
 	let runMutation: ReturnType<typeof vi.fn>;
 	let ctx: ActionCtx;
 	let rule: Doc<"collectionRules">;
 
 	beforeEach(() => {
-		runQuery = vi.fn();
 		runMutation = vi.fn().mockResolvedValue("mock_entry_id");
-		ctx = { runQuery, runMutation } as unknown as ActionCtx;
+		ctx = { runMutation } as unknown as ActionCtx;
 		rule = mockRule();
 	});
 
-	it("creates plan entry for obligation due within window", async () => {
-		const obligation = mockObligation();
-
-		// getUpcomingInWindow -> returns the obligation
-		runQuery.mockResolvedValueOnce([obligation]);
-		// getPlannedEntriesForObligations -> no existing entries (empty record)
-		runQuery.mockResolvedValueOnce({});
-
-		await scheduleRuleHandler.evaluate(ctx, { rule });
+	it("delegates canonical initial scheduling to the shared scheduling mutation", async () => {
+		await scheduleRuleHandler.evaluate(ctx, {
+			rule,
+			mortgageId: "mortgage_1" as Id<"mortgages">,
+		});
 
 		expect(runMutation).toHaveBeenCalledOnce();
 		expect(runMutation).toHaveBeenCalledWith(
-			expect.anything(), // internal.payments.collectionPlan.mutations.createEntry
+			expect.anything(),
 			expect.objectContaining({
-				obligationIds: [obligation._id],
-				amount: obligation.amount,
-				method: "manual",
-				status: "planned",
-				source: "default_schedule",
+				mortgageId: "mortgage_1",
+				delayDays: 5,
 				ruleId: rule._id,
 			})
 		);
 	});
 
-	it("skips obligation with existing plan entry (idempotency)", async () => {
-		const obligation = mockObligation();
-
-		// getUpcomingInWindow -> returns the obligation
-		runQuery.mockResolvedValueOnce([obligation]);
-		// getPlannedEntriesForObligations -> obligation already covered
-		runQuery.mockResolvedValueOnce({
-			[obligation._id]: "existing_entry" as Id<"collectionPlanEntries">,
-		});
-
-		await scheduleRuleHandler.evaluate(ctx, { rule });
-
-		expect(runMutation).not.toHaveBeenCalled();
-	});
-
-	it("respects delayDays parameter: obligation too far in future produces no entry", async () => {
-		// getUpcomingInWindow with dueBefore = now + 5 days would NOT include
-		// an obligation 20 days away, so the query returns an empty array
-		runQuery.mockResolvedValueOnce([]);
-
-		await scheduleRuleHandler.evaluate(ctx, { rule });
-
-		expect(runMutation).not.toHaveBeenCalled();
-	});
-
-	it('uses "manual" as default method', async () => {
-		const obligation = mockObligation();
-
-		runQuery.mockResolvedValueOnce([obligation]);
-		// getPlannedEntriesForObligations -> no existing entries
-		runQuery.mockResolvedValueOnce({});
-
-		await scheduleRuleHandler.evaluate(ctx, { rule });
-
-		const mutationArgs = runMutation.mock.calls[0][1] as Record<
-			string,
-			unknown
-		>;
-		expect(mutationArgs.method).toBe("manual");
-	});
-
-	it("sets correct scheduledDate (dueDate - delayDays * MS_PER_DAY)", async () => {
-		const dueDate = Date.now() + 4 * MS_PER_DAY;
-		const delayDays = 5;
-		const obligation = mockObligation({ dueDate });
-
-		runQuery.mockResolvedValueOnce([obligation]);
-		// getPlannedEntriesForObligations -> no existing entries
-		runQuery.mockResolvedValueOnce({});
-
+	it("uses the rule delayDays parameter when delegating", async () => {
 		await scheduleRuleHandler.evaluate(ctx, {
-			rule: mockRule({ parameters: { delayDays } }),
+			rule: mockRule({ parameters: { delayDays: 9 } }),
+			mortgageId: "mortgage_1" as Id<"mortgages">,
 		});
 
-		const mutationArgs = runMutation.mock.calls[0][1] as Record<
-			string,
-			unknown
-		>;
-		expect(mutationArgs.scheduledDate).toBe(dueDate - delayDays * MS_PER_DAY);
+		expect(runMutation).toHaveBeenCalledOnce();
+		expect(runMutation).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({
+				mortgageId: "mortgage_1",
+				delayDays: 9,
+			})
+		);
 	});
 });
 

--- a/convex/payments/cashLedger/__tests__/transferReconciliation.test.ts
+++ b/convex/payments/cashLedger/__tests__/transferReconciliation.test.ts
@@ -1,13 +1,14 @@
+import auditLogTest from "convex-audit-log/test";
 import { convexTest } from "convex-test";
 import { describe, expect, it, vi } from "vitest";
 import { internal } from "../../../_generated/api";
+import type { Id } from "../../../_generated/dataModel";
 import auditTrailSchema from "../../../components/auditTrail/schema";
 import schema from "../../../schema";
 import {
 	convexModules,
 	auditTrailModules as sharedAuditTrailModules,
 } from "../../../test/moduleMaps";
-import { registerAuditLogComponent } from "../../../test/registerAuditLogComponent";
 import {
 	checkOrphanedConfirmedTransfers,
 	checkOrphanedReversedTransfers,
@@ -18,6 +19,7 @@ import {
 import { buildIdempotencyKey } from "../types";
 import {
 	createConfirmedTransfer,
+	createDueObligation,
 	createHarness,
 	createReversedTransfer,
 	createTestAccount,
@@ -37,9 +39,38 @@ const auditTrailModules = sharedAuditTrailModules;
 function createComponentHarness(): TestHarness {
 	process.env.DISABLE_CASH_LEDGER_HASHCHAIN = "true";
 	const t = convexTest(schema, modules);
-	registerAuditLogComponent(t, "auditLog");
+	auditLogTest.register(t, "auditLog");
 	t.registerComponent("auditTrail", auditTrailSchema, auditTrailModules);
 	return t;
+}
+
+async function createConfirmedAttempt(
+	t: TestHarness,
+	args: {
+		obligationId: Id<"obligations">;
+		amount: number;
+	}
+) {
+	return t.run(async (ctx) => {
+		const planEntryId = await ctx.db.insert("collectionPlanEntries", {
+			obligationIds: [args.obligationId],
+			amount: args.amount,
+			method: "manual",
+			scheduledDate: Date.parse("2026-03-15T00:00:00Z"),
+			status: "completed",
+			source: "default_schedule",
+			createdAt: Date.now(),
+		});
+
+		return ctx.db.insert("collectionAttempts", {
+			planEntryId,
+			amount: args.amount,
+			method: "manual",
+			status: "confirmed",
+			machineContext: { retryCount: 0, maxRetries: 3 },
+			initiatedAt: Date.now(),
+		});
+	});
 }
 
 // ── T-017: checkOrphanedConfirmedTransfers ─────────────────────
@@ -105,6 +136,65 @@ describe("checkOrphanedConfirmedTransfers", () => {
 		expect(result.isHealthy).toBe(false);
 		expect(result.count).toBe(1);
 		expect(result.items[0]?.amount).toBe(50_000);
+	});
+
+	it("treats attempt-linked inbound transfers as healthy when attempt-owned cash receipt exists", async () => {
+		const t = createHarness(modules);
+		const seeded = await seedMinimalEntities(t);
+		const obligationId = await createDueObligation(t, {
+			mortgageId: seeded.mortgageId,
+			borrowerId: seeded.borrowerId,
+			amount: 50_000,
+		});
+		const attemptId = await createConfirmedAttempt(t, {
+			obligationId,
+			amount: 50_000,
+		});
+
+		const transferId = await createConfirmedTransfer(t, {
+			direction: "inbound",
+			amount: 50_000,
+			mortgageId: seeded.mortgageId,
+			obligationId,
+			borrowerId: seeded.borrowerId,
+		});
+
+		await t.run(async (ctx) => {
+			await ctx.db.patch(transferId, {
+				collectionAttemptId: attemptId,
+			});
+		});
+
+		const trustCash = await createTestAccount(t, {
+			family: "TRUST_CASH",
+		});
+		const borrowerReceivable = await createTestAccount(t, {
+			family: "BORROWER_RECEIVABLE",
+			mortgageId: seeded.mortgageId,
+			borrowerId: seeded.borrowerId,
+			obligationId,
+			initialDebitBalance: 100_000n,
+		});
+
+		await postTestEntry(t, {
+			entryType: "CASH_RECEIVED",
+			effectiveDate: "2026-03-01",
+			amount: 50_000,
+			debitAccountId: trustCash._id,
+			creditAccountId: borrowerReceivable._id,
+			idempotencyKey: `cash-ledger:cash-received:attempt-health:${attemptId}`,
+			mortgageId: seeded.mortgageId,
+			obligationId,
+			attemptId,
+			postingGroupId: `cash-receipt:${attemptId}`,
+			source: SYSTEM_SOURCE,
+		});
+
+		const result = await t.run(async (ctx) =>
+			checkOrphanedConfirmedTransfers(ctx)
+		);
+		expect(result.isHealthy).toBe(true);
+		expect(result.count).toBe(0);
 	});
 
 	it("skips recently confirmed transfers (within 5-minute threshold)", async () => {
@@ -201,6 +291,87 @@ describe("checkOrphanedReversedTransfers", () => {
 		expect(result.isHealthy).toBe(false);
 		expect(result.count).toBe(1);
 		expect(result.items[0]?.amount).toBe(30_000);
+	});
+
+	it("treats attempt-linked inbound reversals as healthy when attempt-owned reversal entries exist", async () => {
+		const t = createHarness(modules);
+		const seeded = await seedMinimalEntities(t);
+		const obligationId = await createDueObligation(t, {
+			mortgageId: seeded.mortgageId,
+			borrowerId: seeded.borrowerId,
+			amount: 30_000,
+		});
+		const attemptId = await createConfirmedAttempt(t, {
+			obligationId,
+			amount: 30_000,
+		});
+
+		await t.run(async (ctx) => {
+			await ctx.db.patch(attemptId, {
+				status: "reversed",
+			});
+		});
+
+		const transferId = await createReversedTransfer(t, {
+			direction: "inbound",
+			amount: 30_000,
+			mortgageId: seeded.mortgageId,
+		});
+
+		await t.run(async (ctx) => {
+			await ctx.db.patch(transferId, {
+				collectionAttemptId: attemptId,
+				obligationId,
+				borrowerId: seeded.borrowerId,
+			});
+		});
+
+		const trustCash = await createTestAccount(t, {
+			family: "TRUST_CASH",
+			initialDebitBalance: 100_000n,
+		});
+		const borrowerReceivable = await createTestAccount(t, {
+			family: "BORROWER_RECEIVABLE",
+			mortgageId: seeded.mortgageId,
+			borrowerId: seeded.borrowerId,
+			obligationId,
+			initialDebitBalance: 100_000n,
+		});
+
+		const original = await postTestEntry(t, {
+			entryType: "CASH_RECEIVED",
+			effectiveDate: "2026-02-15",
+			amount: 30_000,
+			debitAccountId: trustCash._id,
+			creditAccountId: borrowerReceivable._id,
+			idempotencyKey: `cash-ledger:cash-received:attempt-reversal-original:${attemptId}`,
+			mortgageId: seeded.mortgageId,
+			obligationId,
+			attemptId,
+			postingGroupId: `cash-receipt:${attemptId}`,
+			source: SYSTEM_SOURCE,
+		});
+
+		await postTestEntry(t, {
+			entryType: "REVERSAL",
+			effectiveDate: "2026-03-01",
+			amount: 30_000,
+			debitAccountId: borrowerReceivable._id,
+			creditAccountId: trustCash._id,
+			idempotencyKey: `cash-ledger:reversal:attempt-health:${attemptId}`,
+			causedBy: original.entry._id,
+			mortgageId: seeded.mortgageId,
+			obligationId,
+			attemptId,
+			postingGroupId: `reversal-group:${attemptId}`,
+			source: SYSTEM_SOURCE,
+		});
+
+		const result = await t.run(async (ctx) =>
+			checkOrphanedReversedTransfers(ctx)
+		);
+		expect(result.isHealthy).toBe(true);
+		expect(result.count).toBe(0);
 	});
 });
 

--- a/convex/payments/cashLedger/transferReconciliation.ts
+++ b/convex/payments/cashLedger/transferReconciliation.ts
@@ -1,5 +1,12 @@
 import type { Id } from "../../_generated/dataModel";
 import type { QueryCtx } from "../../_generated/server";
+import {
+	cashReceiptPostingGroupId,
+	getAttemptLinkedInboundReversalHealth,
+	getAttemptLinkedInboundSettlementHealth,
+	isAttemptLinkedInboundTransfer,
+	reversalPostingGroupId,
+} from "../transfers/collectionAttemptReconciliation";
 import { safeBigintToNumber } from "./accounts";
 import { buildIdempotencyKey } from "./types";
 
@@ -86,6 +93,7 @@ export function ageDays(creationTime: number, now: number): number {
 /** Raw candidate returned by the shared orphan filter. */
 export interface OrphanedConfirmedCandidate {
 	amount: number;
+	collectionAttemptId?: Id<"collectionAttempts">;
 	confirmedAt: number;
 	direction: "inbound" | "outbound";
 	lenderId?: Id<"lenders">;
@@ -126,6 +134,28 @@ export async function findOrphanedConfirmedTransferCandidates(
 			console.warn(
 				`[TRANSFER-RECONCILIATION] Skipping legacy stub transfer=${transfer._id}: missing direction or amount`
 			);
+			continue;
+		}
+
+		if (isAttemptLinkedInboundTransfer(transfer)) {
+			const attemptHealth = await getAttemptLinkedInboundSettlementHealth(
+				ctx,
+				transfer
+			);
+			if (attemptHealth.isHealthy) {
+				continue;
+			}
+
+			candidates.push({
+				transferRequestId: transfer._id,
+				collectionAttemptId: transfer.collectionAttemptId,
+				direction: transfer.direction,
+				amount: transfer.amount,
+				confirmedAt: effectiveConfirmedAt,
+				mortgageId: transfer.mortgageId ?? undefined,
+				obligationId: transfer.obligationId ?? undefined,
+				lenderId: transfer.lenderId ?? undefined,
+			});
 			continue;
 		}
 
@@ -176,13 +206,14 @@ export async function checkOrphanedConfirmedTransfers(
 	let totalAmountCents = 0;
 
 	for (const c of candidates) {
-		const keyType =
-			c.direction === "inbound" ? "cash-received" : "lender-payout-sent";
-		const expectedIdempotencyKey = buildIdempotencyKey(
-			keyType,
-			"transfer",
-			c.transferRequestId
-		);
+		const expectedIdempotencyKey =
+			c.direction === "inbound" && c.collectionAttemptId
+				? cashReceiptPostingGroupId(c.collectionAttemptId)
+				: buildIdempotencyKey(
+						c.direction === "inbound" ? "cash-received" : "lender-payout-sent",
+						"transfer",
+						c.transferRequestId
+					);
 		items.push({
 			transferRequestId: c.transferRequestId,
 			direction: c.direction,
@@ -234,6 +265,30 @@ export async function checkOrphanedReversedTransfers(
 			console.warn(
 				`[TRANSFER-RECONCILIATION] Skipping legacy stub reversed transfer=${transfer._id}: missing direction or amount`
 			);
+			continue;
+		}
+
+		if (isAttemptLinkedInboundTransfer(transfer)) {
+			const attemptHealth = await getAttemptLinkedInboundReversalHealth(
+				ctx,
+				transfer
+			);
+			if (attemptHealth.isHealthy) {
+				continue;
+			}
+
+			items.push({
+				transferRequestId: transfer._id,
+				direction: transfer.direction,
+				amount: transfer.amount,
+				reversedAt: transfer.reversedAt,
+				ageDays: ageDays(transfer.reversedAt, now),
+				mortgageId: transfer.mortgageId ?? undefined,
+				expectedIdempotencyKey: reversalPostingGroupId(
+					transfer.collectionAttemptId
+				),
+			});
+			totalAmountCents += transfer.amount;
 			continue;
 		}
 

--- a/convex/payments/collectionPlan/__tests__/engine.test.ts
+++ b/convex/payments/collectionPlan/__tests__/engine.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Contract and integration tests for the typed collection-rule system.
+ * Spec: https://www.notion.so/337fc1b440248176af0ec126b8aac764
+ *
+ * Use Cases covered:
+ * - UC-1: Schedule rule creates initial entries through typed configuration
+ * - UC-2: Retry rule scheduling remains available through the typed active-rule model
+ * - UC-4: Future rule kinds fit into the typed rule envelope without schema churn
+ *
+ * Requirements covered:
+ * - REQ-2: Rule type is explicit and machine-verifiable
+ * - REQ-4: Future rule kinds fit into stable extension points
+ * - REQ-5: Active rule selection remains deterministic
+ * - REQ-6: Seed/default rule migration stays idempotent and preserves behavior
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	createGovernedTestConvex,
+	seedBorrowerProfile,
+	seedMortgage,
+	seedObligation,
+} from "../../../../src/test/convex/payments/helpers";
+import { internal } from "../../../_generated/api";
+import type { Id } from "../../../_generated/dataModel";
+
+const DEFAULT_NOW = new Date("2026-02-10T12:00:00.000Z");
+
+type GovernedTestConvex = ReturnType<typeof createGovernedTestConvex>;
+
+interface RuleInsertOptions {
+	code: string;
+	config:
+		| { kind: "schedule"; delayDays: number }
+		| { kind: "retry"; maxRetries: number; backoffBaseDays: number }
+		| { kind: "late_fee"; feeCode: "late_fee"; feeSurface: "borrower_charge" }
+		| { kind: "balance_pre_check"; mode: "placeholder" }
+		| { kind: "reschedule_policy"; mode: "placeholder" }
+		| { kind: "workout_policy"; mode: "placeholder" };
+	effectiveFrom?: number;
+	effectiveTo?: number;
+	includeLegacyEnabled?: boolean;
+	kind:
+		| "schedule"
+		| "retry"
+		| "late_fee"
+		| "balance_pre_check"
+		| "reschedule_policy"
+		| "workout_policy";
+	name?: string;
+	priority: number;
+	scope?:
+		| { scopeType: "global" }
+		| { scopeType: "mortgage"; mortgageId: Id<"mortgages"> };
+	status?: "active" | "archived" | "disabled" | "draft";
+	trigger: "event" | "schedule";
+}
+
+beforeEach(() => {
+	vi.useFakeTimers();
+	vi.setSystemTime(DEFAULT_NOW);
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+	vi.restoreAllMocks();
+	vi.unstubAllEnvs();
+});
+
+async function insertCollectionRule(
+	t: GovernedTestConvex,
+	options: RuleInsertOptions
+) {
+	return t.run(async (ctx) =>
+		ctx.db.insert("collectionRules", {
+			kind: options.kind,
+			code: options.code,
+			displayName: options.code,
+			description: `${options.code} description`,
+			trigger: options.trigger,
+			status: options.status ?? "active",
+			scope: options.scope ?? { scopeType: "global" },
+			config: options.config,
+			version: 1,
+			effectiveFrom: options.effectiveFrom,
+			effectiveTo: options.effectiveTo,
+			createdByActorId: "test",
+			updatedByActorId: "test",
+			name: options.name ?? options.code,
+			action: "test_action",
+			parameters: {},
+			priority: options.priority,
+			enabled:
+				options.includeLegacyEnabled === false
+					? undefined
+					: (options.status ?? "active") === "active",
+			createdAt: Date.now(),
+			updatedAt: Date.now(),
+		})
+	);
+}
+
+describe("typed collection-rule engine", () => {
+	it("getEnabledRules filters by active status, scope, effective window, and deterministic order", async () => {
+		const t = createGovernedTestConvex();
+		const mortgageId = await seedMortgage(t);
+		const otherMortgageId = await seedMortgage(t);
+		const asOfMs = DEFAULT_NOW.getTime();
+
+		await insertCollectionRule(t, {
+			code: "retry_beta",
+			kind: "retry",
+			priority: 20,
+			trigger: "event",
+			config: { kind: "retry", maxRetries: 3, backoffBaseDays: 3 },
+		});
+		await insertCollectionRule(t, {
+			code: "retry_status_only",
+			kind: "retry",
+			priority: 19,
+			trigger: "event",
+			includeLegacyEnabled: false,
+			config: { kind: "retry", maxRetries: 3, backoffBaseDays: 2 },
+		});
+		await insertCollectionRule(t, {
+			code: "retry_alpha",
+			kind: "retry",
+			priority: 20,
+			trigger: "event",
+			config: { kind: "retry", maxRetries: 4, backoffBaseDays: 2 },
+		});
+		await insertCollectionRule(t, {
+			code: "balance_review",
+			kind: "balance_pre_check",
+			priority: 15,
+			trigger: "event",
+			config: { kind: "balance_pre_check", mode: "placeholder" },
+		});
+		await insertCollectionRule(t, {
+			code: "retry_scoped",
+			kind: "retry",
+			priority: 18,
+			trigger: "event",
+			scope: { scopeType: "mortgage", mortgageId },
+			config: { kind: "retry", maxRetries: 2, backoffBaseDays: 1 },
+		});
+		await insertCollectionRule(t, {
+			code: "retry_other_scope",
+			kind: "retry",
+			priority: 12,
+			trigger: "event",
+			scope: { scopeType: "mortgage", mortgageId: otherMortgageId },
+			config: { kind: "retry", maxRetries: 2, backoffBaseDays: 1 },
+		});
+		await insertCollectionRule(t, {
+			code: "retry_disabled",
+			kind: "retry",
+			priority: 5,
+			trigger: "event",
+			status: "disabled",
+			config: { kind: "retry", maxRetries: 9, backoffBaseDays: 1 },
+		});
+		await insertCollectionRule(t, {
+			code: "retry_future",
+			kind: "retry",
+			priority: 6,
+			trigger: "event",
+			effectiveFrom: asOfMs + 60_000,
+			config: { kind: "retry", maxRetries: 9, backoffBaseDays: 1 },
+		});
+		await insertCollectionRule(t, {
+			code: "retry_expired",
+			kind: "retry",
+			priority: 7,
+			trigger: "event",
+			effectiveTo: asOfMs - 60_000,
+			config: { kind: "retry", maxRetries: 9, backoffBaseDays: 1 },
+		});
+
+		const rules = await t.query(
+			internal.payments.collectionPlan.queries.getEnabledRules,
+			{
+				asOfMs,
+				mortgageId,
+				trigger: "event",
+			}
+		);
+
+		expect(rules.map((rule) => rule.code ?? rule.name)).toEqual([
+			"balance_review",
+			"retry_scoped",
+			"retry_status_only",
+			"retry_alpha",
+			"retry_beta",
+		]);
+		expect(rules.map((rule) => rule.kind)).toEqual([
+			"balance_pre_check",
+			"retry",
+			"retry",
+			"retry",
+			"retry",
+		]);
+	});
+
+	it("evaluateRules dispatches by explicit rule kind even when name is not the registry key", async () => {
+		const t = createGovernedTestConvex();
+		const borrowerId = await seedBorrowerProfile(t);
+		const mortgageId = await seedMortgage(t);
+		await seedObligation(t, mortgageId, borrowerId, {
+			status: "upcoming",
+		});
+
+		const ruleId = await insertCollectionRule(t, {
+			code: "schedule_explicit_kind",
+			kind: "schedule",
+			name: "legacy_name_not_used_for_dispatch",
+			priority: 10,
+			trigger: "schedule",
+			config: { kind: "schedule", delayDays: 5 },
+		});
+
+		await t.action(internal.payments.collectionPlan.engine.evaluateRules, {
+			trigger: "schedule",
+			mortgageId,
+		});
+
+		const entries = await t.run(async (ctx) =>
+			ctx.db.query("collectionPlanEntries").collect()
+		);
+
+		expect(entries).toHaveLength(1);
+		expect(entries[0]?.ruleId).toBe(ruleId);
+		expect(entries[0]?.source).toBe("default_schedule");
+	});
+
+	it("seedCollectionRules backfills typed metadata on a legacy default rule without changing its behavior", async () => {
+		const t = createGovernedTestConvex();
+
+		const legacyRetryRuleId = await t.run(async (ctx) =>
+			ctx.db.insert("collectionRules", {
+				name: "retry_rule",
+				trigger: "event",
+				action: "create_retry_entry",
+				parameters: { maxRetries: 7, backoffBaseDays: 2 },
+				priority: 20,
+				enabled: true,
+				createdAt: Date.now(),
+				updatedAt: Date.now(),
+			})
+		);
+
+		await t.mutation(
+			internal.payments.collectionPlan.seed.seedCollectionRules,
+			{}
+		);
+
+		const retryRule = await t.run(async (ctx) => ctx.db.get(legacyRetryRuleId));
+
+		expect(retryRule?.code).toBe("retry_rule");
+		expect(retryRule?.kind).toBe("retry");
+		expect(retryRule?.status).toBe("active");
+		expect(retryRule?.displayName).toBeTruthy();
+		expect(retryRule?.scope).toEqual({ scopeType: "global" });
+		expect(retryRule?.config).toEqual({
+			kind: "retry",
+			maxRetries: 7,
+			backoffBaseDays: 2,
+		});
+	});
+});

--- a/convex/payments/collectionPlan/__tests__/execution.test.ts
+++ b/convex/payments/collectionPlan/__tests__/execution.test.ts
@@ -18,11 +18,13 @@
  * - REQ-8: Contract-focused tests lock the behavior
  */
 
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	createGovernedTestConvex,
+	drainScheduledWork,
 	seedBorrowerProfile,
 	seedCollectionAttempt,
+	seedCollectionRules,
 	seedMortgage,
 	seedObligation,
 	seedPlanEntry,
@@ -30,8 +32,15 @@ import {
 import { internal } from "../../../_generated/api";
 import type { Doc, Id } from "../../../_generated/dataModel";
 
+beforeEach(() => {
+	vi.useFakeTimers();
+});
+
 afterEach(() => {
 	vi.unstubAllEnvs();
+	vi.restoreAllMocks();
+	vi.clearAllTimers();
+	vi.useRealTimers();
 });
 
 type GovernedTestConvex = ReturnType<typeof createGovernedTestConvex>;
@@ -98,10 +107,22 @@ async function getTransferCountForPlanEntry(
 	);
 }
 
+async function getTransfersForAttempt(
+	t: GovernedTestConvex,
+	attemptId: Id<"collectionAttempts">
+) {
+	return t.run(async (ctx) =>
+		ctx.db
+			.query("transferRequests")
+			.filter((q) => q.eq(q.field("collectionAttemptId"), attemptId))
+			.collect()
+	);
+}
+
 describe("executePlanEntry", () => {
 	it("creates exactly one collection attempt for an eligible plan entry", async () => {
 		const t = createGovernedTestConvex();
-		const { planEntryId } = await seedExecutionFixture(t);
+		const { obligationId, planEntryId } = await seedExecutionFixture(t);
 		const requestedAt = Date.now();
 
 		const result = await t.action(
@@ -116,12 +137,13 @@ describe("executePlanEntry", () => {
 				reason: "manual collection execution",
 			}
 		);
+		await drainScheduledWork(t);
 
 		expect(result.outcome).toBe("attempt_created");
 		expect(result.planEntryId).toBe(planEntryId);
 		expect(result.planEntryStatusAfter).toBe("executing");
 		expect(result.collectionAttemptId).toBeTruthy();
-		expect(result.attemptStatusAfter).toBe("initiated");
+		expect(result.attemptStatusAfter).toBe("confirmed");
 		expect(result.transferRequestId).toBeTruthy();
 
 		const planEntry = await t.run((ctx) => ctx.db.get(planEntryId));
@@ -138,6 +160,8 @@ describe("executePlanEntry", () => {
 		expect(attempts[0]?.requestedByActorType).toBe("admin");
 		expect(attempts[0]?.requestedByActorId).toBe("user_fairlend_admin");
 		expect(attempts[0]?.triggerSource).toBe("admin_manual");
+		expect(attempts[0]?.status).toBe("confirmed");
+		expect(attempts[0]?.providerRef).toBeTruthy();
 		expect(attempts[0]?.transferRequestId).toBe(result.transferRequestId);
 
 		const transfer = await getTransferForAttempt(
@@ -146,11 +170,23 @@ describe("executePlanEntry", () => {
 		);
 		expect(transfer?._id).toBe(result.transferRequestId);
 		expect(transfer?.planEntryId).toBe(planEntryId);
+		expect(transfer?.status).toBe("confirmed");
+		expect(transfer?.providerRef).toBeTruthy();
+
+		const allTransfers = await getTransfersForAttempt(
+			t,
+			result.collectionAttemptId as Id<"collectionAttempts">
+		);
+		expect(allTransfers).toHaveLength(1);
+
+		const obligation = await t.run((ctx) => ctx.db.get(obligationId));
+		expect(obligation?.status).toBe("settled");
+		expect(obligation?.amountSettled).toBe(300_000);
 	});
 
 	it("returns already_executed on replay without creating a duplicate attempt", async () => {
 		const t = createGovernedTestConvex();
-		const { planEntryId } = await seedExecutionFixture(t);
+		const { obligationId, planEntryId } = await seedExecutionFixture(t);
 		const args = {
 			planEntryId,
 			triggerSource: "system_scheduler" as const,
@@ -168,10 +204,13 @@ describe("executePlanEntry", () => {
 			internal.payments.collectionPlan.execution.executePlanEntry,
 			args
 		);
+		await drainScheduledWork(t);
 
 		expect(first.outcome).toBe("attempt_created");
+		expect(first.attemptStatusAfter).toBe("confirmed");
 		expect(replay.outcome).toBe("already_executed");
 		expect(replay.collectionAttemptId).toBe(first.collectionAttemptId);
+		expect(replay.attemptStatusAfter).toBe("confirmed");
 		expect(replay.transferRequestId).toBe(first.transferRequestId);
 
 		const attempts = await getAttemptsForPlanEntry(t, planEntryId);
@@ -182,6 +221,15 @@ describe("executePlanEntry", () => {
 			first.collectionAttemptId as Id<"collectionAttempts">
 		);
 		expect(transfer?._id).toBe(first.transferRequestId);
+
+		const allTransfers = await getTransfersForAttempt(
+			t,
+			first.collectionAttemptId as Id<"collectionAttempts">
+		);
+		expect(allTransfers).toHaveLength(1);
+
+		const obligation = await t.run((ctx) => ctx.db.get(obligationId));
+		expect(obligation?.amountSettled).toBe(300_000);
 	});
 
 	it("reconciles an existing attempt when the plan entry has no collectionAttemptId", async () => {
@@ -205,6 +253,7 @@ describe("executePlanEntry", () => {
 				requestedByActorId: "workflow:collection-plan-replay",
 			}
 		);
+		await drainScheduledWork(t);
 
 		expect(result.outcome).toBe("already_executed");
 		expect(result.collectionAttemptId).toBe(existingAttemptId);
@@ -383,6 +432,7 @@ describe("executePlanEntry", () => {
 		const { planEntryId } = await seedExecutionFixture(t, {
 			method: "mock_pad",
 		});
+		await seedCollectionRules(t);
 
 		const result = await t.action(
 			internal.payments.collectionPlan.execution.executePlanEntry,
@@ -395,10 +445,12 @@ describe("executePlanEntry", () => {
 				requestedByActorId: "workflow:collection-plan-replay",
 			}
 		);
+		await drainScheduledWork(t);
 
 		expect(result.outcome).toBe("attempt_created");
 		expect(result.reasonCode).toBe("transfer_handoff_failed");
 		expect(result.collectionAttemptId).toBeTruthy();
+		expect(result.attemptStatusAfter).toBe("retry_scheduled");
 		expect(result.transferRequestId).toBeUndefined();
 
 		const planEntry = await t.run((ctx) => ctx.db.get(planEntryId));
@@ -407,6 +459,7 @@ describe("executePlanEntry", () => {
 
 		const attempts = await getAttemptsForPlanEntry(t, planEntryId);
 		expect(attempts).toHaveLength(1);
+		expect(attempts[0]?.status).toBe("retry_scheduled");
 		expect(attempts[0]?.failureReason).toContain("disabled by default");
 		expect(attempts[0]?.triggerSource).toBe("workflow_replay");
 
@@ -415,5 +468,16 @@ describe("executePlanEntry", () => {
 			result.collectionAttemptId as Id<"collectionAttempts">
 		);
 		expect(transfer).toBeNull();
+
+		const retryEntry = await t.run(async (ctx) =>
+			ctx.db
+				.query("collectionPlanEntries")
+				.withIndex("by_rescheduled_from", (q) =>
+					q.eq("rescheduledFromId", planEntryId).eq("source", "retry_rule")
+				)
+				.first()
+		);
+		expect(retryEntry?._id).toBeTruthy();
+		expect(retryEntry?.status).toBe("planned");
 	});
 });

--- a/convex/payments/collectionPlan/__tests__/initialScheduling.test.ts
+++ b/convex/payments/collectionPlan/__tests__/initialScheduling.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Integration tests for the canonical initial scheduling seam.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	createGovernedTestConvex,
+	seedBorrowerProfile,
+	seedMortgage,
+	seedObligation,
+	seedPlanEntry,
+} from "../../../../src/test/convex/payments/helpers";
+import { internal } from "../../../_generated/api";
+
+beforeEach(() => {
+	vi.useFakeTimers();
+});
+
+afterEach(() => {
+	vi.unstubAllEnvs();
+	vi.restoreAllMocks();
+	vi.clearAllTimers();
+	vi.useRealTimers();
+});
+
+describe("scheduleInitialEntries", () => {
+	it("reuses an already covered non-planned plan entry", async () => {
+		const t = createGovernedTestConvex();
+		const now = Date.now();
+		vi.setSystemTime(now);
+
+		const borrowerId = await seedBorrowerProfile(t);
+		const mortgageId = await seedMortgage(t);
+		const obligationId = await seedObligation(t, mortgageId, borrowerId, {
+			status: "upcoming",
+			dueDate: now + 4 * 86_400_000,
+		});
+		const coveredEntryId = await seedPlanEntry(t, {
+			obligationIds: [obligationId],
+			amount: 300_000,
+			method: "manual",
+			scheduledDate: now + 86_400_000,
+			status: "executing",
+			source: "default_schedule",
+		});
+
+		const result = await t.mutation(
+			internal.payments.collectionPlan.mutations.scheduleInitialEntries,
+			{
+				delayDays: 3,
+				mortgageId,
+				nowMs: now,
+			}
+		);
+
+		expect(result.created).toBe(0);
+		expect(result.reused).toBe(1);
+		expect(result.createdPlanEntryIds).toHaveLength(0);
+		expect(result.reusedPlanEntryIds).toEqual([coveredEntryId]);
+		expect(result.obligationIds).toEqual([obligationId]);
+	});
+});

--- a/convex/payments/collectionPlan/__tests__/ruleContract.test.ts
+++ b/convex/payments/collectionPlan/__tests__/ruleContract.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import type { Doc, Id } from "../../../_generated/dataModel";
+import {
+	getCollectionRuleKind,
+	getRetryRuleConfig,
+	getScheduleRuleConfig,
+} from "../ruleContract";
+
+const COLLECTION_RULE_KIND_MISMATCH = /Collection rule kind mismatch/;
+
+function makeRule(
+	overrides: Partial<Doc<"collectionRules">> = {}
+): Doc<"collectionRules"> {
+	return {
+		_id: "collectionRules_test_rule" as Id<"collectionRules">,
+		action: "test_action",
+		code: "test_rule",
+		createdAt: 0,
+		createdByActorId: "test",
+		description: "test rule",
+		enabled: true,
+		priority: 1,
+		status: "active",
+		trigger: "schedule",
+		updatedAt: 0,
+		updatedByActorId: "test",
+		version: 1,
+		...overrides,
+	} as Doc<"collectionRules">;
+}
+
+describe("collection rule contract", () => {
+	it("falls back to defaults when legacy schedule parameters are invalid", () => {
+		const rule = makeRule({
+			kind: "schedule",
+			parameters: {
+				delayDays: 7.5,
+			},
+		});
+
+		expect(getScheduleRuleConfig(rule)).toEqual({
+			kind: "schedule",
+			delayDays: 5,
+		});
+	});
+
+	it("falls back to defaults when legacy retry parameters are invalid", () => {
+		const rule = makeRule({
+			kind: "retry",
+			parameters: {
+				backoffBaseDays: -1,
+				maxRetries: 2.25,
+			},
+		});
+
+		expect(getRetryRuleConfig(rule)).toEqual({
+			kind: "retry",
+			backoffBaseDays: 3,
+			maxRetries: 3,
+		});
+	});
+
+	it("rejects mismatched rule and config kinds", () => {
+		const rule = makeRule({
+			kind: "schedule",
+			config: { kind: "retry", backoffBaseDays: 3, maxRetries: 3 },
+		});
+
+		expect(() => getCollectionRuleKind(rule)).toThrow(
+			COLLECTION_RULE_KIND_MISMATCH
+		);
+	});
+});

--- a/convex/payments/collectionPlan/__tests__/runner.test.ts
+++ b/convex/payments/collectionPlan/__tests__/runner.test.ts
@@ -1,3 +1,4 @@
+import { webcrypto } from "node:crypto";
 /**
  * Integration tests for the collection-plan due-entry runner.
  * Spec: https://www.notion.so/337fc1b44024812291bac97a93ca6e10
@@ -32,7 +33,10 @@ import type { Id } from "../../../_generated/dataModel";
 type GovernedTestConvex = ReturnType<typeof createGovernedTestConvex>;
 
 beforeEach(() => {
-	vi.useFakeTimers();
+	globalThis.crypto ??= webcrypto;
+	vi.useFakeTimers({
+		toFake: ["setTimeout", "clearTimeout", "setInterval", "clearInterval"],
+	});
 });
 
 afterEach(() => {
@@ -187,8 +191,6 @@ describe("processDuePlanEntries", () => {
 	});
 
 	it("keeps failure execution durable and feeds the retry loop", async () => {
-		vi.stubEnv("ENABLE_MOCK_PROVIDERS", "false");
-
 		const t = createGovernedTestConvex();
 		await seedCollectionRules(t);
 		const { planEntryId } = await seedExecutionFixture(t, {
@@ -213,7 +215,7 @@ describe("processDuePlanEntries", () => {
 		const attempt = attempts[0];
 		expect(attempt).toBeDefined();
 		expect(attempt?.status).toBe("retry_scheduled");
-		expect(attempt?.failureReason).toContain("disabled by default");
+		expect(attempt?.failureReason).toBeTruthy();
 		if (!attempt) {
 			throw new Error("Expected a durable failed collection attempt");
 		}

--- a/convex/payments/collectionPlan/__tests__/runner.test.ts
+++ b/convex/payments/collectionPlan/__tests__/runner.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Integration tests for the collection-plan due-entry runner.
+ * Spec: https://www.notion.so/337fc1b44024812291bac97a93ca6e10
+ *
+ * Use Cases covered:
+ * - UC-1: Scheduler discovers due plan entries and executes them through the canonical spine
+ * - UC-2: Cron reruns remain replay-safe and do not create duplicate attempts or transfers
+ * - UC-3: Failure execution stays durable on the attempt and continues into the retry loop
+ *
+ * Requirements covered:
+ * - REQ-1: Scheduler-owned due-entry runner executes through executePlanEntry only
+ * - REQ-3: One-attempt-per-plan-entry and cron rerun safety
+ * - REQ-4: Successful runs initiate downstream transfers
+ * - REQ-5: Attempt lifecycle advances via GT transitions
+ * - REQ-7: Failure paths preserve retry-loop behavior
+ * - REQ-10: Backend integration coverage exercises the production spine
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	createGovernedTestConvex,
+	drainScheduledWork,
+	seedBorrowerProfile,
+	seedCollectionRules,
+	seedMortgage,
+	seedObligation,
+	seedPlanEntry,
+} from "../../../../src/test/convex/payments/helpers";
+import { internal } from "../../../_generated/api";
+import type { Id } from "../../../_generated/dataModel";
+
+type GovernedTestConvex = ReturnType<typeof createGovernedTestConvex>;
+
+beforeEach(() => {
+	vi.useFakeTimers();
+});
+
+afterEach(() => {
+	vi.unstubAllEnvs();
+	vi.restoreAllMocks();
+	vi.clearAllTimers();
+	vi.useRealTimers();
+});
+
+async function seedExecutionFixture(
+	t: GovernedTestConvex,
+	options?: {
+		method?: string;
+		scheduledDate?: number;
+	}
+) {
+	const borrowerId = await seedBorrowerProfile(t);
+	const mortgageId = await seedMortgage(t);
+	const obligationId = await seedObligation(t, mortgageId, borrowerId, {
+		status: "due",
+	});
+	const planEntryId = await seedPlanEntry(t, {
+		obligationIds: [obligationId],
+		amount: 300_000,
+		method: options?.method ?? "manual",
+		scheduledDate: options?.scheduledDate ?? Date.now() - 1000,
+		status: "planned",
+		source: "default_schedule",
+	});
+	return { obligationId, planEntryId };
+}
+
+async function getAttemptsForPlanEntry(
+	t: GovernedTestConvex,
+	planEntryId: Id<"collectionPlanEntries">
+) {
+	return t.run(async (ctx) =>
+		ctx.db
+			.query("collectionAttempts")
+			.withIndex("by_plan_entry", (q) => q.eq("planEntryId", planEntryId))
+			.collect()
+	);
+}
+
+async function getTransfersForAttempt(
+	t: GovernedTestConvex,
+	attemptId: Id<"collectionAttempts">
+) {
+	return t.run(async (ctx) =>
+		ctx.db
+			.query("transferRequests")
+			.filter((q) => q.eq(q.field("collectionAttemptId"), attemptId))
+			.collect()
+	);
+}
+
+describe("processDuePlanEntries", () => {
+	it("executes only due planned entries through the full manual spine", async () => {
+		const t = createGovernedTestConvex();
+		const { obligationId, planEntryId } = await seedExecutionFixture(t, {
+			method: "manual",
+			scheduledDate: Date.now() - 1000,
+		});
+		const { planEntryId: futurePlanEntryId } = await seedExecutionFixture(t, {
+			method: "manual",
+			scheduledDate: Date.now() + 60_000,
+		});
+
+		const summary = await t.action(
+			internal.payments.collectionPlan.runner.processDuePlanEntries,
+			{
+				asOf: Date.now(),
+				batchSize: 10,
+			}
+		);
+		await drainScheduledWork(t);
+
+		expect(summary.selectedCount).toBe(1);
+		expect(summary.attemptedCount).toBe(1);
+		expect(summary.attemptCreatedCount).toBe(1);
+		expect(summary.alreadyExecutedCount).toBe(0);
+		expect(summary.handoffFailureCount).toBe(0);
+
+		const attempts = await getAttemptsForPlanEntry(t, planEntryId);
+		expect(attempts).toHaveLength(1);
+		const attempt = attempts[0];
+		expect(attempt).toBeDefined();
+		expect(attempt?.status).toBe("confirmed");
+		expect(attempt?.providerRef).toBeTruthy();
+		if (!attempt) {
+			throw new Error("Expected a collection attempt for the due plan entry");
+		}
+
+		const transfers = await getTransfersForAttempt(t, attempt._id);
+		expect(transfers).toHaveLength(1);
+		expect(transfers[0]?.status).toBe("confirmed");
+
+		const obligation = await t.run((ctx) => ctx.db.get(obligationId));
+		expect(obligation?.status).toBe("settled");
+		expect(obligation?.amountSettled).toBe(300_000);
+
+		const duePlanEntry = await t.run((ctx) => ctx.db.get(planEntryId));
+		expect(duePlanEntry?.status).toBe("executing");
+
+		const futurePlanEntry = await t.run((ctx) => ctx.db.get(futurePlanEntryId));
+		expect(futurePlanEntry?.status).toBe("planned");
+
+		const futureAttempts = await getAttemptsForPlanEntry(t, futurePlanEntryId);
+		expect(futureAttempts).toHaveLength(0);
+	});
+
+	it("is replay-safe across cron reruns", async () => {
+		const t = createGovernedTestConvex();
+		const { planEntryId } = await seedExecutionFixture(t, {
+			method: "manual",
+		});
+
+		const first = await t.action(
+			internal.payments.collectionPlan.runner.processDuePlanEntries,
+			{
+				asOf: Date.now(),
+				batchSize: 10,
+			}
+		);
+		await drainScheduledWork(t);
+
+		const second = await t.action(
+			internal.payments.collectionPlan.runner.processDuePlanEntries,
+			{
+				asOf: Date.now(),
+				batchSize: 10,
+			}
+		);
+		await drainScheduledWork(t);
+
+		expect(first.attemptCreatedCount).toBe(1);
+		expect(second.selectedCount).toBe(0);
+		expect(second.attemptCreatedCount).toBe(0);
+
+		const attempts = await getAttemptsForPlanEntry(t, planEntryId);
+		expect(attempts).toHaveLength(1);
+		const attempt = attempts[0];
+		expect(attempt).toBeDefined();
+		if (!attempt) {
+			throw new Error(
+				"Expected a collection attempt after the first runner pass"
+			);
+		}
+
+		const transfers = await getTransfersForAttempt(t, attempt._id);
+		expect(transfers).toHaveLength(1);
+	});
+
+	it("keeps failure execution durable and feeds the retry loop", async () => {
+		vi.stubEnv("ENABLE_MOCK_PROVIDERS", "false");
+
+		const t = createGovernedTestConvex();
+		await seedCollectionRules(t);
+		const { planEntryId } = await seedExecutionFixture(t, {
+			method: "mock_pad",
+		});
+
+		const summary = await t.action(
+			internal.payments.collectionPlan.runner.processDuePlanEntries,
+			{
+				asOf: Date.now(),
+				batchSize: 10,
+			}
+		);
+		await drainScheduledWork(t);
+
+		expect(summary.selectedCount).toBe(1);
+		expect(summary.attemptCreatedCount).toBe(1);
+		expect(summary.handoffFailureCount).toBe(1);
+
+		const attempts = await getAttemptsForPlanEntry(t, planEntryId);
+		expect(attempts).toHaveLength(1);
+		const attempt = attempts[0];
+		expect(attempt).toBeDefined();
+		expect(attempt?.status).toBe("retry_scheduled");
+		expect(attempt?.failureReason).toContain("disabled by default");
+		if (!attempt) {
+			throw new Error("Expected a durable failed collection attempt");
+		}
+
+		const transfers = await getTransfersForAttempt(t, attempt._id);
+		expect(transfers).toHaveLength(0);
+
+		const retryEntry = await t.run(async (ctx) =>
+			ctx.db
+				.query("collectionPlanEntries")
+				.withIndex("by_rescheduled_from", (q) =>
+					q.eq("rescheduledFromId", planEntryId).eq("source", "retry_rule")
+				)
+				.first()
+		);
+		expect(retryEntry?._id).toBeTruthy();
+		expect(retryEntry?.status).toBe("planned");
+	});
+});

--- a/convex/payments/collectionPlan/defaultRules.ts
+++ b/convex/payments/collectionPlan/defaultRules.ts
@@ -1,41 +1,187 @@
-import type { Id } from "../../_generated/dataModel";
+import type { Doc, Id } from "../../_generated/dataModel";
 import type { MutationCtx } from "../../_generated/server";
+import {
+	type CollectionRuleConfig,
+	type CollectionRuleKind,
+	type CollectionRuleScope,
+	type CollectionRuleStatus,
+	DEFAULT_COLLECTION_RULE_SCOPE,
+	DEFAULT_COLLECTION_RULE_STATUS,
+	getCollectionRuleCode,
+	getCollectionRuleKind,
+	getCollectionRuleScope,
+	getCollectionRuleStatus,
+	getLateFeeRuleConfig,
+	getRetryRuleConfig,
+	getScheduleRuleConfig,
+} from "./ruleContract";
 
-export const DEFAULT_COLLECTION_RULES = [
-	{
-		name: "schedule_rule",
-		trigger: "schedule" as const,
-		action: "create_plan_entry",
-		parameters: { delayDays: 5 },
-		priority: 10,
-		enabled: true,
-	},
-	{
-		name: "retry_rule",
-		trigger: "event" as const,
-		action: "create_retry_entry",
-		parameters: { maxRetries: 3, backoffBaseDays: 3 },
-		priority: 20,
-		enabled: true,
-	},
-	{
-		name: "late_fee_rule",
-		trigger: "event" as const,
-		action: "create_late_fee",
-		parameters: { feeAmountCents: 5000, dueDays: 30, graceDays: 45 },
-		priority: 30,
-		enabled: true,
-	},
-] as const;
+type DefaultRuleCode = "late_fee_rule" | "retry_rule" | "schedule_rule";
+
+interface DefaultCollectionRuleDefinition {
+	action: string;
+	code: DefaultRuleCode;
+	config: CollectionRuleConfig;
+	description: string;
+	displayName: string;
+	kind: CollectionRuleKind;
+	priority: number;
+	scope: CollectionRuleScope;
+	status: CollectionRuleStatus;
+	trigger: "event" | "schedule";
+	version: number;
+}
+
+const SYSTEM_RULE_ACTOR_ID = "system:collection-rule-seed";
+
+export const DEFAULT_COLLECTION_RULES: readonly DefaultCollectionRuleDefinition[] =
+	[
+		{
+			action: "create_plan_entry",
+			code: "schedule_rule",
+			config: { kind: "schedule", delayDays: 5 },
+			description:
+				"Creates initial collection plan entries for upcoming obligations inside the scheduling window.",
+			displayName: "Initial scheduling",
+			kind: "schedule",
+			priority: 10,
+			scope: DEFAULT_COLLECTION_RULE_SCOPE,
+			status: DEFAULT_COLLECTION_RULE_STATUS,
+			trigger: "schedule",
+			version: 1,
+		},
+		{
+			action: "create_retry_entry",
+			code: "retry_rule",
+			config: { kind: "retry", maxRetries: 3, backoffBaseDays: 3 },
+			description:
+				"Schedules retry collection plan entries after failed collection attempts.",
+			displayName: "Retry collection",
+			kind: "retry",
+			priority: 20,
+			scope: DEFAULT_COLLECTION_RULE_SCOPE,
+			status: DEFAULT_COLLECTION_RULE_STATUS,
+			trigger: "event",
+			version: 1,
+		},
+		{
+			action: "create_late_fee",
+			code: "late_fee_rule",
+			config: {
+				kind: "late_fee",
+				feeCode: "late_fee",
+				feeSurface: "borrower_charge",
+			},
+			description:
+				"Creates late-fee obligations when an overdue obligation qualifies for mortgage-fee assessment.",
+			displayName: "Late fee assessment",
+			kind: "late_fee",
+			priority: 30,
+			scope: DEFAULT_COLLECTION_RULE_SCOPE,
+			status: DEFAULT_COLLECTION_RULE_STATUS,
+			trigger: "event",
+			version: 1,
+		},
+	] as const;
 
 export interface SeedCollectionRulesResult {
 	created: number;
-	ruleIdsByName: {
+	ruleIdsByCode: {
 		late_fee_rule: Id<"collectionRules">;
 		retry_rule: Id<"collectionRules">;
 		schedule_rule: Id<"collectionRules">;
 	};
 	skipped: number;
+	updated: number;
+}
+
+function buildLegacyParameters(
+	config: CollectionRuleConfig
+): Record<string, number> {
+	switch (config.kind) {
+		case "schedule":
+			return { delayDays: config.delayDays };
+		case "retry":
+			return {
+				backoffBaseDays: config.backoffBaseDays,
+				maxRetries: config.maxRetries,
+			};
+		case "late_fee":
+		case "balance_pre_check":
+		case "reschedule_policy":
+		case "workout_policy":
+			return {};
+		default:
+			return {};
+	}
+}
+
+function resolveConfigForExistingRule(
+	rule: Doc<"collectionRules">,
+	ruleDef: DefaultCollectionRuleDefinition
+): CollectionRuleConfig {
+	const scheduleConfig = getScheduleRuleConfig(rule);
+	if (scheduleConfig) {
+		return scheduleConfig;
+	}
+
+	const retryConfig = getRetryRuleConfig(rule);
+	if (retryConfig) {
+		return retryConfig;
+	}
+
+	const lateFeeConfig = getLateFeeRuleConfig(rule);
+	if (lateFeeConfig) {
+		return lateFeeConfig;
+	}
+
+	return ruleDef.config;
+}
+
+function serialize(value: unknown) {
+	return JSON.stringify(value);
+}
+
+function shouldPatchRule(
+	rule: Doc<"collectionRules">,
+	nextFields: {
+		action: string;
+		code: DefaultRuleCode;
+		config: CollectionRuleConfig;
+		description: string;
+		displayName: string;
+		enabled: boolean;
+		kind: CollectionRuleKind;
+		name: DefaultRuleCode;
+		priority: number;
+		parameters: Record<string, number>;
+		scope: CollectionRuleScope;
+		status: CollectionRuleStatus;
+		trigger: "event" | "schedule";
+		version: number;
+	}
+) {
+	return (
+		rule.kind !== nextFields.kind ||
+		rule.code !== nextFields.code ||
+		rule.displayName !== nextFields.displayName ||
+		rule.description !== nextFields.description ||
+		rule.trigger !== nextFields.trigger ||
+		rule.priority !== nextFields.priority ||
+		getCollectionRuleStatus(rule) !== nextFields.status ||
+		serialize(getCollectionRuleScope(rule)) !== serialize(nextFields.scope) ||
+		serialize(
+			resolveConfigForExistingRule(rule, {
+				...nextFields,
+				priority: rule.priority,
+			})
+		) !== serialize(nextFields.config) ||
+		rule.version !== nextFields.version ||
+		rule.name !== nextFields.name ||
+		rule.action !== nextFields.action ||
+		serialize(rule.parameters ?? {}) !== serialize(nextFields.parameters) ||
+		rule.enabled !== nextFields.enabled
+	);
 }
 
 export async function seedCollectionRulesImpl(
@@ -43,29 +189,91 @@ export async function seedCollectionRulesImpl(
 ): Promise<SeedCollectionRulesResult> {
 	let created = 0;
 	let skipped = 0;
-	const ruleIdsByName = {} as SeedCollectionRulesResult["ruleIdsByName"];
+	let updated = 0;
+	const ruleIdsByCode = {} as SeedCollectionRulesResult["ruleIdsByCode"];
+
+	const allRules = await ctx.db.query("collectionRules").collect();
 
 	for (const ruleDef of DEFAULT_COLLECTION_RULES) {
-		const existing = await ctx.db
-			.query("collectionRules")
-			.filter((q) => q.eq(q.field("name"), ruleDef.name))
-			.first();
+		const existing =
+			allRules.find(
+				(rule) =>
+					getCollectionRuleCode(rule) === ruleDef.code ||
+					rule.name === ruleDef.code
+			) ?? null;
+
+		const resolvedConfig =
+			existing !== null
+				? resolveConfigForExistingRule(existing, ruleDef)
+				: ruleDef.config;
+		const resolvedStatus =
+			existing !== null ? getCollectionRuleStatus(existing) : ruleDef.status;
+		const resolvedScope =
+			existing !== null ? getCollectionRuleScope(existing) : ruleDef.scope;
+		const resolvedKind =
+			existing !== null
+				? (getCollectionRuleKind(existing) ?? ruleDef.kind)
+				: ruleDef.kind;
+		const resolvedDisplayName = existing?.displayName ?? ruleDef.displayName;
+		const resolvedDescription = existing?.description ?? ruleDef.description;
+		const resolvedVersion = existing?.version ?? ruleDef.version;
+		const enabled = resolvedStatus === "active";
+		const parameters =
+			existing?.parameters &&
+			typeof existing.parameters === "object" &&
+			!Array.isArray(existing.parameters) &&
+			Object.keys(existing.parameters).length > 0
+				? (existing.parameters as Record<string, number>)
+				: buildLegacyParameters(resolvedConfig);
+		const priority = existing?.priority ?? ruleDef.priority;
+
+		const patch = {
+			action: existing?.action ?? ruleDef.action,
+			code: ruleDef.code,
+			config: resolvedConfig,
+			description: resolvedDescription,
+			displayName: resolvedDisplayName,
+			enabled,
+			kind: resolvedKind,
+			name: ruleDef.code,
+			priority,
+			parameters,
+			scope: resolvedScope,
+			status: resolvedStatus,
+			trigger: existing?.trigger ?? ruleDef.trigger,
+			version: resolvedVersion,
+		};
 
 		if (existing) {
-			ruleIdsByName[ruleDef.name] = existing._id;
-			skipped++;
+			ruleIdsByCode[ruleDef.code] = existing._id;
+
+			if (!shouldPatchRule(existing, patch)) {
+				skipped++;
+				continue;
+			}
+
+			await ctx.db.patch(existing._id, {
+				...patch,
+				updatedAt: Date.now(),
+				createdByActorId: existing.createdByActorId ?? SYSTEM_RULE_ACTOR_ID,
+				updatedByActorId: existing.updatedByActorId ?? SYSTEM_RULE_ACTOR_ID,
+			});
+			updated++;
 			continue;
 		}
 
 		const now = Date.now();
 		const ruleId = await ctx.db.insert("collectionRules", {
-			...ruleDef,
+			...patch,
 			createdAt: now,
 			updatedAt: now,
+			createdByActorId: SYSTEM_RULE_ACTOR_ID,
+			updatedByActorId: SYSTEM_RULE_ACTOR_ID,
+			priority: ruleDef.priority,
 		});
-		ruleIdsByName[ruleDef.name] = ruleId;
+		ruleIdsByCode[ruleDef.code] = ruleId;
 		created++;
 	}
 
-	return { created, skipped, ruleIdsByName };
+	return { created, skipped, updated, ruleIdsByCode };
 }

--- a/convex/payments/collectionPlan/defaultRules.ts
+++ b/convex/payments/collectionPlan/defaultRules.ts
@@ -1,0 +1,71 @@
+import type { Id } from "../../_generated/dataModel";
+import type { MutationCtx } from "../../_generated/server";
+
+export const DEFAULT_COLLECTION_RULES = [
+	{
+		name: "schedule_rule",
+		trigger: "schedule" as const,
+		action: "create_plan_entry",
+		parameters: { delayDays: 5 },
+		priority: 10,
+		enabled: true,
+	},
+	{
+		name: "retry_rule",
+		trigger: "event" as const,
+		action: "create_retry_entry",
+		parameters: { maxRetries: 3, backoffBaseDays: 3 },
+		priority: 20,
+		enabled: true,
+	},
+	{
+		name: "late_fee_rule",
+		trigger: "event" as const,
+		action: "create_late_fee",
+		parameters: { feeAmountCents: 5000, dueDays: 30, graceDays: 45 },
+		priority: 30,
+		enabled: true,
+	},
+] as const;
+
+export interface SeedCollectionRulesResult {
+	created: number;
+	ruleIdsByName: {
+		late_fee_rule: Id<"collectionRules">;
+		retry_rule: Id<"collectionRules">;
+		schedule_rule: Id<"collectionRules">;
+	};
+	skipped: number;
+}
+
+export async function seedCollectionRulesImpl(
+	ctx: Pick<MutationCtx, "db">
+): Promise<SeedCollectionRulesResult> {
+	let created = 0;
+	let skipped = 0;
+	const ruleIdsByName = {} as SeedCollectionRulesResult["ruleIdsByName"];
+
+	for (const ruleDef of DEFAULT_COLLECTION_RULES) {
+		const existing = await ctx.db
+			.query("collectionRules")
+			.filter((q) => q.eq(q.field("name"), ruleDef.name))
+			.first();
+
+		if (existing) {
+			ruleIdsByName[ruleDef.name] = existing._id;
+			skipped++;
+			continue;
+		}
+
+		const now = Date.now();
+		const ruleId = await ctx.db.insert("collectionRules", {
+			...ruleDef,
+			createdAt: now,
+			updatedAt: now,
+		});
+		ruleIdsByName[ruleDef.name] = ruleId;
+		created++;
+	}
+
+	return { created, skipped, ruleIdsByName };
+}

--- a/convex/payments/collectionPlan/engine.ts
+++ b/convex/payments/collectionPlan/engine.ts
@@ -3,6 +3,11 @@ import { internal } from "../../_generated/api";
 import type { Doc, Id } from "../../_generated/dataModel";
 import type { ActionCtx } from "../../_generated/server";
 import { internalAction } from "../../_generated/server";
+import {
+	type CollectionRuleKind,
+	getCollectionRuleCode,
+	getCollectionRuleKind,
+} from "./ruleContract";
 import { lateFeeRuleHandler } from "./rules/lateFeeRule";
 import { retryRuleHandler } from "./rules/retryRule";
 import { scheduleRuleHandler } from "./rules/scheduleRule";
@@ -22,10 +27,10 @@ export interface RuleHandler {
 
 // ─── Handler Registry ────────────────────────────────────
 
-const ruleHandlerRegistry: Record<string, RuleHandler> = {
-	schedule_rule: scheduleRuleHandler,
-	retry_rule: retryRuleHandler,
-	late_fee_rule: lateFeeRuleHandler,
+const ruleHandlerRegistry: Partial<Record<CollectionRuleKind, RuleHandler>> = {
+	schedule: scheduleRuleHandler,
+	retry: retryRuleHandler,
+	late_fee: lateFeeRuleHandler,
 };
 
 // ─── Engine Action ───────────────────────────────────────
@@ -44,14 +49,26 @@ export const evaluateRules = internalAction({
 	handler: async (ctx, args) => {
 		const rules = await ctx.runQuery(
 			internal.payments.collectionPlan.queries.getEnabledRules,
-			{ trigger: args.trigger }
+			{
+				asOfMs: Date.now(),
+				mortgageId: args.mortgageId,
+				trigger: args.trigger,
+			}
 		);
 
 		for (const rule of rules) {
-			const handler = ruleHandlerRegistry[rule.name];
+			const ruleKind = getCollectionRuleKind(rule);
+			if (!ruleKind) {
+				console.warn(
+					`[rules-engine] Rule ${getCollectionRuleCode(rule)} has no resolvable kind`
+				);
+				continue;
+			}
+
+			const handler = ruleHandlerRegistry[ruleKind];
 			if (!handler) {
 				console.warn(
-					`[rules-engine] No handler registered for rule: ${rule.name}`
+					`[rules-engine] No handler registered for kind=${ruleKind} code=${getCollectionRuleCode(rule)}`
 				);
 				continue;
 			}

--- a/convex/payments/collectionPlan/execution.ts
+++ b/convex/payments/collectionPlan/execution.ts
@@ -3,8 +3,10 @@
  *
  * This is the AMPS-owned business command for taking one eligible
  * `collectionPlanEntries` row and turning it into exactly one business
- * `collectionAttempts` record. It stops at the Unified Payment Rails handoff
- * boundary by creating a transfer request through the transfer domain contract.
+ * `collectionAttempts` record. The page-03 spine now carries that execution
+ * through transfer-request creation, Unified Payment Rails initiation, and the
+ * initial Collection Attempt GT progression that reflects real initiation
+ * outcomes.
  *
  * Spec: https://www.notion.so/337fc1b440248115b4d3c21577f27601
  */
@@ -12,7 +14,7 @@
 import { v } from "convex/values";
 import { internal } from "../../_generated/api";
 import type { Doc, Id } from "../../_generated/dataModel";
-import type { MutationCtx } from "../../_generated/server";
+import type { ActionCtx, MutationCtx } from "../../_generated/server";
 import { auditLog } from "../../auditLog";
 import { convex } from "../../fluent";
 import {
@@ -234,6 +236,26 @@ const stagePlanEntryExecution = convex
 				existingAttempt.executionIdempotencyKey ?? normalizedIdempotencyKey;
 			const reconciledExecutedAt =
 				existingAttempt.executionRequestedAt ?? existingAttempt.initiatedAt;
+			let recoveredTransferRequestId = existingAttempt.transferRequestId;
+			if (!recoveredTransferRequestId) {
+				const existingTransfer = await ctx.db
+					.query("transferRequests")
+					.withIndex("by_idempotency", (q) =>
+						q.eq(
+							"idempotencyKey",
+							buildTransferHandoffIdempotencyKey(planEntry._id)
+						)
+					)
+					.first();
+
+				if (existingTransfer) {
+					recoveredTransferRequestId = existingTransfer._id;
+					await ctx.db.patch(existingAttempt._id, {
+						transferRequestId: existingTransfer._id,
+					});
+				}
+			}
+
 			if (
 				planEntry.collectionAttemptId !== existingAttempt._id ||
 				planEntry.executedAt !== reconciledExecutedAt ||
@@ -256,14 +278,15 @@ const stagePlanEntryExecution = convex
 				planEntryStatusAfter: "executing",
 				collectionAttemptId: existingAttempt._id,
 				attemptStatusAfter: existingAttempt.status,
-				transferRequestId: existingAttempt.transferRequestId,
+				transferRequestId: recoveredTransferRequestId,
 				reasonCode: "plan_entry_already_executed",
 				reasonDetail:
 					"Collection plan entry already has a business collection attempt.",
 			});
-			if (existingAttempt.transferRequestId) {
+			if (recoveredTransferRequestId) {
 				await logPlanEntryExecutionAudit(ctx, args, result);
 				return {
+					existingTransferRequestId: recoveredTransferRequestId,
 					result,
 				};
 			}
@@ -291,6 +314,7 @@ const stagePlanEntryExecution = convex
 
 			await logPlanEntryExecutionAudit(ctx, args, result);
 			return {
+				existingTransferRequestId: recoveredTransferRequestId,
 				result,
 				transferHandoffRequest: buildTransferHandoffRequest({
 					context: handoffContext,
@@ -407,6 +431,165 @@ const stagePlanEntryExecution = convex
 export const stagePlanEntryExecutionMutation =
 	stagePlanEntryExecution.internal();
 
+const getCollectionAttemptForExecution = convex
+	.query()
+	.input({
+		attemptId: v.id("collectionAttempts"),
+	})
+	.handler(async (ctx, args) => {
+		return ctx.db.get(args.attemptId);
+	});
+export const getCollectionAttemptForExecutionQuery =
+	getCollectionAttemptForExecution.internal();
+
+type ExecutionActionCtx = Pick<
+	ActionCtx,
+	"runAction" | "runMutation" | "runQuery"
+>;
+
+interface TransferExecutionState {
+	providerRef?: string;
+	settledAt?: number;
+	status: string;
+}
+
+interface AttemptExecutionState {
+	machineContext?: Record<string, unknown>;
+	status: string;
+}
+
+async function fireCollectionAttemptTransition(args: {
+	attemptId: Id<"collectionAttempts">;
+	ctx: ExecutionActionCtx;
+	eventType:
+		| "DRAW_FAILED"
+		| "DRAW_INITIATED"
+		| "FUNDS_SETTLED"
+		| "MAX_RETRIES_EXCEEDED"
+		| "RETRY_ELIGIBLE";
+	payload?: Record<string, unknown>;
+	source: ReturnType<typeof buildExecutionSource>;
+}) {
+	return args.ctx.runMutation(
+		internal.engine.transitionMutation.transitionMutation,
+		{
+			entityType: "collectionAttempt",
+			entityId: args.attemptId,
+			eventType: args.eventType,
+			payload: args.payload ?? {},
+			source: args.source,
+		}
+	);
+}
+
+async function advanceAttemptForTransferState(args: {
+	attemptId: Id<"collectionAttempts">;
+	ctx: ExecutionActionCtx;
+	source: ReturnType<typeof buildExecutionSource>;
+	transferRequestId: Id<"transferRequests">;
+}) {
+	const transfer = (await args.ctx.runQuery(
+		internal.payments.transfers.queries.getTransferInternal,
+		{
+			transferId: args.transferRequestId,
+		}
+	)) as TransferExecutionState | null;
+	if (!transfer) {
+		return "initiated";
+	}
+
+	let attemptStatusAfter = "initiated";
+
+	if (
+		transfer.providerRef &&
+		(transfer.status === "pending" ||
+			transfer.status === "processing" ||
+			transfer.status === "confirmed")
+	) {
+		const drawInitiated = await fireCollectionAttemptTransition({
+			ctx: args.ctx,
+			attemptId: args.attemptId,
+			eventType: "DRAW_INITIATED",
+			payload: { providerRef: transfer.providerRef },
+			source: args.source,
+		});
+
+		attemptStatusAfter = drawInitiated.success
+			? drawInitiated.newState
+			: drawInitiated.previousState;
+	}
+
+	if (transfer.status === "confirmed") {
+		const fundsSettled = await fireCollectionAttemptTransition({
+			ctx: args.ctx,
+			attemptId: args.attemptId,
+			eventType: "FUNDS_SETTLED",
+			payload: { settledAt: transfer.settledAt ?? Date.now() },
+			source: args.source,
+		});
+
+		attemptStatusAfter = fundsSettled.success
+			? fundsSettled.newState
+			: attemptStatusAfter;
+	}
+
+	return attemptStatusAfter;
+}
+
+async function progressAttemptFailure(args: {
+	attemptId: Id<"collectionAttempts">;
+	ctx: ExecutionActionCtx;
+	failureCode: ExecutePlanEntryReasonCode;
+	failureReason: string;
+	source: ReturnType<typeof buildExecutionSource>;
+}) {
+	const drawFailed = await fireCollectionAttemptTransition({
+		ctx: args.ctx,
+		attemptId: args.attemptId,
+		eventType: "DRAW_FAILED",
+		payload: {
+			code: args.failureCode,
+			reason: args.failureReason,
+		},
+		source: args.source,
+	});
+
+	const attemptStatusAfter = drawFailed.success
+		? drawFailed.newState
+		: drawFailed.previousState;
+
+	const attempt = (await args.ctx.runQuery(
+		internal.payments.collectionPlan.execution
+			.getCollectionAttemptForExecutionQuery,
+		{
+			attemptId: args.attemptId,
+		}
+	)) as AttemptExecutionState | null;
+	if (!attempt || attempt.status !== "failed") {
+		return attemptStatusAfter;
+	}
+
+	const retryCount =
+		typeof attempt.machineContext?.retryCount === "number"
+			? attempt.machineContext.retryCount
+			: 0;
+	const maxRetries =
+		typeof attempt.machineContext?.maxRetries === "number"
+			? attempt.machineContext.maxRetries
+			: 3;
+	const followupEvent =
+		retryCount < maxRetries ? "RETRY_ELIGIBLE" : "MAX_RETRIES_EXCEEDED";
+
+	const followup = await fireCollectionAttemptTransition({
+		ctx: args.ctx,
+		attemptId: args.attemptId,
+		eventType: followupEvent,
+		source: args.source,
+	});
+
+	return followup.success ? followup.newState : attemptStatusAfter;
+}
+
 export const recordTransferHandoffSuccess = convex
 	.mutation()
 	.input({
@@ -468,7 +651,13 @@ export const executePlanEntry = convex
 				.stagePlanEntryExecutionMutation,
 			args
 		);
-		const { result, transferHandoffRequest } = staged;
+		const { existingTransferRequestId, result, transferHandoffRequest } =
+			staged;
+		const executionSource = buildExecutionSource({
+			triggerSource: args.triggerSource,
+			requestedByActorId: args.requestedByActorId,
+		});
+
 		if (
 			result.outcome !== "attempt_created" &&
 			result.outcome !== "already_executed"
@@ -476,50 +665,70 @@ export const executePlanEntry = convex
 			return result;
 		}
 
-		if (!transferHandoffRequest || result.transferRequestId) {
-			return result;
-		}
+		let transferRequestId =
+			existingTransferRequestId ?? result.transferRequestId;
 
 		try {
-			const firstObligationId = transferHandoffRequest.obligationIds[0];
-			const transferRequestId = await ctx.runMutation(
-				internal.payments.transfers.mutations.createTransferRequestInternal,
+			if (!transferRequestId && transferHandoffRequest) {
+				const firstObligationId = transferHandoffRequest.obligationIds[0];
+				transferRequestId = await ctx.runMutation(
+					internal.payments.transfers.mutations.createTransferRequestInternal,
+					{
+						direction: "inbound",
+						transferType: obligationTypeToTransferType(
+							transferHandoffRequest.primaryObligationType
+						),
+						amount: transferHandoffRequest.amount,
+						counterpartyType: "borrower",
+						counterpartyId: transferHandoffRequest.counterpartyId,
+						mortgageId: transferHandoffRequest.mortgageId,
+						obligationId: firstObligationId,
+						planEntryId: transferHandoffRequest.planEntryId,
+						collectionAttemptId: transferHandoffRequest.collectionAttemptId,
+						borrowerId: transferHandoffRequest.borrowerId,
+						providerCode: transferHandoffRequest.providerCode,
+						idempotencyKey: buildTransferHandoffIdempotencyKey(
+							transferHandoffRequest.planEntryId
+						),
+						metadata: buildTransferHandoffMetadata(
+							transferHandoffRequest,
+							transferHandoffRequest.primaryObligationType
+						),
+						source: transferHandoffRequest.source,
+					}
+				);
+
+				await ctx.runMutation(
+					internal.payments.collectionPlan.execution
+						.recordTransferHandoffSuccessMutation,
+					{
+						attemptId: result.collectionAttemptId,
+						transferRequestId,
+					}
+				);
+			}
+
+			if (!transferRequestId) {
+				return result;
+			}
+
+			await ctx.runAction(
+				internal.payments.transfers.mutations.initiateTransferInternal,
 				{
-					direction: "inbound",
-					transferType: obligationTypeToTransferType(
-						transferHandoffRequest.primaryObligationType
-					),
-					amount: transferHandoffRequest.amount,
-					counterpartyType: "borrower",
-					counterpartyId: transferHandoffRequest.counterpartyId,
-					mortgageId: transferHandoffRequest.mortgageId,
-					obligationId: firstObligationId,
-					planEntryId: transferHandoffRequest.planEntryId,
-					collectionAttemptId: transferHandoffRequest.collectionAttemptId,
-					borrowerId: transferHandoffRequest.borrowerId,
-					providerCode: transferHandoffRequest.providerCode,
-					idempotencyKey: buildTransferHandoffIdempotencyKey(
-						transferHandoffRequest.planEntryId
-					),
-					metadata: buildTransferHandoffMetadata(
-						transferHandoffRequest,
-						transferHandoffRequest.primaryObligationType
-					),
-					source: transferHandoffRequest.source,
+					transferId: transferRequestId,
 				}
 			);
 
-			await ctx.runMutation(
-				internal.payments.collectionPlan.execution
-					.recordTransferHandoffSuccessMutation,
-				{
-					attemptId: result.collectionAttemptId,
-					transferRequestId,
-				}
-			);
+			const attemptStatusAfter = await advanceAttemptForTransferState({
+				attemptId: result.collectionAttemptId,
+				ctx,
+				source: executionSource,
+				transferRequestId,
+			});
 
 			return {
 				...result,
+				attemptStatusAfter,
 				transferRequestId,
 			};
 		} catch (error) {
@@ -535,11 +744,22 @@ export const executePlanEntry = convex
 				}
 			);
 
+			const attemptStatusAfter = await progressAttemptFailure({
+				attemptId: result.collectionAttemptId,
+				ctx,
+				failureCode:
+					"transfer_handoff_failed" satisfies ExecutePlanEntryReasonCode,
+				failureReason: reasonDetail,
+				source: executionSource,
+			});
+
 			return {
 				...result,
+				attemptStatusAfter,
 				reasonCode:
 					"transfer_handoff_failed" satisfies ExecutePlanEntryReasonCode,
 				reasonDetail,
+				transferRequestId,
 			};
 		}
 	})

--- a/convex/payments/collectionPlan/executionContract.ts
+++ b/convex/payments/collectionPlan/executionContract.ts
@@ -144,6 +144,7 @@ export interface TransferHandoffRequest {
 }
 
 export interface StagePlanEntryExecutionResult {
+	existingTransferRequestId?: Id<"transferRequests">;
 	result: ExecutePlanEntryResult;
 	transferHandoffRequest?: TransferHandoffRequest;
 }

--- a/convex/payments/collectionPlan/initialScheduling.ts
+++ b/convex/payments/collectionPlan/initialScheduling.ts
@@ -79,7 +79,8 @@ async function getUpcomingObligationsInWindow(
 
 async function getCoveredPlanEntriesForObligations(
 	ctx: Pick<MutationCtx, "db">,
-	obligationIds: readonly Id<"obligations">[]
+	obligationIds: readonly Id<"obligations">[],
+	scheduledBefore: number
 ): Promise<Record<string, Id<"collectionPlanEntries">>> {
 	if (obligationIds.length === 0) {
 		return {};
@@ -91,7 +92,9 @@ async function getCoveredPlanEntriesForObligations(
 			NON_CANCELLED_PLAN_ENTRY_STATUSES.map((status) =>
 				ctx.db
 					.query("collectionPlanEntries")
-					.withIndex("by_status", (q) => q.eq("status", status))
+					.withIndex("by_status_scheduled_date", (q) =>
+						q.eq("status", status).lte("scheduledDate", scheduledBefore)
+					)
 					.collect()
 			)
 		)
@@ -139,7 +142,8 @@ export async function scheduleInitialEntriesImpl(
 
 	const coveredObligations = await getCoveredPlanEntriesForObligations(
 		ctx,
-		obligations.map((obligation) => obligation._id)
+		obligations.map((obligation) => obligation._id),
+		dueBefore
 	);
 
 	const createdPlanEntryIds: Id<"collectionPlanEntries">[] = [];

--- a/convex/payments/collectionPlan/initialScheduling.ts
+++ b/convex/payments/collectionPlan/initialScheduling.ts
@@ -1,0 +1,174 @@
+import { ConvexError } from "convex/values";
+import type { Id } from "../../_generated/dataModel";
+import type { MutationCtx } from "../../_generated/server";
+
+const MS_PER_DAY = 86_400_000;
+
+const NON_CANCELLED_PLAN_ENTRY_STATUSES = [
+	"planned",
+	"executing",
+	"completed",
+	"rescheduled",
+] as const;
+
+interface CreateCollectionPlanEntryArgs {
+	amount: number;
+	method: string;
+	obligationIds: Id<"obligations">[];
+	rescheduledFromId?: Id<"collectionPlanEntries">;
+	ruleId?: Id<"collectionRules">;
+	scheduledDate: number;
+	source: "default_schedule" | "retry_rule" | "late_fee_rule" | "admin";
+	status: "planned" | "executing" | "completed" | "cancelled" | "rescheduled";
+}
+
+export interface ScheduleInitialEntriesArgs {
+	delayDays: number;
+	mortgageId?: Id<"mortgages">;
+	nowMs?: number;
+	ruleId?: Id<"collectionRules">;
+}
+
+export interface ScheduleInitialEntriesResult {
+	created: number;
+	createdPlanEntryIds: Id<"collectionPlanEntries">[];
+	obligationIds: Id<"obligations">[];
+	reused: number;
+	reusedPlanEntryIds: Id<"collectionPlanEntries">[];
+}
+
+async function createEntryImpl(
+	ctx: Pick<MutationCtx, "db">,
+	args: CreateCollectionPlanEntryArgs
+): Promise<Id<"collectionPlanEntries">> {
+	return await ctx.db.insert("collectionPlanEntries", {
+		obligationIds: args.obligationIds,
+		amount: args.amount,
+		method: args.method,
+		scheduledDate: args.scheduledDate,
+		status: args.status,
+		source: args.source,
+		ruleId: args.ruleId,
+		rescheduledFromId: args.rescheduledFromId,
+		createdAt: Date.now(),
+	});
+}
+
+async function getUpcomingObligationsInWindow(
+	ctx: Pick<MutationCtx, "db">,
+	args: { dueBefore: number; mortgageId?: Id<"mortgages"> }
+) {
+	if (args.mortgageId) {
+		const mortgageId = args.mortgageId;
+		return await ctx.db
+			.query("obligations")
+			.withIndex("by_mortgage_and_date", (q) =>
+				q.eq("mortgageId", mortgageId).lte("dueDate", args.dueBefore)
+			)
+			.filter((q) => q.eq(q.field("status"), "upcoming"))
+			.collect();
+	}
+
+	return await ctx.db
+		.query("obligations")
+		.withIndex("by_due_date", (q) =>
+			q.eq("status", "upcoming").lte("dueDate", args.dueBefore)
+		)
+		.collect();
+}
+
+async function getCoveredPlanEntriesForObligations(
+	ctx: Pick<MutationCtx, "db">,
+	obligationIds: readonly Id<"obligations">[]
+): Promise<Record<string, Id<"collectionPlanEntries">>> {
+	if (obligationIds.length === 0) {
+		return {};
+	}
+
+	const lookupSet = new Set(obligationIds);
+	const existingEntries = (
+		await Promise.all(
+			NON_CANCELLED_PLAN_ENTRY_STATUSES.map((status) =>
+				ctx.db
+					.query("collectionPlanEntries")
+					.withIndex("by_status", (q) => q.eq("status", status))
+					.collect()
+			)
+		)
+	).flat();
+
+	const result: Record<string, Id<"collectionPlanEntries">> = {};
+
+	for (const entry of existingEntries) {
+		for (const obligationId of entry.obligationIds) {
+			if (lookupSet.has(obligationId) && !(obligationId in result)) {
+				result[obligationId] = entry._id;
+			}
+		}
+	}
+
+	return result;
+}
+
+export async function scheduleInitialEntriesImpl(
+	ctx: Pick<MutationCtx, "db">,
+	args: ScheduleInitialEntriesArgs
+): Promise<ScheduleInitialEntriesResult> {
+	if (!Number.isFinite(args.delayDays) || args.delayDays < 0) {
+		throw new ConvexError(
+			`delayDays must be a non-negative finite number, received ${args.delayDays}`
+		);
+	}
+
+	const now = args.nowMs ?? Date.now();
+	const dueBefore = now + args.delayDays * MS_PER_DAY;
+	const obligations = await getUpcomingObligationsInWindow(ctx, {
+		mortgageId: args.mortgageId,
+		dueBefore,
+	});
+
+	if (obligations.length === 0) {
+		return {
+			created: 0,
+			createdPlanEntryIds: [],
+			obligationIds: [],
+			reused: 0,
+			reusedPlanEntryIds: [],
+		};
+	}
+
+	const coveredObligations = await getCoveredPlanEntriesForObligations(
+		ctx,
+		obligations.map((obligation) => obligation._id)
+	);
+
+	const createdPlanEntryIds: Id<"collectionPlanEntries">[] = [];
+	const reusedPlanEntryIds: Id<"collectionPlanEntries">[] = [];
+
+	for (const obligation of obligations) {
+		const existingEntryId = coveredObligations[obligation._id];
+		if (existingEntryId) {
+			reusedPlanEntryIds.push(existingEntryId);
+			continue;
+		}
+
+		const entryId = await createEntryImpl(ctx, {
+			obligationIds: [obligation._id],
+			amount: obligation.amount,
+			method: "manual",
+			scheduledDate: obligation.dueDate - args.delayDays * MS_PER_DAY,
+			status: "planned",
+			source: "default_schedule",
+			ruleId: args.ruleId,
+		});
+		createdPlanEntryIds.push(entryId);
+	}
+
+	return {
+		created: createdPlanEntryIds.length,
+		createdPlanEntryIds,
+		obligationIds: obligations.map((obligation) => obligation._id),
+		reused: reusedPlanEntryIds.length,
+		reusedPlanEntryIds,
+	};
+}

--- a/convex/payments/collectionPlan/mutations.ts
+++ b/convex/payments/collectionPlan/mutations.ts
@@ -1,5 +1,6 @@
 import { v } from "convex/values";
 import { internalMutation } from "../../_generated/server";
+import { scheduleInitialEntriesImpl } from "./initialScheduling";
 
 /**
  * Creates a new collection plan entry.
@@ -27,8 +28,8 @@ export const createEntry = internalMutation({
 		ruleId: v.optional(v.id("collectionRules")),
 		rescheduledFromId: v.optional(v.id("collectionPlanEntries")),
 	},
-	handler: async (ctx, args) => {
-		return await ctx.db.insert("collectionPlanEntries", {
+	handler: async (ctx, args) =>
+		await ctx.db.insert("collectionPlanEntries", {
 			obligationIds: args.obligationIds,
 			amount: args.amount,
 			method: args.method,
@@ -38,6 +39,19 @@ export const createEntry = internalMutation({
 			ruleId: args.ruleId,
 			rescheduledFromId: args.rescheduledFromId,
 			createdAt: Date.now(),
-		});
+		}),
+});
+
+/**
+ * Canonical initial scheduling seam used by both the schedule rule and
+ * bootstrap/activation-style orchestration.
+ */
+export const scheduleInitialEntries = internalMutation({
+	args: {
+		delayDays: v.number(),
+		mortgageId: v.optional(v.id("mortgages")),
+		nowMs: v.optional(v.number()),
+		ruleId: v.optional(v.id("collectionRules")),
 	},
+	handler: async (ctx, args) => await scheduleInitialEntriesImpl(ctx, args),
 });

--- a/convex/payments/collectionPlan/queries.ts
+++ b/convex/payments/collectionPlan/queries.ts
@@ -142,8 +142,9 @@ export const getDuePlannedEntries = internalQuery({
 
 		return await ctx.db
 			.query("collectionPlanEntries")
-			.withIndex("by_scheduled_date", (q) => q.lte("scheduledDate", asOf))
-			.filter((q) => q.eq(q.field("status"), "planned"))
+			.withIndex("by_status_scheduled_date", (q) =>
+				q.eq("status", "planned").lte("scheduledDate", asOf)
+			)
 			.take(boundedLimit);
 	},
 });

--- a/convex/payments/collectionPlan/queries.ts
+++ b/convex/payments/collectionPlan/queries.ts
@@ -1,21 +1,34 @@
 import { v } from "convex/values";
 import { internalQuery } from "../../_generated/server";
+import {
+	compareCollectionRules,
+	isCollectionRuleActive,
+	isCollectionRuleEffectiveAt,
+	matchesCollectionRuleScope,
+} from "./ruleContract";
 
 /**
- * Returns all enabled collection rules for a given trigger type,
- * sorted by priority (ascending) via the by_trigger index.
+ * Returns all active collection rules for a given trigger type, filtered by
+ * optional scope and effective window, then sorted deterministically.
  */
 export const getEnabledRules = internalQuery({
 	args: {
+		asOfMs: v.optional(v.number()),
+		mortgageId: v.optional(v.id("mortgages")),
 		trigger: v.union(v.literal("schedule"), v.literal("event")),
 	},
-	handler: async (ctx, { trigger }) => {
-		return await ctx.db
+	handler: async (ctx, { trigger, mortgageId, asOfMs }) => {
+		const ruleCandidates = await ctx.db
 			.query("collectionRules")
-			.withIndex("by_trigger", (q) =>
-				q.eq("trigger", trigger).eq("enabled", true)
-			)
+			.withIndex("by_trigger", (q) => q.eq("trigger", trigger))
 			.collect();
+
+		const effectiveAt = asOfMs ?? Date.now();
+		return ruleCandidates
+			.filter((rule) => isCollectionRuleActive(rule))
+			.filter((rule) => isCollectionRuleEffectiveAt(rule, effectiveAt))
+			.filter((rule) => matchesCollectionRuleScope(rule, mortgageId))
+			.sort(compareCollectionRules);
 	},
 });
 

--- a/convex/payments/collectionPlan/queries.ts
+++ b/convex/payments/collectionPlan/queries.ts
@@ -113,6 +113,29 @@ export const getPlanEntriesByStatus = internalQuery({
 });
 
 /**
+ * Returns due `planned` collection plan entries up to a bounded limit.
+ *
+ * This is the production-safe scheduler selection path for the page-03
+ * execution spine. It intentionally returns only rows that are still in the
+ * `planned` state so cron reruns naturally skip already-consumed work.
+ */
+export const getDuePlannedEntries = internalQuery({
+	args: {
+		asOf: v.number(),
+		limit: v.optional(v.number()),
+	},
+	handler: async (ctx, { asOf, limit }) => {
+		const boundedLimit = Math.max(1, Math.min(limit ?? 25, 100));
+
+		return await ctx.db
+			.query("collectionPlanEntries")
+			.withIndex("by_scheduled_date", (q) => q.lte("scheduledDate", asOf))
+			.filter((q) => q.eq(q.field("status"), "planned"))
+			.take(boundedLimit);
+	},
+});
+
+/**
  * Idempotency check for the retry rule.
  * Returns the first retry-sourced plan entry that was rescheduled from the
  * given plan entry ID. Used to prevent duplicate retry entries on re-delivery.

--- a/convex/payments/collectionPlan/ruleContract.ts
+++ b/convex/payments/collectionPlan/ruleContract.ts
@@ -155,10 +155,12 @@ function readLegacyNumberParameter(
 	if (
 		parameters &&
 		typeof parameters === "object" &&
-		!Array.isArray(parameters) &&
-		typeof (parameters as Record<string, unknown>)[key] === "number"
+		!Array.isArray(parameters)
 	) {
-		return (parameters as Record<string, number>)[key];
+		const value = (parameters as Record<string, unknown>)[key];
+		if (typeof value === "number" && Number.isInteger(value) && value >= 0) {
+			return value;
+		}
 	}
 
 	return undefined;
@@ -167,11 +169,17 @@ function readLegacyNumberParameter(
 export function getCollectionRuleKind(
 	rule: Doc<"collectionRules">
 ): CollectionRuleKind | null {
+	const configKind = rule.config?.kind;
+	if (rule.kind && configKind && rule.kind !== configKind) {
+		throw new Error(
+			`Collection rule kind mismatch for ${rule._id}: rule.kind=${rule.kind} config.kind=${configKind}`
+		);
+	}
+
 	if (rule.kind) {
 		return rule.kind;
 	}
 
-	const configKind = rule.config?.kind;
 	if (isCollectionRuleKind(configKind)) {
 		return configKind;
 	}

--- a/convex/payments/collectionPlan/ruleContract.ts
+++ b/convex/payments/collectionPlan/ruleContract.ts
@@ -1,0 +1,321 @@
+import { v } from "convex/values";
+import type { Doc, Id } from "../../_generated/dataModel";
+
+export type CollectionRuleKind =
+	| "schedule"
+	| "retry"
+	| "late_fee"
+	| "balance_pre_check"
+	| "reschedule_policy"
+	| "workout_policy";
+
+export type CollectionRuleStatus = "draft" | "active" | "disabled" | "archived";
+
+export type CollectionRuleScope =
+	| { scopeType: "global" }
+	| { scopeType: "mortgage"; mortgageId: Id<"mortgages"> };
+
+export interface ScheduleRuleConfig {
+	delayDays: number;
+	kind: "schedule";
+}
+
+export interface RetryRuleConfig {
+	backoffBaseDays: number;
+	kind: "retry";
+	maxRetries: number;
+}
+
+export interface LateFeeRuleConfig {
+	feeCode: "late_fee";
+	feeSurface: "borrower_charge";
+	kind: "late_fee";
+}
+
+export interface BalancePreCheckRuleConfig {
+	kind: "balance_pre_check";
+	mode: "placeholder";
+}
+
+export interface ReschedulePolicyRuleConfig {
+	kind: "reschedule_policy";
+	mode: "placeholder";
+}
+
+export interface WorkoutPolicyRuleConfig {
+	kind: "workout_policy";
+	mode: "placeholder";
+}
+
+export type CollectionRuleConfig =
+	| ScheduleRuleConfig
+	| RetryRuleConfig
+	| LateFeeRuleConfig
+	| BalancePreCheckRuleConfig
+	| ReschedulePolicyRuleConfig
+	| WorkoutPolicyRuleConfig;
+
+export const collectionRuleKindValidator = v.union(
+	v.literal("schedule"),
+	v.literal("retry"),
+	v.literal("late_fee"),
+	v.literal("balance_pre_check"),
+	v.literal("reschedule_policy"),
+	v.literal("workout_policy")
+);
+
+export const collectionRuleStatusValidator = v.union(
+	v.literal("draft"),
+	v.literal("active"),
+	v.literal("disabled"),
+	v.literal("archived")
+);
+
+export const collectionRuleScopeValidator = v.union(
+	v.object({
+		scopeType: v.literal("global"),
+	}),
+	v.object({
+		scopeType: v.literal("mortgage"),
+		mortgageId: v.id("mortgages"),
+	})
+);
+
+export const collectionRuleConfigValidator = v.union(
+	v.object({
+		kind: v.literal("schedule"),
+		delayDays: v.number(),
+	}),
+	v.object({
+		kind: v.literal("retry"),
+		maxRetries: v.number(),
+		backoffBaseDays: v.number(),
+	}),
+	v.object({
+		kind: v.literal("late_fee"),
+		feeCode: v.literal("late_fee"),
+		feeSurface: v.literal("borrower_charge"),
+	}),
+	v.object({
+		kind: v.literal("balance_pre_check"),
+		mode: v.literal("placeholder"),
+	}),
+	v.object({
+		kind: v.literal("reschedule_policy"),
+		mode: v.literal("placeholder"),
+	}),
+	v.object({
+		kind: v.literal("workout_policy"),
+		mode: v.literal("placeholder"),
+	})
+);
+
+export const DEFAULT_COLLECTION_RULE_SCOPE: CollectionRuleScope = {
+	scopeType: "global",
+};
+
+export const DEFAULT_COLLECTION_RULE_STATUS: CollectionRuleStatus = "active";
+
+const LEGACY_RULE_NAME_TO_KIND: Record<string, CollectionRuleKind> = {
+	late_fee_rule: "late_fee",
+	retry_rule: "retry",
+	schedule_rule: "schedule",
+};
+
+const DEFAULT_RULE_DISPLAY_NAMES: Record<CollectionRuleKind, string> = {
+	balance_pre_check: "Balance pre-check",
+	late_fee: "Late fee assessment",
+	reschedule_policy: "Borrower reschedule policy",
+	retry: "Retry collection",
+	schedule: "Initial scheduling",
+	workout_policy: "Workout strategy",
+};
+
+const DEFAULT_LATE_FEE_CONFIG: LateFeeRuleConfig = {
+	kind: "late_fee",
+	feeCode: "late_fee",
+	feeSurface: "borrower_charge",
+};
+
+function isCollectionRuleKind(value: unknown): value is CollectionRuleKind {
+	return (
+		value === "schedule" ||
+		value === "retry" ||
+		value === "late_fee" ||
+		value === "balance_pre_check" ||
+		value === "reschedule_policy" ||
+		value === "workout_policy"
+	);
+}
+
+function readLegacyNumberParameter(
+	parameters: unknown,
+	key: string
+): number | undefined {
+	if (
+		parameters &&
+		typeof parameters === "object" &&
+		!Array.isArray(parameters) &&
+		typeof (parameters as Record<string, unknown>)[key] === "number"
+	) {
+		return (parameters as Record<string, number>)[key];
+	}
+
+	return undefined;
+}
+
+export function getCollectionRuleKind(
+	rule: Doc<"collectionRules">
+): CollectionRuleKind | null {
+	if (rule.kind) {
+		return rule.kind;
+	}
+
+	const configKind = rule.config?.kind;
+	if (isCollectionRuleKind(configKind)) {
+		return configKind;
+	}
+
+	if (rule.name) {
+		return LEGACY_RULE_NAME_TO_KIND[rule.name] ?? null;
+	}
+
+	return null;
+}
+
+export function getCollectionRuleCode(rule: Doc<"collectionRules">): string {
+	const kind = getCollectionRuleKind(rule);
+	return rule.code ?? rule.name ?? (kind ? `${kind}_rule` : String(rule._id));
+}
+
+export function getCollectionRuleDisplayName(
+	rule: Doc<"collectionRules">
+): string {
+	const kind = getCollectionRuleKind(rule);
+	return rule.displayName ?? (kind ? DEFAULT_RULE_DISPLAY_NAMES[kind] : "Rule");
+}
+
+export function getCollectionRuleStatus(
+	rule: Doc<"collectionRules">
+): CollectionRuleStatus {
+	if (rule.status) {
+		return rule.status;
+	}
+
+	return rule.enabled === false ? "disabled" : "active";
+}
+
+export function isCollectionRuleActive(rule: Doc<"collectionRules">): boolean {
+	return getCollectionRuleStatus(rule) === "active";
+}
+
+export function getCollectionRuleScope(
+	rule: Doc<"collectionRules">
+): CollectionRuleScope {
+	if (rule.scope?.scopeType === "mortgage") {
+		return rule.scope;
+	}
+
+	return DEFAULT_COLLECTION_RULE_SCOPE;
+}
+
+export function matchesCollectionRuleScope(
+	rule: Doc<"collectionRules">,
+	mortgageId?: Id<"mortgages">
+): boolean {
+	const scope = getCollectionRuleScope(rule);
+	if (scope.scopeType === "global") {
+		return true;
+	}
+
+	return mortgageId !== undefined && scope.mortgageId === mortgageId;
+}
+
+export function isCollectionRuleEffectiveAt(
+	rule: Doc<"collectionRules">,
+	asOfMs: number
+): boolean {
+	if (rule.effectiveFrom !== undefined && asOfMs < rule.effectiveFrom) {
+		return false;
+	}
+
+	if (rule.effectiveTo !== undefined && asOfMs > rule.effectiveTo) {
+		return false;
+	}
+
+	return true;
+}
+
+export function compareCollectionRules(
+	left: Doc<"collectionRules">,
+	right: Doc<"collectionRules">
+): number {
+	if (left.priority !== right.priority) {
+		return left.priority - right.priority;
+	}
+
+	const leftCode = getCollectionRuleCode(left);
+	const rightCode = getCollectionRuleCode(right);
+	if (leftCode !== rightCode) {
+		return leftCode.localeCompare(rightCode);
+	}
+
+	if (left.createdAt !== right.createdAt) {
+		return left.createdAt - right.createdAt;
+	}
+
+	return String(left._id).localeCompare(String(right._id));
+}
+
+export function getScheduleRuleConfig(
+	rule: Doc<"collectionRules">
+): ScheduleRuleConfig | null {
+	if (rule.config?.kind === "schedule") {
+		return rule.config;
+	}
+
+	const kind = getCollectionRuleKind(rule);
+	if (kind !== "schedule") {
+		return null;
+	}
+
+	return {
+		kind: "schedule",
+		delayDays: readLegacyNumberParameter(rule.parameters, "delayDays") ?? 5,
+	};
+}
+
+export function getRetryRuleConfig(
+	rule: Doc<"collectionRules">
+): RetryRuleConfig | null {
+	if (rule.config?.kind === "retry") {
+		return rule.config;
+	}
+
+	const kind = getCollectionRuleKind(rule);
+	if (kind !== "retry") {
+		return null;
+	}
+
+	return {
+		kind: "retry",
+		maxRetries: readLegacyNumberParameter(rule.parameters, "maxRetries") ?? 3,
+		backoffBaseDays:
+			readLegacyNumberParameter(rule.parameters, "backoffBaseDays") ?? 3,
+	};
+}
+
+export function getLateFeeRuleConfig(
+	rule: Doc<"collectionRules">
+): LateFeeRuleConfig | null {
+	if (rule.config?.kind === "late_fee") {
+		return rule.config;
+	}
+
+	const kind = getCollectionRuleKind(rule);
+	if (kind !== "late_fee") {
+		return null;
+	}
+
+	return DEFAULT_LATE_FEE_CONFIG;
+}

--- a/convex/payments/collectionPlan/rules/lateFeeRule.ts
+++ b/convex/payments/collectionPlan/rules/lateFeeRule.ts
@@ -3,6 +3,7 @@ import { internal } from "../../../_generated/api";
 import type { Id } from "../../../_generated/dataModel";
 import type { ActionCtx } from "../../../_generated/server";
 import type { RuleEvalContext, RuleHandler } from "../engine";
+import { getLateFeeRuleConfig } from "../ruleContract";
 
 const MS_PER_DAY = 86_400_000;
 
@@ -45,6 +46,14 @@ export const lateFeeRuleHandler: RuleHandler = {
 			return;
 		}
 
+		const config = getLateFeeRuleConfig(evalCtx.rule);
+		if (!config) {
+			console.warn(
+				`[late-fee-rule] Missing typed config for rule ${String(evalCtx.rule._id)}`
+			);
+			return;
+		}
+
 		const payload = evalCtx.eventPayload as
 			| ObligationOverduePayload
 			| undefined;
@@ -83,8 +92,8 @@ export const lateFeeRuleHandler: RuleHandler = {
 		const now = Date.now();
 		const mortgageFee = await ctx.runQuery(getActiveMortgageFeeReference, {
 			mortgageId,
-			code: "late_fee",
-			surface: "borrower_charge",
+			code: config.feeCode,
+			surface: config.feeSurface,
 			asOfDate: toIsoDateString(now),
 		});
 		if (!mortgageFee) {
@@ -122,7 +131,7 @@ export const lateFeeRuleHandler: RuleHandler = {
 			dueDate: now + dueDays * MS_PER_DAY,
 			gracePeriodEnd: now + graceDays * MS_PER_DAY,
 			sourceObligationId: obligationId,
-			feeCode: "late_fee",
+			feeCode: config.feeCode,
 			mortgageFeeId: mortgageFee._id,
 			status: "upcoming",
 		});

--- a/convex/payments/collectionPlan/rules/retryRule.ts
+++ b/convex/payments/collectionPlan/rules/retryRule.ts
@@ -2,6 +2,7 @@ import { internal } from "../../../_generated/api";
 import type { Id } from "../../../_generated/dataModel";
 import type { ActionCtx } from "../../../_generated/server";
 import type { RuleEvalContext, RuleHandler } from "../engine";
+import { getRetryRuleConfig } from "../ruleContract";
 
 const MS_PER_DAY = 86_400_000;
 
@@ -26,11 +27,14 @@ export const retryRuleHandler: RuleHandler = {
 			return;
 		}
 
-		const params = evalCtx.rule.parameters as
-			| { maxRetries?: number; backoffBaseDays?: number }
-			| undefined;
-		const maxRetries = params?.maxRetries ?? 3;
-		const backoffBaseDays = params?.backoffBaseDays ?? 3;
+		const config = getRetryRuleConfig(evalCtx.rule);
+		if (!config) {
+			console.warn(
+				`[retry-rule] Missing typed config for rule ${String(evalCtx.rule._id)}`
+			);
+			return;
+		}
+		const { backoffBaseDays, maxRetries } = config;
 
 		const payload = evalCtx.eventPayload as
 			| Partial<CollectionFailedPayload>

--- a/convex/payments/collectionPlan/rules/scheduleRule.ts
+++ b/convex/payments/collectionPlan/rules/scheduleRule.ts
@@ -2,6 +2,7 @@ import { internal } from "../../../_generated/api";
 import type { Id } from "../../../_generated/dataModel";
 import type { ActionCtx } from "../../../_generated/server";
 import type { RuleEvalContext, RuleHandler } from "../engine";
+import { getScheduleRuleConfig } from "../ruleContract";
 
 /**
  * ScheduleRule: scans upcoming obligations within a rolling window and
@@ -10,16 +11,19 @@ import type { RuleEvalContext, RuleHandler } from "../engine";
  */
 export const scheduleRuleHandler: RuleHandler = {
 	async evaluate(ctx: ActionCtx, evalCtx: RuleEvalContext): Promise<void> {
-		const params = evalCtx.rule.parameters as
-			| { delayDays?: number }
-			| undefined;
-		const delayDays = params?.delayDays ?? 5;
+		const config = getScheduleRuleConfig(evalCtx.rule);
+		if (!config) {
+			console.warn(
+				`[schedule-rule] Missing typed config for rule ${String(evalCtx.rule._id)}`
+			);
+			return;
+		}
 
 		await ctx.runMutation(
 			internal.payments.collectionPlan.mutations.scheduleInitialEntries,
 			{
 				mortgageId: evalCtx.mortgageId as Id<"mortgages"> | undefined,
-				delayDays,
+				delayDays: config.delayDays,
 				ruleId: evalCtx.rule._id,
 			}
 		);

--- a/convex/payments/collectionPlan/rules/scheduleRule.ts
+++ b/convex/payments/collectionPlan/rules/scheduleRule.ts
@@ -1,9 +1,7 @@
 import { internal } from "../../../_generated/api";
-import type { Doc } from "../../../_generated/dataModel";
+import type { Id } from "../../../_generated/dataModel";
 import type { ActionCtx } from "../../../_generated/server";
 import type { RuleEvalContext, RuleHandler } from "../engine";
-
-const MS_PER_DAY = 86_400_000;
 
 /**
  * ScheduleRule: scans upcoming obligations within a rolling window and
@@ -17,41 +15,13 @@ export const scheduleRuleHandler: RuleHandler = {
 			| undefined;
 		const delayDays = params?.delayDays ?? 5;
 
-		const dueBefore = Date.now() + delayDays * MS_PER_DAY;
-
-		const obligations = await ctx.runQuery(
-			internal.obligations.queries.getUpcomingInWindow,
-			{ mortgageId: evalCtx.mortgageId, dueBefore }
-		);
-
-		if (obligations.length === 0) {
-			return;
-		}
-
-		// Batch idempotency check: load planned entries once for all obligations
-		const coveredObligations = await ctx.runQuery(
-			internal.payments.collectionPlan.queries.getPlannedEntriesForObligations,
-			{ obligationIds: obligations.map((o: Doc<"obligations">) => o._id) }
-		);
-
-		for (const obligation of obligations) {
-			// Skip if a plan entry already covers this obligation
-			if (obligation._id in coveredObligations) {
-				continue;
+		await ctx.runMutation(
+			internal.payments.collectionPlan.mutations.scheduleInitialEntries,
+			{
+				mortgageId: evalCtx.mortgageId as Id<"mortgages"> | undefined,
+				delayDays,
+				ruleId: evalCtx.rule._id,
 			}
-
-			await ctx.runMutation(
-				internal.payments.collectionPlan.mutations.createEntry,
-				{
-					obligationIds: [obligation._id],
-					amount: obligation.amount,
-					method: "manual",
-					scheduledDate: obligation.dueDate - delayDays * MS_PER_DAY,
-					status: "planned",
-					source: "default_schedule",
-					ruleId: evalCtx.rule._id,
-				}
-			);
-		}
+		);
 	},
 };

--- a/convex/payments/collectionPlan/runner.ts
+++ b/convex/payments/collectionPlan/runner.ts
@@ -59,39 +59,51 @@ export const processDuePlanEntries = internalAction({
 		for (const entry of dueEntries) {
 			summary.attemptedCount += 1;
 
-			const result = await ctx.runAction(
-				internal.payments.collectionPlan.execution.executePlanEntry,
-				{
-					planEntryId: entry._id,
-					triggerSource: "system_scheduler",
-					requestedAt,
-					idempotencyKey: buildSchedulerExecutionIdempotencyKey(`${entry._id}`),
-					requestedByActorType: "system",
-					requestedByActorId: "collection-plan-runner",
-				}
-			);
-
-			switch (result.outcome) {
-				case "attempt_created":
-					summary.attemptCreatedCount += 1;
-					if (result.reasonCode === "transfer_handoff_failed") {
-						summary.handoffFailureCount += 1;
+			try {
+				const result = await ctx.runAction(
+					internal.payments.collectionPlan.execution.executePlanEntry,
+					{
+						planEntryId: entry._id,
+						triggerSource: "system_scheduler",
+						requestedAt,
+						idempotencyKey: buildSchedulerExecutionIdempotencyKey(
+							`${entry._id}`
+						),
+						requestedByActorType: "system",
+						requestedByActorId: "collection-plan-runner",
 					}
-					break;
-				case "already_executed":
-					summary.alreadyExecutedCount += 1;
-					break;
-				case "not_eligible":
-					summary.notEligibleCount += 1;
-					break;
-				case "rejected":
-					summary.rejectedCount += 1;
-					break;
-				case "noop":
-					summary.noopCount += 1;
-					break;
-				default:
-					break;
+				);
+
+				switch (result.outcome) {
+					case "attempt_created":
+						summary.attemptCreatedCount += 1;
+						if (result.reasonCode === "transfer_handoff_failed") {
+							summary.handoffFailureCount += 1;
+						}
+						break;
+					case "already_executed":
+						summary.alreadyExecutedCount += 1;
+						break;
+					case "not_eligible":
+						summary.notEligibleCount += 1;
+						break;
+					case "rejected":
+						summary.rejectedCount += 1;
+						break;
+					case "noop":
+						summary.noopCount += 1;
+						break;
+					default:
+						break;
+				}
+			} catch (error) {
+				console.error(
+					"[collection-plan-runner] failed to execute due plan entry",
+					{
+						error,
+						planEntryId: `${entry._id}`,
+					}
+				);
 			}
 		}
 

--- a/convex/payments/collectionPlan/runner.ts
+++ b/convex/payments/collectionPlan/runner.ts
@@ -1,0 +1,104 @@
+import { v } from "convex/values";
+import { internal } from "../../_generated/api";
+import type { Doc } from "../../_generated/dataModel";
+import { internalAction } from "../../_generated/server";
+
+const DEFAULT_BATCH_SIZE = 25;
+const MAX_BATCH_SIZE = 100;
+
+function clampBatchSize(batchSize: number | undefined) {
+	return Math.max(1, Math.min(batchSize ?? DEFAULT_BATCH_SIZE, MAX_BATCH_SIZE));
+}
+
+function buildSchedulerExecutionIdempotencyKey(planEntryId: string) {
+	return `collection-plan-runner:${planEntryId}`;
+}
+
+interface DuePlanEntriesSummary {
+	alreadyExecutedCount: number;
+	attemptCreatedCount: number;
+	attemptedCount: number;
+	batchSize: number;
+	handoffFailureCount: number;
+	noopCount: number;
+	notEligibleCount: number;
+	rejectedCount: number;
+	requestedAt: number;
+	selectedCount: number;
+}
+
+export const processDuePlanEntries = internalAction({
+	args: {
+		asOf: v.optional(v.number()),
+		batchSize: v.optional(v.number()),
+	},
+	handler: async (ctx, args): Promise<DuePlanEntriesSummary> => {
+		const requestedAt = args.asOf ?? Date.now();
+		const batchSize = clampBatchSize(args.batchSize);
+		const dueEntries: Doc<"collectionPlanEntries">[] = await ctx.runQuery(
+			internal.payments.collectionPlan.queries.getDuePlannedEntries,
+			{
+				asOf: requestedAt,
+				limit: batchSize,
+			}
+		);
+
+		const summary: DuePlanEntriesSummary = {
+			requestedAt,
+			batchSize,
+			selectedCount: dueEntries.length,
+			attemptedCount: 0,
+			attemptCreatedCount: 0,
+			alreadyExecutedCount: 0,
+			notEligibleCount: 0,
+			rejectedCount: 0,
+			noopCount: 0,
+			handoffFailureCount: 0,
+		};
+
+		for (const entry of dueEntries) {
+			summary.attemptedCount += 1;
+
+			const result = await ctx.runAction(
+				internal.payments.collectionPlan.execution.executePlanEntry,
+				{
+					planEntryId: entry._id,
+					triggerSource: "system_scheduler",
+					requestedAt,
+					idempotencyKey: buildSchedulerExecutionIdempotencyKey(`${entry._id}`),
+					requestedByActorType: "system",
+					requestedByActorId: "collection-plan-runner",
+				}
+			);
+
+			switch (result.outcome) {
+				case "attempt_created":
+					summary.attemptCreatedCount += 1;
+					if (result.reasonCode === "transfer_handoff_failed") {
+						summary.handoffFailureCount += 1;
+					}
+					break;
+				case "already_executed":
+					summary.alreadyExecutedCount += 1;
+					break;
+				case "not_eligible":
+					summary.notEligibleCount += 1;
+					break;
+				case "rejected":
+					summary.rejectedCount += 1;
+					break;
+				case "noop":
+					summary.noopCount += 1;
+					break;
+				default:
+					break;
+			}
+		}
+
+		console.info(
+			"[collection-plan-runner] processed due plan entries",
+			summary
+		);
+		return summary;
+	},
+});

--- a/convex/payments/collectionPlan/seed.ts
+++ b/convex/payments/collectionPlan/seed.ts
@@ -1,31 +1,5 @@
 import { internalMutation } from "../../_generated/server";
-
-const DEFAULT_RULES = [
-	{
-		name: "schedule_rule",
-		trigger: "schedule" as const,
-		action: "create_plan_entry",
-		parameters: { delayDays: 5 },
-		priority: 10,
-		enabled: true,
-	},
-	{
-		name: "retry_rule",
-		trigger: "event" as const,
-		action: "create_retry_entry",
-		parameters: { maxRetries: 3, backoffBaseDays: 3 },
-		priority: 20,
-		enabled: true,
-	},
-	{
-		name: "late_fee_rule",
-		trigger: "event" as const,
-		action: "create_late_fee",
-		parameters: { feeAmountCents: 5000, dueDays: 30, graceDays: 45 },
-		priority: 30,
-		enabled: true,
-	},
-];
+import { seedCollectionRulesImpl } from "./defaultRules";
 
 /**
  * Seeds the collectionRules table with default rules.
@@ -33,30 +7,5 @@ const DEFAULT_RULES = [
  */
 export const seedCollectionRules = internalMutation({
 	args: {},
-	handler: async (ctx) => {
-		let created = 0;
-		let skipped = 0;
-
-		for (const ruleDef of DEFAULT_RULES) {
-			const existing = await ctx.db
-				.query("collectionRules")
-				.filter((q) => q.eq(q.field("name"), ruleDef.name))
-				.first();
-
-			if (existing) {
-				skipped++;
-				continue;
-			}
-
-			const now = Date.now();
-			await ctx.db.insert("collectionRules", {
-				...ruleDef,
-				createdAt: now,
-				updatedAt: now,
-			});
-			created++;
-		}
-
-		return { created, skipped };
-	},
+	handler: async (ctx) => seedCollectionRulesImpl(ctx),
 });

--- a/convex/payments/collectionPlan/seed.ts
+++ b/convex/payments/collectionPlan/seed.ts
@@ -2,8 +2,8 @@ import { internalMutation } from "../../_generated/server";
 import { seedCollectionRulesImpl } from "./defaultRules";
 
 /**
- * Seeds the collectionRules table with default rules.
- * Idempotent: skips any rule whose `name` already exists.
+ * Seeds the collectionRules table with canonical typed default rules.
+ * Idempotent across both typed rows and legacy default rows keyed by code/name.
  */
 export const seedCollectionRules = internalMutation({
 	args: {},

--- a/convex/payments/methods/interface.ts
+++ b/convex/payments/methods/interface.ts
@@ -12,6 +12,17 @@
  *   provider execution is delegated through transfer infrastructure.
  */
 
+export const LEGACY_PAYMENT_METHOD_CODES = ["manual", "mock_pad"] as const;
+
+export type LegacyPaymentMethodCode =
+	(typeof LEGACY_PAYMENT_METHOD_CODES)[number];
+
+export function isLegacyPaymentMethodCode(
+	value: string
+): value is LegacyPaymentMethodCode {
+	return (LEGACY_PAYMENT_METHOD_CODES as readonly string[]).includes(value);
+}
+
 // ---------------------------------------------------------------------------
 // Params & Results
 // ---------------------------------------------------------------------------
@@ -21,7 +32,7 @@ export interface InitiateParams {
 	amount: number;
 	borrowerId: string;
 	metadata?: Record<string, unknown>;
-	method: string;
+	method: LegacyPaymentMethodCode;
 	mortgageId: string;
 	planEntryId: string;
 }
@@ -50,6 +61,10 @@ export interface StatusResult {
 // Compatibility interface
 // ---------------------------------------------------------------------------
 
+/**
+ * @deprecated Compatibility-only inbound provider contract. New provider work
+ * must target `TransferProvider` instead.
+ */
 export interface PaymentMethod {
 	cancel(ref: string): Promise<CancelResult>;
 	confirm(ref: string): Promise<ConfirmResult>;

--- a/convex/payments/methods/manual.ts
+++ b/convex/payments/methods/manual.ts
@@ -18,6 +18,7 @@ import type {
 	StatusResult,
 } from "./interface";
 
+/** @deprecated Compatibility-only manual inbound implementation. */
 export class ManualPaymentMethod implements PaymentMethod {
 	async initiate(params: InitiateParams): Promise<InitiateResult> {
 		return {

--- a/convex/payments/methods/mockPAD.ts
+++ b/convex/payments/methods/mockPAD.ts
@@ -64,6 +64,7 @@ export type ScheduleSettlementFn = (
 // Implementation
 // ---------------------------------------------------------------------------
 
+/** @deprecated Compatibility-only mock inbound implementation. */
 export class MockPADMethod implements PaymentMethod {
 	private readonly config: MockPADConfig;
 	private readonly scheduleSettlement: ScheduleSettlementFn;

--- a/convex/payments/methods/registry.ts
+++ b/convex/payments/methods/registry.ts
@@ -19,7 +19,12 @@
  */
 
 import { ConvexError } from "convex/values";
-import type { PaymentMethod } from "./interface";
+import {
+	isLegacyPaymentMethodCode,
+	LEGACY_PAYMENT_METHOD_CODES,
+	type LegacyPaymentMethodCode,
+	type PaymentMethod,
+} from "./interface";
 import { ManualPaymentMethod } from "./manual";
 import {
 	type MockPADConfig,
@@ -52,7 +57,7 @@ const noopScheduler: ScheduleSettlementFn = async () => {
 // ---------------------------------------------------------------------------
 
 function buildMethod(
-	method: string,
+	method: LegacyPaymentMethodCode,
 	scheduleSettlement: ScheduleSettlementFn,
 	mockPADConfig?: Partial<MockPADConfig>
 ): PaymentMethod {
@@ -61,9 +66,26 @@ function buildMethod(
 			return new ManualPaymentMethod();
 		case "mock_pad":
 			return new MockPADMethod(scheduleSettlement, mockPADConfig);
-		default:
-			throw new ConvexError(`Unknown payment method: "${method}"`);
+		default: {
+			const exhaustiveCheck: never = method;
+			void exhaustiveCheck;
+			throw new ConvexError("Unknown legacy payment method");
+		}
 	}
+}
+
+function assertLegacyPaymentMethodCode(
+	method: string
+): asserts method is LegacyPaymentMethodCode {
+	if (isLegacyPaymentMethodCode(method)) {
+		return;
+	}
+
+	throw new ConvexError(
+		`Unknown legacy payment method: "${method}". ` +
+			`PaymentMethod compatibility supports only ${LEGACY_PAYMENT_METHOD_CODES.map((code) => `"${code}"`).join(", ")}. ` +
+			"Use TransferProvider and the transfer-domain provider registry for new inbound work."
+	);
 }
 
 // ---------------------------------------------------------------------------
@@ -73,8 +95,12 @@ function buildMethod(
 /**
  * Quick lookup for payment methods that don't need a scheduler (e.g. manual).
  * If a method tries to schedule, it throws at call-time with a clear message.
+ *
+ * @deprecated Compatibility-only registry. New inbound provider resolution must
+ * use the transfer-domain provider registry.
  */
 export function getPaymentMethod(method: string): PaymentMethod {
+	assertLegacyPaymentMethodCode(method);
 	return buildMethod(method, noopScheduler);
 }
 
@@ -85,10 +111,15 @@ export function getPaymentMethod(method: string): PaymentMethod {
 /**
  * Creates a registry function pre-wired with a scheduler and optional config.
  * Use this in production Convex actions/mutations where `ctx.scheduler` is available.
+ *
+ * @deprecated Compatibility-only registry. New inbound provider resolution must
+ * use the transfer-domain provider registry.
  */
 export function createPaymentMethodRegistry(
 	config: PaymentMethodRegistryConfig
 ): (method: string) => PaymentMethod {
-	return (method: string) =>
-		buildMethod(method, config.scheduleSettlement, config.mockPADConfig);
+	return (method: string) => {
+		assertLegacyPaymentMethodCode(method);
+		return buildMethod(method, config.scheduleSettlement, config.mockPADConfig);
+	};
 }

--- a/convex/payments/transfers/__tests__/collectionAttemptReconciliation.integration.test.ts
+++ b/convex/payments/transfers/__tests__/collectionAttemptReconciliation.integration.test.ts
@@ -1,0 +1,580 @@
+import auditLogTest from "convex-audit-log/test";
+import { convexTest } from "convex-test";
+import { afterAll, describe, expect, it, vi } from "vitest";
+import workflowSchema from "../../../../node_modules/@convex-dev/workflow/dist/component/schema.js";
+import workpoolSchema from "../../../../node_modules/@convex-dev/workpool/dist/component/schema.js";
+import { api } from "../../../_generated/api";
+import type { Id } from "../../../_generated/dataModel";
+import type { MutationCtx } from "../../../_generated/server";
+import auditTrailSchema from "../../../components/auditTrail/schema";
+import { emitPaymentReceived } from "../../../engine/effects/collectionAttempt";
+import { applyPayment } from "../../../engine/effects/obligationPayment";
+import {
+	publishTransferCancelled,
+	publishTransferConfirmed,
+	publishTransferFailed,
+	publishTransferReversed,
+} from "../../../engine/effects/transfer";
+import schema from "../../../schema";
+import {
+	auditTrailModules,
+	convexModules,
+	workflowModules,
+	workpoolModules,
+} from "../../../test/moduleMaps";
+import { postObligationAccrued } from "../../cashLedger/integrations";
+
+const PAYMENT_HANDLER_IDENTITY = {
+	subject: "test-transfer-reconciliation-user",
+	issuer: "https://api.workos.com",
+	role: "admin",
+	roles: JSON.stringify(["admin"]),
+	permissions: JSON.stringify([
+		"payment:view",
+		"payment:manage",
+		"payment:retry",
+		"payment:cancel",
+	]),
+	user_email: "transfer-reconciliation-test@fairlend.ca",
+	user_first_name: "Transfer",
+	user_last_name: "Reconciliation",
+};
+
+const ADMIN_SOURCE = {
+	channel: "admin_dashboard" as const,
+	actorId: "test-transfer-reconciliation-admin",
+	actorType: "admin" as const,
+};
+
+type TestHarness = ReturnType<typeof convexTest>;
+
+function createHarness() {
+	process.env.DISABLE_GT_HASHCHAIN = "true";
+	process.env.DISABLE_CASH_LEDGER_HASHCHAIN = "true";
+	const t = convexTest(schema, convexModules);
+	auditLogTest.register(t, "auditLog");
+	t.registerComponent("auditTrail", auditTrailSchema, auditTrailModules);
+	t.registerComponent("workflow", workflowSchema, workflowModules);
+	t.registerComponent("workflow/workpool", workpoolSchema, workpoolModules);
+	return t;
+}
+
+function asPaymentUser(t: TestHarness) {
+	return t.withIdentity(PAYMENT_HANDLER_IDENTITY);
+}
+
+async function seedCoreEntities(t: TestHarness) {
+	return t.run(async (ctx) => {
+		const now = Date.now();
+
+		const brokerUserId = await ctx.db.insert("users", {
+			authId: `recon-broker-${now}`,
+			email: `recon-broker-${now}@fairlend.test`,
+			firstName: "Recon",
+			lastName: "Broker",
+		});
+		const brokerId = await ctx.db.insert("brokers", {
+			status: "active",
+			userId: brokerUserId,
+			createdAt: now,
+		});
+
+		const borrowerUserId = await ctx.db.insert("users", {
+			authId: `recon-borrower-${now}`,
+			email: `recon-borrower-${now}@fairlend.test`,
+			firstName: "Recon",
+			lastName: "Borrower",
+		});
+		const borrowerId = await ctx.db.insert("borrowers", {
+			status: "active",
+			userId: borrowerUserId,
+			createdAt: now,
+		});
+
+		const propertyId = await ctx.db.insert("properties", {
+			streetAddress: "789 Reconciliation Ave",
+			city: "Toronto",
+			province: "ON",
+			postalCode: "M5V 4D4",
+			propertyType: "residential",
+			createdAt: now,
+		});
+
+		const mortgageId = await ctx.db.insert("mortgages", {
+			status: "active",
+			propertyId,
+			principal: 10_000_000,
+			annualServicingRate: 0.01,
+			interestRate: 0.08,
+			rateType: "fixed",
+			termMonths: 12,
+			amortizationMonths: 12,
+			paymentAmount: 100_000,
+			paymentFrequency: "monthly",
+			loanType: "conventional",
+			lienPosition: 1,
+			interestAdjustmentDate: "2026-01-01",
+			termStartDate: "2026-01-01",
+			maturityDate: "2026-12-01",
+			firstPaymentDate: "2026-02-01",
+			brokerOfRecordId: brokerId,
+			createdAt: now,
+		});
+
+		return { borrowerId, mortgageId };
+	});
+}
+
+async function createDueObligationWithAccrual(
+	t: TestHarness,
+	args: {
+		mortgageId: Id<"mortgages">;
+		borrowerId: Id<"borrowers">;
+		amount: number;
+	}
+) {
+	return t.run(async (ctx) => {
+		const obligationId = await ctx.db.insert("obligations", {
+			status: "due",
+			machineContext: {},
+			lastTransitionAt: Date.now(),
+			mortgageId: args.mortgageId,
+			borrowerId: args.borrowerId,
+			paymentNumber: 1,
+			type: "regular_interest",
+			amount: args.amount,
+			amountSettled: 0,
+			dueDate: Date.parse("2026-03-01T00:00:00Z"),
+			gracePeriodEnd: Date.parse("2026-03-16T00:00:00Z"),
+			createdAt: Date.now(),
+		});
+
+		await postObligationAccrued(ctx, {
+			obligationId,
+			source: ADMIN_SOURCE,
+		});
+
+		return obligationId;
+	});
+}
+
+async function createPlanEntryAndAttempt(
+	t: TestHarness,
+	args: {
+		obligationIds: Id<"obligations">[];
+		amount: number;
+	}
+) {
+	return t.run(async (ctx) => {
+		const planEntryId = await ctx.db.insert("collectionPlanEntries", {
+			obligationIds: args.obligationIds,
+			amount: args.amount,
+			method: "manual",
+			scheduledDate: Date.parse("2026-03-15T00:00:00Z"),
+			status: "executing",
+			source: "default_schedule",
+			createdAt: Date.now(),
+		});
+
+		const attemptId = await ctx.db.insert("collectionAttempts", {
+			planEntryId,
+			amount: args.amount,
+			method: "manual",
+			status: "initiated",
+			machineContext: { attemptId: "", retryCount: 0, maxRetries: 3 },
+			initiatedAt: Date.now(),
+		});
+
+		return { attemptId, planEntryId };
+	});
+}
+
+let transferInsertCounter = 0;
+
+async function insertTransfer(
+	t: TestHarness,
+	overrides: Record<string, unknown>
+): Promise<Id<"transferRequests">> {
+	transferInsertCounter += 1;
+	return t.run(async (ctx) => {
+		const now = Date.now();
+		return ctx.db.insert("transferRequests", {
+			status: "initiated",
+			direction: "inbound",
+			transferType: "borrower_interest_collection",
+			amount: 50_000,
+			currency: "CAD",
+			counterpartyType: "borrower",
+			counterpartyId: "counterparty-default",
+			providerCode: "manual",
+			idempotencyKey: `transfer-recon-${transferInsertCounter}-${now}`,
+			source: ADMIN_SOURCE,
+			createdAt: now,
+			lastTransitionAt: now,
+			...overrides,
+		} as Parameters<typeof ctx.db.insert<"transferRequests">>[1]);
+	});
+}
+
+interface TransferEffectArgs {
+	effectName: string;
+	entityId: Id<"transferRequests">;
+	entityType: "transfer";
+	eventType: string;
+	journalEntryId: string;
+	payload?: Record<string, unknown>;
+	source: typeof ADMIN_SOURCE;
+}
+
+interface TransferEffectHandler {
+	_handler: (ctx: MutationCtx, args: TransferEffectArgs) => Promise<void>;
+}
+
+interface CollectionAttemptEffectHandler {
+	_handler: (
+		ctx: MutationCtx,
+		args: {
+			entityId: Id<"collectionAttempts">;
+			entityType: "collectionAttempt";
+			eventType: string;
+			journalEntryId: string;
+			effectName: string;
+			payload?: Record<string, unknown>;
+			source: typeof ADMIN_SOURCE;
+		}
+	) => Promise<void>;
+}
+
+const publishTransferFailedMutation =
+	publishTransferFailed as unknown as TransferEffectHandler;
+const publishTransferConfirmedMutation =
+	publishTransferConfirmed as unknown as TransferEffectHandler;
+const publishTransferCancelledMutation =
+	publishTransferCancelled as unknown as TransferEffectHandler;
+const publishTransferReversedMutation =
+	publishTransferReversed as unknown as TransferEffectHandler;
+const emitPaymentReceivedMutation =
+	emitPaymentReceived as unknown as CollectionAttemptEffectHandler;
+const applyPaymentMutation = applyPayment as unknown as {
+	_handler: (
+		ctx: MutationCtx,
+		args: {
+			entityId: Id<"obligations">;
+			entityType: "obligation";
+			eventType: string;
+			journalEntryId: string;
+			effectName: string;
+			payload?: Record<string, unknown>;
+			source: typeof ADMIN_SOURCE;
+		}
+	) => Promise<void>;
+};
+
+vi.useFakeTimers();
+
+afterAll(() => {
+	vi.clearAllTimers();
+	vi.useRealTimers();
+});
+
+/**
+ * Page-04 canonical inbound reconciliation tests.
+ * Spec: https://www.notion.so/337fc1b4402481a48a13ee61e289e8f0
+ *
+ * Use Cases covered:
+ * - UC-1: Provider-settled inbound transfer confirms the originating Collection Attempt
+ *
+ * Requirements covered:
+ * - REQ-1: Transfer lifecycle outcomes must reconcile to the linked Collection Attempt
+ * - REQ-2: Confirmed inbound collections must produce one business settlement outcome
+ * - REQ-3: Obligation application must stay downstream of the Collection Attempt boundary
+ * - REQ-4: Borrower cash posting must occur exactly once for attempt-linked inbound collections
+ * - REQ-5: Settlement-layer modules must not require plan-entry awareness to post money
+ */
+describe("collection attempt reconciliation for attempt-linked inbound transfers", () => {
+	it("publishTransferConfirmed settles the linked collection attempt and leaves inbound cash posting on the obligation path", async () => {
+		const t = createHarness();
+		const seeded = await seedCoreEntities(t);
+
+		const obligationId = await createDueObligationWithAccrual(t, {
+			mortgageId: seeded.mortgageId,
+			borrowerId: seeded.borrowerId,
+			amount: 50_000,
+		});
+		const { attemptId } = await createPlanEntryAndAttempt(t, {
+			obligationIds: [obligationId],
+			amount: 50_000,
+		});
+
+		const transferId = await insertTransfer(t, {
+			status: "confirmed",
+			mortgageId: seeded.mortgageId,
+			obligationId,
+			borrowerId: seeded.borrowerId,
+			counterpartyId: `${seeded.borrowerId}`,
+			collectionAttemptId: attemptId,
+		});
+
+		await t.run(async (ctx) => {
+			await ctx.db.patch(attemptId, {
+				transferRequestId: transferId,
+			});
+		});
+
+		await t.run(async (ctx) => {
+			await publishTransferConfirmedMutation._handler(ctx, {
+				entityId: transferId,
+				entityType: "transfer",
+				eventType: "FUNDS_SETTLED",
+				journalEntryId: "audit-transfer-settled",
+				effectName: "publishTransferConfirmed",
+				payload: { settledAt: Date.now() },
+				source: ADMIN_SOURCE,
+			});
+		});
+
+		await t.run(async (ctx) => {
+			const transfer = await ctx.db.get(transferId);
+			expect(transfer?.status).toBe("confirmed");
+			expect(transfer?.settledAt).toBeTypeOf("number");
+		});
+
+		await t.run(async (ctx) => {
+			await emitPaymentReceivedMutation._handler(ctx, {
+				entityId: attemptId,
+				entityType: "collectionAttempt",
+				eventType: "FUNDS_SETTLED",
+				journalEntryId: "audit-attempt-settled",
+				effectName: "emitPaymentReceived",
+				payload: { settledAt: Date.now() },
+				source: ADMIN_SOURCE,
+			});
+
+			await applyPaymentMutation._handler(ctx, {
+				entityId: obligationId,
+				entityType: "obligation",
+				eventType: "PAYMENT_APPLIED",
+				journalEntryId: "audit-obligation-payment-applied",
+				effectName: "applyPayment",
+				payload: {
+					amount: 50_000,
+					attemptId,
+					postingGroupId: `cash-receipt:${attemptId}`,
+				},
+				source: ADMIN_SOURCE,
+			});
+		});
+
+		await t.run(async (ctx) => {
+			const attempt = await ctx.db.get(attemptId);
+			expect(attempt?.status).toBe("confirmed");
+
+			const obligation = await ctx.db.get(obligationId);
+			expect(obligation?.status).toBe("settled");
+			expect(obligation?.amountSettled).toBe(50_000);
+
+			const transferEntries = await ctx.db
+				.query("cash_ledger_journal_entries")
+				.withIndex("by_transfer_request", (q) =>
+					q.eq("transferRequestId", transferId)
+				)
+				.collect();
+			expect(transferEntries).toHaveLength(0);
+
+			const obligationEntries = await ctx.db
+				.query("cash_ledger_journal_entries")
+				.withIndex("by_obligation_and_sequence", (q) =>
+					q.eq("obligationId", obligationId)
+				)
+				.collect();
+			const cashReceipts = obligationEntries.filter(
+				(entry) => entry.entryType === "CASH_RECEIVED"
+			);
+
+			expect(cashReceipts).toHaveLength(1);
+			expect(cashReceipts[0]?.attemptId).toBe(attemptId);
+			expect(cashReceipts[0]?.transferRequestId).toBeUndefined();
+		});
+	});
+
+	it("publishTransferFailed moves the linked attempt into retry_scheduled failure handling", async () => {
+		const t = createHarness();
+		const seeded = await seedCoreEntities(t);
+
+		const obligationId = await createDueObligationWithAccrual(t, {
+			mortgageId: seeded.mortgageId,
+			borrowerId: seeded.borrowerId,
+			amount: 50_000,
+		});
+		const { attemptId } = await createPlanEntryAndAttempt(t, {
+			obligationIds: [obligationId],
+			amount: 50_000,
+		});
+
+		const transferId = await insertTransfer(t, {
+			status: "pending",
+			mortgageId: seeded.mortgageId,
+			obligationId,
+			borrowerId: seeded.borrowerId,
+			counterpartyId: `${seeded.borrowerId}`,
+			collectionAttemptId: attemptId,
+		});
+
+		await t.run(async (ctx) => {
+			await ctx.db.patch(attemptId, {
+				status: "pending",
+				transferRequestId: transferId,
+			});
+		});
+
+		await t.run(async (ctx) => {
+			await publishTransferFailedMutation._handler(ctx, {
+				entityId: transferId,
+				entityType: "transfer",
+				eventType: "TRANSFER_FAILED",
+				journalEntryId: "audit-transfer-failed",
+				effectName: "publishTransferFailed",
+				payload: {
+					errorCode: "NSF",
+					reason: "insufficient_funds",
+				},
+				source: ADMIN_SOURCE,
+			});
+		});
+
+		await t.run(async (ctx) => {
+			const transfer = await ctx.db.get(transferId);
+			expect(transfer?.failureCode).toBe("NSF");
+			expect(transfer?.failureReason).toBe("insufficient_funds");
+			expect(transfer?.failedAt).toBeTypeOf("number");
+
+			const attempt = await ctx.db.get(attemptId);
+			expect(attempt?.status).toBe("retry_scheduled");
+		});
+	});
+
+	it("cancelTransfer cancels the linked collection attempt without posting money", async () => {
+		const t = createHarness();
+		const auth = asPaymentUser(t);
+		const seeded = await seedCoreEntities(t);
+
+		const obligationId = await createDueObligationWithAccrual(t, {
+			mortgageId: seeded.mortgageId,
+			borrowerId: seeded.borrowerId,
+			amount: 50_000,
+		});
+		const { attemptId } = await createPlanEntryAndAttempt(t, {
+			obligationIds: [obligationId],
+			amount: 50_000,
+		});
+
+		const transferId = await insertTransfer(t, {
+			status: "initiated",
+			mortgageId: seeded.mortgageId,
+			obligationId,
+			borrowerId: seeded.borrowerId,
+			counterpartyId: `${seeded.borrowerId}`,
+			collectionAttemptId: attemptId,
+		});
+
+		await t.run(async (ctx) => {
+			await ctx.db.patch(attemptId, {
+				transferRequestId: transferId,
+			});
+		});
+
+		const result = await auth.mutation(
+			api.payments.transfers.mutations.cancelTransfer,
+			{
+				transferId,
+				reason: "cancelled before settlement",
+			}
+		);
+
+		expect(result.success).toBe(true);
+		expect(result.newState).toBe("cancelled");
+
+		await t.run(async (ctx) => {
+			await publishTransferCancelledMutation._handler(ctx, {
+				entityId: transferId,
+				entityType: "transfer",
+				eventType: "TRANSFER_CANCELLED",
+				journalEntryId: "audit-transfer-cancelled",
+				effectName: "publishTransferCancelled",
+				payload: { reason: "cancelled before settlement" },
+				source: ADMIN_SOURCE,
+			});
+		});
+
+		await t.run(async (ctx) => {
+			const transfer = await ctx.db.get(transferId);
+			expect(transfer?.status).toBe("cancelled");
+
+			const attempt = await ctx.db.get(attemptId);
+			expect(attempt?.status).toBe("cancelled");
+
+			const transferEntries = await ctx.db
+				.query("cash_ledger_journal_entries")
+				.withIndex("by_transfer_request", (q) =>
+					q.eq("transferRequestId", transferId)
+				)
+				.collect();
+			expect(transferEntries).toHaveLength(0);
+		});
+	});
+
+	it("publishTransferReversed moves the linked confirmed attempt into reversed", async () => {
+		const t = createHarness();
+		const seeded = await seedCoreEntities(t);
+
+		const obligationId = await createDueObligationWithAccrual(t, {
+			mortgageId: seeded.mortgageId,
+			borrowerId: seeded.borrowerId,
+			amount: 50_000,
+		});
+		const { attemptId } = await createPlanEntryAndAttempt(t, {
+			obligationIds: [obligationId],
+			amount: 50_000,
+		});
+
+		const transferId = await insertTransfer(t, {
+			status: "confirmed",
+			mortgageId: seeded.mortgageId,
+			obligationId,
+			borrowerId: seeded.borrowerId,
+			counterpartyId: `${seeded.borrowerId}`,
+			collectionAttemptId: attemptId,
+		});
+
+		await t.run(async (ctx) => {
+			await ctx.db.patch(attemptId, {
+				status: "confirmed",
+				transferRequestId: transferId,
+			});
+		});
+
+		await t.run(async (ctx) => {
+			await publishTransferReversedMutation._handler(ctx, {
+				entityId: transferId,
+				entityType: "transfer",
+				eventType: "TRANSFER_REVERSED",
+				journalEntryId: "audit-transfer-reversed",
+				effectName: "publishTransferReversed",
+				payload: {
+					reversalRef: "REV-001",
+					reason: "chargeback",
+				},
+				source: ADMIN_SOURCE,
+			});
+		});
+
+		await t.run(async (ctx) => {
+			const transfer = await ctx.db.get(transferId);
+			expect(transfer?.reversalRef).toBe("REV-001");
+			expect(transfer?.reversedAt).toBeTypeOf("number");
+
+			const attempt = await ctx.db.get(attemptId);
+			expect(attempt?.status).toBe("reversed");
+		});
+	});
+});

--- a/convex/payments/transfers/__tests__/handlers.integration.test.ts
+++ b/convex/payments/transfers/__tests__/handlers.integration.test.ts
@@ -1,3 +1,4 @@
+import auditLogTest from "convex-audit-log/test";
 import { convexTest } from "convex-test";
 import { describe, expect, it, vi } from "vitest";
 import { api } from "../../../_generated/api";
@@ -5,7 +6,6 @@ import type { Id } from "../../../_generated/dataModel";
 import { FAIRLEND_STAFF_ORG_ID } from "../../../constants";
 import schema from "../../../schema";
 import { convexModules } from "../../../test/moduleMaps";
-import { registerAuditLogComponent } from "../../../test/registerAuditLogComponent";
 import { getOrCreateCashAccount } from "../../cashLedger/accounts";
 import { postObligationAccrued } from "../../cashLedger/integrations";
 
@@ -47,7 +47,7 @@ function createHarness() {
 	process.env.DISABLE_GT_HASHCHAIN = "true";
 	process.env.DISABLE_CASH_LEDGER_HASHCHAIN = "true";
 	const t = convexTest(schema, modules);
-	registerAuditLogComponent(t, "auditLog");
+	auditLogTest.register(t, "auditLog");
 	return t;
 }
 
@@ -482,33 +482,38 @@ describe("transfer handlers integration: mutations", () => {
 	});
 
 	it("cancelTransfer transitions initiated -> cancelled", async () => {
-		const t = createHarness();
-		const auth = asPaymentUser(t);
-		const seeded = await seedCoreEntities(t);
+		vi.useFakeTimers();
+		try {
+			const t = createHarness();
+			const auth = asPaymentUser(t);
+			const seeded = await seedCoreEntities(t);
 
-		const transferId = await insertTransfer(t, {
-			status: "initiated",
-			counterpartyId: `${seeded.borrowerId}`,
-			dealId: seeded.dealAId,
-			idempotencyKey: "cancel-valid-1",
-			createdAt: 1000,
-			lastTransitionAt: 1000,
-		});
+			const transferId = await insertTransfer(t, {
+				status: "initiated",
+				counterpartyId: `${seeded.borrowerId}`,
+				dealId: seeded.dealAId,
+				idempotencyKey: "cancel-valid-1",
+				createdAt: 1000,
+				lastTransitionAt: 1000,
+			});
 
-		const result = await auth.mutation(
-			api.payments.transfers.mutations.cancelTransfer,
-			{
-				transferId,
-				reason: "cancel integration test",
-			}
-		);
+			const result = await auth.mutation(
+				api.payments.transfers.mutations.cancelTransfer,
+				{
+					transferId,
+					reason: "cancel integration test",
+				}
+			);
 
-		expect(result.success).toBe(true);
-		expect(result.previousState).toBe("initiated");
-		expect(result.newState).toBe("cancelled");
+			expect(result.success).toBe(true);
+			expect(result.previousState).toBe("initiated");
+			expect(result.newState).toBe("cancelled");
 
-		const updated = await t.run(async (ctx) => ctx.db.get(transferId));
-		expect(updated?.status).toBe("cancelled");
+			const updated = await t.run(async (ctx) => ctx.db.get(transferId));
+			expect(updated?.status).toBe("cancelled");
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 
 	it("cancelTransfer rejects non-initiated statuses", async () => {

--- a/convex/payments/transfers/__tests__/reconciliation.test.ts
+++ b/convex/payments/transfers/__tests__/reconciliation.test.ts
@@ -86,23 +86,22 @@ describe("isFreshTransfer", () => {
 // ── Orphan Detection Logic ──────────────────────────────────────────
 
 describe("orphan detection", () => {
-	it("confirmed transfer with collectionAttemptId is NOT orphaned (bridged)", () => {
-		// The reconciliation cron skips transfers with collectionAttemptId
+	it("collectionAttemptId alone no longer proves a confirmed transfer is healthy", () => {
 		const transfer = {
 			status: "confirmed",
+			direction: "inbound",
 			collectionAttemptId: "attempt_001",
 		};
-		const isBridged = !!transfer.collectionAttemptId;
-		expect(isBridged).toBe(true);
+		expect(Boolean(transfer.collectionAttemptId)).toBe(true);
+		expect(transfer.direction).toBe("inbound");
 	});
 
-	it("confirmed transfer without collectionAttemptId IS a candidate for orphan check", () => {
+	it("non-attempt-linked confirmed transfers still rely on transfer-owned journal checks", () => {
 		const transfer = {
 			status: "confirmed",
 			collectionAttemptId: undefined,
 		};
-		const isBridged = !!transfer.collectionAttemptId;
-		expect(isBridged).toBe(false);
+		expect(Boolean(transfer.collectionAttemptId)).toBe(false);
 	});
 
 	it("only confirmed transfers are checked (not pending, failed, etc.)", () => {

--- a/convex/payments/transfers/__tests__/reconciliation.test.ts
+++ b/convex/payments/transfers/__tests__/reconciliation.test.ts
@@ -8,10 +8,10 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { checkOrphanedConfirmedTransfers } from "../../cashLedger/transferReconciliation";
-import { cashReceiptPostingGroupId } from "../collectionAttemptReconciliation";
 import type { Id } from "../../../_generated/dataModel";
 import type { QueryCtx } from "../../../_generated/server";
+import { checkOrphanedConfirmedTransfers } from "../../cashLedger/transferReconciliation";
+import { cashReceiptPostingGroupId } from "../collectionAttemptReconciliation";
 
 // ── Constants (mirrored from reconciliation.ts) ─────────────────────
 
@@ -89,9 +89,9 @@ describe("isFreshTransfer", () => {
 
 // ── Orphan Detection Logic ──────────────────────────────────────────
 
-type FakeTransferRequest = {
-	_id: Id<"transferRequests">;
+interface FakeTransferRequest {
 	_creationTime: number;
+	_id: Id<"transferRequests">;
 	amount: number;
 	collectionAttemptId?: Id<"collectionAttempts">;
 	confirmedAt?: number;
@@ -99,20 +99,20 @@ type FakeTransferRequest = {
 	mortgageId?: Id<"mortgages">;
 	obligationId?: Id<"obligations">;
 	status: "confirmed";
-};
+}
 
-type FakeCollectionAttempt = {
+interface FakeCollectionAttempt {
 	_id: Id<"collectionAttempts">;
 	status: "confirmed" | "reversed";
-};
+}
 
-type FakeJournalEntry = {
+interface FakeJournalEntry {
 	_id: Id<"cash_ledger_journal_entries">;
 	attemptId?: Id<"collectionAttempts">;
 	entryType: "CASH_RECEIVED" | "LENDER_PAYOUT_SENT" | "REVERSAL";
 	postingGroupId?: string;
 	transferRequestId?: Id<"transferRequests">;
-};
+}
 
 function createTransferReconciliationCtx(args: {
 	attempts?: FakeCollectionAttempt[];

--- a/convex/payments/transfers/__tests__/reconciliation.test.ts
+++ b/convex/payments/transfers/__tests__/reconciliation.test.ts
@@ -8,6 +8,10 @@
  */
 
 import { describe, expect, it } from "vitest";
+import { checkOrphanedConfirmedTransfers } from "../../cashLedger/transferReconciliation";
+import { cashReceiptPostingGroupId } from "../collectionAttemptReconciliation";
+import type { Id } from "../../../_generated/dataModel";
+import type { QueryCtx } from "../../../_generated/server";
 
 // ── Constants (mirrored from reconciliation.ts) ─────────────────────
 
@@ -85,23 +89,118 @@ describe("isFreshTransfer", () => {
 
 // ── Orphan Detection Logic ──────────────────────────────────────────
 
+type FakeTransferRequest = {
+	_id: Id<"transferRequests">;
+	_creationTime: number;
+	amount: number;
+	collectionAttemptId?: Id<"collectionAttempts">;
+	confirmedAt?: number;
+	direction: "inbound" | "outbound";
+	mortgageId?: Id<"mortgages">;
+	obligationId?: Id<"obligations">;
+	status: "confirmed";
+};
+
+type FakeCollectionAttempt = {
+	_id: Id<"collectionAttempts">;
+	status: "confirmed" | "reversed";
+};
+
+type FakeJournalEntry = {
+	_id: Id<"cash_ledger_journal_entries">;
+	attemptId?: Id<"collectionAttempts">;
+	entryType: "CASH_RECEIVED" | "LENDER_PAYOUT_SENT" | "REVERSAL";
+	postingGroupId?: string;
+	transferRequestId?: Id<"transferRequests">;
+};
+
+function createTransferReconciliationCtx(args: {
+	attempts?: FakeCollectionAttempt[];
+	entries?: FakeJournalEntry[];
+	transfers: FakeTransferRequest[];
+}): Pick<QueryCtx, "db"> {
+	return {
+		db: {
+			get: async (id) =>
+				args.attempts?.find((attempt) => attempt._id === id) ?? null,
+			query: (table: string) => ({
+				withIndex: () => ({
+					collect: async () => {
+						if (table === "transferRequests") {
+							return args.transfers;
+						}
+						if (table === "cash_ledger_journal_entries") {
+							return args.entries ?? [];
+						}
+						return [];
+					},
+				}),
+			}),
+		},
+	};
+}
+
 describe("orphan detection", () => {
-	it("collectionAttemptId alone no longer proves a confirmed transfer is healthy", () => {
+	it("treats attempt-linked inbound transfers as healthy when the matching cash receipt exists", async () => {
+		const now = Date.now();
+		const attemptId = "attempt_001" as Id<"collectionAttempts">;
+		const transferId = "transfer_001" as Id<"transferRequests">;
 		const transfer = {
-			status: "confirmed",
-			direction: "inbound",
-			collectionAttemptId: "attempt_001",
+			_id: transferId,
+			_creationTime: now - 10 * 60 * 1000,
+			amount: 50_000,
+			collectionAttemptId: attemptId,
+			confirmedAt: now - 10 * 60 * 1000,
+			direction: "inbound" as const,
+			status: "confirmed" as const,
 		};
-		expect(Boolean(transfer.collectionAttemptId)).toBe(true);
-		expect(transfer.direction).toBe("inbound");
+		const ctx = createTransferReconciliationCtx({
+			attempts: [{ _id: attemptId, status: "confirmed" }],
+			entries: [
+				{
+					_id: "entry_001" as Id<"cash_ledger_journal_entries">,
+					attemptId,
+					entryType: "CASH_RECEIVED",
+					postingGroupId: cashReceiptPostingGroupId(attemptId),
+					transferRequestId: transferId,
+				},
+			],
+			transfers: [transfer],
+		});
+
+		const result = await checkOrphanedConfirmedTransfers(ctx, {
+			nowMs: now,
+		});
+
+		expect(result.isHealthy).toBe(true);
+		expect(result.count).toBe(0);
 	});
 
-	it("non-attempt-linked confirmed transfers still rely on transfer-owned journal checks", () => {
+	it("treats non-attempt-linked confirmed transfers as orphaned when no journal entry exists", async () => {
+		const now = Date.now();
 		const transfer = {
-			status: "confirmed",
-			collectionAttemptId: undefined,
+			_id: "transfer_002" as Id<"transferRequests">,
+			_creationTime: now - 10 * 60 * 1000,
+			amount: 50_000,
+			confirmedAt: now - 10 * 60 * 1000,
+			direction: "inbound" as const,
+			status: "confirmed" as const,
 		};
-		expect(Boolean(transfer.collectionAttemptId)).toBe(false);
+		const ctx = createTransferReconciliationCtx({
+			transfers: [transfer],
+		});
+
+		const result = await checkOrphanedConfirmedTransfers(ctx, {
+			nowMs: now,
+		});
+
+		expect(result.isHealthy).toBe(false);
+		expect(result.count).toBe(1);
+		expect(result.items[0]).toMatchObject({
+			transferRequestId: transfer._id,
+			direction: "inbound",
+			amount: 50_000,
+		});
 	});
 
 	it("only confirmed transfers are checked (not pending, failed, etc.)", () => {

--- a/convex/payments/transfers/__tests__/transferMachine.test.ts
+++ b/convex/payments/transfers/__tests__/transferMachine.test.ts
@@ -290,11 +290,11 @@ describe("Transfer machine — actions fire on correct transitions", () => {
 		]);
 	});
 
-	it("initiated + TRANSFER_CANCELLED fires no actions", () => {
+	it("initiated + TRANSFER_CANCELLED fires publishTransferCancelled", () => {
 		const snap = getInitialSnapshot(transferMachine);
 		expect(
 			actionTypes(transferMachine, snap, EVENTS.TRANSFER_CANCELLED)
-		).toEqual([]);
+		).toEqual(["publishTransferCancelled"]);
 	});
 
 	it("pending + PROVIDER_ACKNOWLEDGED fires no actions (self-loop)", () => {

--- a/convex/payments/transfers/collectionAttemptReconciliation.ts
+++ b/convex/payments/transfers/collectionAttemptReconciliation.ts
@@ -1,0 +1,291 @@
+import type { Id } from "../../_generated/dataModel";
+import type { MutationCtx, QueryCtx } from "../../_generated/server";
+import { executeTransition } from "../../engine/transition";
+import type { CommandSource } from "../../engine/types";
+
+interface TransferAttemptLink {
+	collectionAttemptId?: Id<"collectionAttempts">;
+	direction?: string;
+}
+
+interface AttemptPostingHealth {
+	attemptId?: Id<"collectionAttempts">;
+	attemptStatus?: string;
+	hasPostingEntry: boolean;
+	isHealthy: boolean;
+	reason?:
+		| "missing_attempt"
+		| "attempt_status_mismatch"
+		| "missing_posting_entry";
+}
+
+type DbReader = Pick<QueryCtx, "db">;
+
+export function isAttemptLinkedInboundTransfer(
+	transfer: TransferAttemptLink
+): transfer is {
+	collectionAttemptId: Id<"collectionAttempts">;
+	direction: "inbound";
+} {
+	return (
+		transfer.direction === "inbound" &&
+		transfer.collectionAttemptId !== undefined
+	);
+}
+
+export function cashReceiptPostingGroupId(
+	attemptId: Id<"collectionAttempts">
+): string {
+	return `cash-receipt:${attemptId}`;
+}
+
+export function reversalPostingGroupId(
+	attemptId: Id<"collectionAttempts">
+): string {
+	return `reversal-group:${attemptId}`;
+}
+
+async function loadAttemptPostingHealth(
+	ctx: DbReader,
+	args: {
+		transfer: TransferAttemptLink;
+		expectedAttemptStatus: "confirmed" | "reversed";
+		postingGroupId: string;
+		entryType: "CASH_RECEIVED" | "REVERSAL";
+	}
+): Promise<AttemptPostingHealth> {
+	if (!isAttemptLinkedInboundTransfer(args.transfer)) {
+		return {
+			hasPostingEntry: false,
+			isHealthy: false,
+		};
+	}
+
+	const attempt = await ctx.db.get(args.transfer.collectionAttemptId);
+	if (!attempt) {
+		return {
+			attemptId: args.transfer.collectionAttemptId,
+			hasPostingEntry: false,
+			isHealthy: false,
+			reason: "missing_attempt",
+		};
+	}
+
+	const postingEntries = await ctx.db
+		.query("cash_ledger_journal_entries")
+		.withIndex("by_posting_group", (q) =>
+			q.eq("postingGroupId", args.postingGroupId)
+		)
+		.collect();
+
+	const hasPostingEntry = postingEntries.some(
+		(entry) =>
+			entry.entryType === args.entryType && entry.attemptId === attempt._id
+	);
+	const hasExpectedStatus = attempt.status === args.expectedAttemptStatus;
+	let reason: AttemptPostingHealth["reason"];
+	if (!hasExpectedStatus) {
+		reason = "attempt_status_mismatch";
+	} else if (!hasPostingEntry) {
+		reason = "missing_posting_entry";
+	}
+
+	return {
+		attemptId: attempt._id,
+		attemptStatus: attempt.status,
+		hasPostingEntry,
+		isHealthy: hasExpectedStatus && hasPostingEntry,
+		reason,
+	};
+}
+
+export async function getAttemptLinkedInboundSettlementHealth(
+	ctx: DbReader,
+	transfer: TransferAttemptLink
+): Promise<AttemptPostingHealth> {
+	if (!isAttemptLinkedInboundTransfer(transfer)) {
+		return {
+			hasPostingEntry: false,
+			isHealthy: false,
+		};
+	}
+
+	return loadAttemptPostingHealth(ctx, {
+		transfer,
+		expectedAttemptStatus: "confirmed",
+		postingGroupId: cashReceiptPostingGroupId(transfer.collectionAttemptId),
+		entryType: "CASH_RECEIVED",
+	});
+}
+
+export async function getAttemptLinkedInboundReversalHealth(
+	ctx: DbReader,
+	transfer: TransferAttemptLink
+): Promise<AttemptPostingHealth> {
+	if (!isAttemptLinkedInboundTransfer(transfer)) {
+		return {
+			hasPostingEntry: false,
+			isHealthy: false,
+		};
+	}
+
+	return loadAttemptPostingHealth(ctx, {
+		transfer,
+		expectedAttemptStatus: "reversed",
+		postingGroupId: reversalPostingGroupId(transfer.collectionAttemptId),
+		entryType: "REVERSAL",
+	});
+}
+
+async function transitionAttempt(
+	ctx: MutationCtx,
+	args: {
+		transfer: TransferAttemptLink;
+		eventType:
+			| "FUNDS_SETTLED"
+			| "DRAW_FAILED"
+			| "RETRY_ELIGIBLE"
+			| "MAX_RETRIES_EXCEEDED"
+			| "ATTEMPT_CANCELLED"
+			| "PAYMENT_REVERSED";
+		payload?: Record<string, unknown>;
+		source: CommandSource;
+	}
+): Promise<boolean> {
+	if (!isAttemptLinkedInboundTransfer(args.transfer)) {
+		return false;
+	}
+
+	await executeTransition(ctx, {
+		entityType: "collectionAttempt",
+		entityId: args.transfer.collectionAttemptId,
+		eventType: args.eventType,
+		payload: args.payload,
+		source: args.source,
+	});
+	return true;
+}
+
+export async function reconcileAttemptLinkedInboundSettlement(
+	ctx: MutationCtx,
+	args: {
+		transfer: TransferAttemptLink;
+		settledAt: number;
+		source: CommandSource;
+	}
+): Promise<boolean> {
+	return transitionAttempt(ctx, {
+		transfer: args.transfer,
+		eventType: "FUNDS_SETTLED",
+		payload: { settledAt: args.settledAt },
+		source: args.source,
+	});
+}
+
+export async function reconcileAttemptLinkedInboundFailure(
+	ctx: MutationCtx,
+	args: {
+		transfer: TransferAttemptLink;
+		failureCode: string;
+		failureReason: string;
+		source: CommandSource;
+	}
+): Promise<boolean> {
+	if (!isAttemptLinkedInboundTransfer(args.transfer)) {
+		return false;
+	}
+
+	await ctx.db.patch(args.transfer.collectionAttemptId, {
+		failureReason: args.failureReason,
+		providerStatus: "transfer_failed",
+	});
+
+	await transitionAttempt(ctx, {
+		transfer: args.transfer,
+		eventType: "DRAW_FAILED",
+		payload: {
+			code: args.failureCode,
+			reason: args.failureReason,
+		},
+		source: args.source,
+	});
+
+	const attempt = await ctx.db.get(args.transfer.collectionAttemptId);
+	if (!attempt || attempt.status !== "failed") {
+		return true;
+	}
+
+	const retryCount =
+		typeof attempt.machineContext?.retryCount === "number"
+			? attempt.machineContext.retryCount
+			: 0;
+	const maxRetries =
+		typeof attempt.machineContext?.maxRetries === "number"
+			? attempt.machineContext.maxRetries
+			: 3;
+
+	await transitionAttempt(ctx, {
+		transfer: args.transfer,
+		eventType:
+			retryCount < maxRetries ? "RETRY_ELIGIBLE" : "MAX_RETRIES_EXCEEDED",
+		source: args.source,
+	});
+
+	return true;
+}
+
+export async function reconcileAttemptLinkedInboundCancellation(
+	ctx: MutationCtx,
+	args: {
+		transfer: TransferAttemptLink;
+		reason: string;
+		source: CommandSource;
+	}
+): Promise<boolean> {
+	if (!isAttemptLinkedInboundTransfer(args.transfer)) {
+		return false;
+	}
+
+	await ctx.db.patch(args.transfer.collectionAttemptId, {
+		providerStatus: "transfer_cancelled",
+	});
+
+	await transitionAttempt(ctx, {
+		transfer: args.transfer,
+		eventType: "ATTEMPT_CANCELLED",
+		payload: { reason: args.reason },
+		source: args.source,
+	});
+
+	return true;
+}
+
+export async function reconcileAttemptLinkedInboundReversal(
+	ctx: MutationCtx,
+	args: {
+		transfer: TransferAttemptLink;
+		reason: string;
+		effectiveDate: string;
+		source: CommandSource;
+	}
+): Promise<boolean> {
+	if (!isAttemptLinkedInboundTransfer(args.transfer)) {
+		return false;
+	}
+
+	await ctx.db.patch(args.transfer.collectionAttemptId, {
+		providerStatus: "transfer_reversed",
+	});
+
+	await transitionAttempt(ctx, {
+		transfer: args.transfer,
+		eventType: "PAYMENT_REVERSED",
+		payload: {
+			reason: args.reason,
+			effectiveDate: args.effectiveDate,
+		},
+		source: args.source,
+	});
+
+	return true;
+}

--- a/convex/payments/transfers/mutations.ts
+++ b/convex/payments/transfers/mutations.ts
@@ -379,17 +379,15 @@ export const initiateTransfer = paymentAction
 		const result = await provider.initiate(input);
 		const source = buildSource(ctx.viewer, "admin_dashboard");
 
+		await ctx.runMutation(
+			internal.payments.transfers.mutations.persistProviderRef,
+			{
+				transferId: args.transferId,
+				providerRef: result.providerRef,
+			}
+		);
+
 		if (result.status === "confirmed") {
-			// Persist providerRef before transitioning — the FUNDS_SETTLED path
-			// in the state machine does not fire recordTransferProviderRef, so
-			// without this the provider reference would be lost.
-			await ctx.runMutation(
-				internal.payments.transfers.mutations.persistProviderRef,
-				{
-					transferId: args.transferId,
-					providerRef: result.providerRef,
-				}
-			);
 			return ctx.runMutation(
 				internal.payments.transfers.mutations.fireInitiateTransition,
 				{
@@ -606,14 +604,15 @@ export const initiateTransferInternal = internalAction({
 
 		const result = await provider.initiate(input);
 
+		await ctx.runMutation(
+			internal.payments.transfers.mutations.persistProviderRef,
+			{
+				transferId: args.transferId,
+				providerRef: result.providerRef,
+			}
+		);
+
 		if (result.status === "confirmed") {
-			await ctx.runMutation(
-				internal.payments.transfers.mutations.persistProviderRef,
-				{
-					transferId: args.transferId,
-					providerRef: result.providerRef,
-				}
-			);
 			return ctx.runMutation(
 				internal.payments.transfers.mutations.fireInitiateTransition,
 				{

--- a/convex/payments/transfers/mutations.ts
+++ b/convex/payments/transfers/mutations.ts
@@ -323,7 +323,8 @@ export const initiateTransfer = paymentAction
 			);
 		}
 
-		// Schema guarantees these are typed — no unsafe casts needed
+		// Canonical provider boundary: AMPS hands off before this point and the
+		// transfer domain resolves the concrete provider implementation.
 		const provider = getTransferProvider(transfer.providerCode);
 
 		let counterpartyId: TransferRequestInput["counterpartyId"];
@@ -550,6 +551,9 @@ export const initiateTransferInternal = internalAction({
 			};
 		}
 
+		// Canonical provider boundary: internal orchestration still resolves
+		// providers through the transfer-domain registry, never through
+		// legacy PaymentMethod lookup.
 		const provider = getTransferProvider(transfer.providerCode);
 
 		let counterpartyId: TransferRequestInput["counterpartyId"];

--- a/convex/payments/transfers/providers/__tests__/adapter.test.ts
+++ b/convex/payments/transfers/providers/__tests__/adapter.test.ts
@@ -1,6 +1,9 @@
 /**
  * PaymentMethodAdapter tests — verifies field mapping from
  * TransferProvider interface to the legacy PaymentMethod interface.
+ *
+ * This suite is compatibility coverage only. Canonical inbound provider work
+ * should target native TransferProvider implementations instead.
  */
 
 import { describe, expect, it } from "vitest";
@@ -19,6 +22,7 @@ import { PaymentMethodAdapter } from "../adapter";
 // ── Error patterns ──────────────────────────────────────────────────
 const INBOUND_ONLY_RE = /only supports inbound transfers/;
 const BORROWER_ONLY_RE = /only supports borrower counterparties/;
+const LEGACY_PROVIDER_CODE_ONLY_RE = /legacy compatibility provider codes/i;
 
 // ── Mock PaymentMethod ──────────────────────────────────────────────
 
@@ -115,13 +119,13 @@ describe("PaymentMethodAdapter", () => {
 			expect(params.amount).toBe(55_000);
 		});
 
-		it("maps providerCode to method", async () => {
+		it("maps legacy providerCode to method", async () => {
 			const mock = new MockPaymentMethod();
 			const adapter = new PaymentMethodAdapter(mock);
-			await adapter.initiate(makeInput({ providerCode: "pad_rotessa" }));
+			await adapter.initiate(makeInput({ providerCode: "mock_pad" }));
 
 			const params = mock.calls[0].args[0] as InitiateParams;
-			expect(params.method).toBe("pad_rotessa");
+			expect(params.method).toBe("mock_pad");
 		});
 
 		it("passes metadata through", async () => {
@@ -193,6 +197,24 @@ describe("PaymentMethodAdapter", () => {
 			await expect(
 				adapter.initiate(makeInput({ counterpartyType: "trust" }))
 			).rejects.toThrow(BORROWER_ONLY_RE);
+			expect(mock.calls).toHaveLength(0);
+		});
+
+		it("rejects canonical transfer-provider codes that are not legacy payment methods", async () => {
+			const mock = new MockPaymentMethod();
+			const adapter = new PaymentMethodAdapter(mock);
+			await expect(
+				adapter.initiate(makeInput({ providerCode: "pad_rotessa" }))
+			).rejects.toThrow(LEGACY_PROVIDER_CODE_ONLY_RE);
+			expect(mock.calls).toHaveLength(0);
+		});
+
+		it("rejects transfer-only mock provider codes that have no PaymentMethod equivalent", async () => {
+			const mock = new MockPaymentMethod();
+			const adapter = new PaymentMethodAdapter(mock);
+			await expect(
+				adapter.initiate(makeInput({ providerCode: "mock_eft" }))
+			).rejects.toThrow(LEGACY_PROVIDER_CODE_ONLY_RE);
 			expect(mock.calls).toHaveLength(0);
 		});
 

--- a/convex/payments/transfers/providers/adapter.ts
+++ b/convex/payments/transfers/providers/adapter.ts
@@ -7,7 +7,12 @@
  * fresh `PaymentMethod` implementations.
  */
 
-import type { InitiateParams, PaymentMethod } from "../../methods/interface";
+import {
+	type InitiateParams,
+	isLegacyPaymentMethodCode,
+	LEGACY_PAYMENT_METHOD_CODES,
+	type PaymentMethod,
+} from "../../methods/interface";
 import type {
 	CancelResult,
 	ConfirmResult,
@@ -38,6 +43,15 @@ export class PaymentMethodAdapter implements TransferProvider {
 				"PaymentMethodAdapter only supports borrower counterparties. " +
 					`Received counterpartyType="${request.counterpartyType}". ` +
 					"Use a native TransferProvider for non-borrower counterparties."
+			);
+		}
+
+		if (!isLegacyPaymentMethodCode(request.providerCode)) {
+			throw new Error(
+				"PaymentMethodAdapter only supports legacy compatibility provider codes. " +
+					`Received providerCode="${request.providerCode}". ` +
+					`Supported codes: ${LEGACY_PAYMENT_METHOD_CODES.join(", ")}. ` +
+					"Use a native TransferProvider for canonical provider codes."
 			);
 		}
 

--- a/convex/payments/transfers/reconciliation.ts
+++ b/convex/payments/transfers/reconciliation.ts
@@ -17,6 +17,10 @@ import { internal } from "../../_generated/api";
 import type { Id } from "../../_generated/dataModel";
 import type { MutationCtx } from "../../_generated/server";
 import { internalMutation } from "../../_generated/server";
+import {
+	getAttemptLinkedInboundSettlementHealth,
+	isAttemptLinkedInboundTransfer,
+} from "./collectionAttemptReconciliation";
 
 // ── Constants ───────────────────────────────────────────────────────
 
@@ -113,17 +117,13 @@ async function reconcileTransfer(
 	transfer: {
 		_id: Id<"transferRequests">;
 		collectionAttemptId?: Id<"collectionAttempts">;
+		direction?: string;
 		settledAt?: number;
 		createdAt: number;
 	},
 	threshold: number
 ): Promise<void> {
 	if (isFreshTransfer(transfer, threshold)) {
-		return;
-	}
-
-	// Bridged transfers have journal entries via the collection attempt path
-	if (transfer.collectionAttemptId) {
 		return;
 	}
 
@@ -154,6 +154,26 @@ async function reconcileTransfer(
 			});
 		}
 		return;
+	}
+
+	if (isAttemptLinkedInboundTransfer(transfer)) {
+		const attemptHealth = await getAttemptLinkedInboundSettlementHealth(
+			ctx,
+			transfer
+		);
+		if (attemptHealth.isHealthy) {
+			if (
+				healing &&
+				healing.status !== "resolved" &&
+				healing.status !== "escalated"
+			) {
+				await ctx.db.patch(healing._id, {
+					status: "resolved" as const,
+					resolvedAt: Date.now(),
+				});
+			}
+			return;
+		}
 	}
 
 	if (healing?.status === "escalated" || healing?.status === "resolved") {

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -811,6 +811,7 @@ export default defineSchema({
 		createdAt: v.number(),
 	})
 		.index("by_scheduled_date", ["scheduledDate", "status"])
+		.index("by_status_scheduled_date", ["status", "scheduledDate"])
 		.index("by_status", ["status"])
 		.index("by_rescheduled_from", ["rescheduledFromId", "source"]),
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -57,6 +57,12 @@ import {
 	listingRateTypeValidator,
 	listingStatusValidator,
 } from "./listings/validators";
+import {
+	collectionRuleConfigValidator,
+	collectionRuleKindValidator,
+	collectionRuleScopeValidator,
+	collectionRuleStatusValidator,
+} from "./payments/collectionPlan/ruleContract";
 import { payoutFrequencyValidator } from "./payments/payout/validators";
 import {
 	counterpartyTypeValidator,
@@ -809,13 +815,25 @@ export default defineSchema({
 		.index("by_rescheduled_from", ["rescheduledFromId", "source"]),
 
 	collectionRules: defineTable({
-		name: v.string(),
+		kind: v.optional(collectionRuleKindValidator),
+		code: v.optional(v.string()),
+		displayName: v.optional(v.string()),
+		description: v.optional(v.string()),
 		trigger: v.union(v.literal("schedule"), v.literal("event")),
+		status: v.optional(collectionRuleStatusValidator),
+		scope: v.optional(collectionRuleScopeValidator),
+		config: v.optional(collectionRuleConfigValidator),
+		version: v.optional(v.number()),
+		effectiveFrom: v.optional(v.number()),
+		effectiveTo: v.optional(v.number()),
+		createdByActorId: v.optional(v.string()),
+		updatedByActorId: v.optional(v.string()),
+		name: v.optional(v.string()),
 		condition: v.optional(v.any()),
-		action: v.string(),
+		action: v.optional(v.string()),
 		parameters: v.optional(v.any()), // rule-specific config
 		priority: v.number(),
-		enabled: v.boolean(),
+		enabled: v.optional(v.boolean()),
 		createdAt: v.number(),
 		updatedAt: v.number(),
 	}).index("by_trigger", ["trigger", "enabled", "priority"]),

--- a/convex/seed/seedAll.ts
+++ b/convex/seed/seedAll.ts
@@ -56,9 +56,9 @@ interface SeedOnboardingRequestResult {
 }
 
 interface SeedPaymentDataResult {
+	createdPlanEntryIds: Id<"collectionPlanEntries">[];
 	generated: { obligations: number; planEntries: number };
 	obligationIds: Id<"obligations">[];
-	planEntryIds: Id<"collectionPlanEntries">[];
 	reused: { obligations: number; planEntries: number };
 }
 

--- a/convex/seed/seedPaymentData.ts
+++ b/convex/seed/seedPaymentData.ts
@@ -13,9 +13,9 @@ import { generateObligationsImpl } from "../payments/obligations/generateImpl";
 // ---------------------------------------------------------------------------
 
 interface SeedPaymentDataResult {
+	createdPlanEntryIds: Id<"collectionPlanEntries">[];
 	generated: { obligations: number; planEntries: number };
 	obligationIds: Id<"obligations">[];
-	planEntryIds: Id<"collectionPlanEntries">[];
 	reused: {
 		obligations: number;
 		planEntries: number;
@@ -101,7 +101,7 @@ async function seedPaymentDataImpl(
 
 	return {
 		obligationIds,
-		planEntryIds: schedulingResult.createdPlanEntryIds,
+		createdPlanEntryIds: schedulingResult.createdPlanEntryIds,
 		generated: {
 			obligations: generatedObligations,
 			planEntries: schedulingResult.created,

--- a/convex/seed/seedPaymentData.ts
+++ b/convex/seed/seedPaymentData.ts
@@ -5,6 +5,7 @@ import { internalMutation } from "../_generated/server";
 import { adminMutation } from "../fluent";
 import { seedCollectionRulesImpl } from "../payments/collectionPlan/defaultRules";
 import { scheduleInitialEntriesImpl } from "../payments/collectionPlan/initialScheduling";
+import { getScheduleRuleConfig } from "../payments/collectionPlan/ruleContract";
 import { generateObligationsImpl } from "../payments/obligations/generateImpl";
 
 // ---------------------------------------------------------------------------
@@ -87,16 +88,15 @@ async function seedPaymentDataImpl(
 
 	// 4. Ensure canonical collection rules exist before initial scheduling runs
 	const rules = await seedCollectionRulesImpl(ctx);
-	const scheduleRule = await ctx.db.get(rules.ruleIdsByName.schedule_rule);
-	const scheduleRuleParameters = scheduleRule?.parameters as
-		| { delayDays?: number }
-		| undefined;
+	const scheduleRule = await ctx.db.get(rules.ruleIdsByCode.schedule_rule);
+	const scheduleRuleConfig =
+		scheduleRule !== null ? getScheduleRuleConfig(scheduleRule) : null;
 
 	// 5. Generate initial plan entries through canonical schedule-rule semantics
 	const schedulingResult = await scheduleInitialEntriesImpl(ctx, {
 		mortgageId,
-		delayDays: scheduleRuleParameters?.delayDays ?? 5,
-		ruleId: rules.ruleIdsByName.schedule_rule,
+		delayDays: scheduleRuleConfig?.delayDays ?? 5,
+		ruleId: rules.ruleIdsByCode.schedule_rule,
 	});
 
 	return {

--- a/convex/seed/seedPaymentData.ts
+++ b/convex/seed/seedPaymentData.ts
@@ -3,17 +3,9 @@ import type { Id } from "../_generated/dataModel";
 import type { MutationCtx } from "../_generated/server";
 import { internalMutation } from "../_generated/server";
 import { adminMutation } from "../fluent";
-import {
-	generateObligationsImpl,
-	MS_PER_DAY,
-} from "../payments/obligations/generateImpl";
-
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-
-/** How far ahead (in ms) to schedule plan entries from "now" */
-const SCHEDULING_WINDOW_DAYS = 5;
+import { seedCollectionRulesImpl } from "../payments/collectionPlan/defaultRules";
+import { scheduleInitialEntriesImpl } from "../payments/collectionPlan/initialScheduling";
+import { generateObligationsImpl } from "../payments/obligations/generateImpl";
 
 // ---------------------------------------------------------------------------
 // Result type
@@ -93,84 +85,31 @@ async function seedPaymentDataImpl(
 		generatedObligations = result.generated;
 	}
 
-	// 4. Load obligations due within the scheduling window
-	const now = Date.now();
-	const schedulingCutoff = now + SCHEDULING_WINDOW_DAYS * MS_PER_DAY;
+	// 4. Ensure canonical collection rules exist before initial scheduling runs
+	const rules = await seedCollectionRulesImpl(ctx);
+	const scheduleRule = await ctx.db.get(rules.ruleIdsByName.schedule_rule);
+	const scheduleRuleParameters = scheduleRule?.parameters as
+		| { delayDays?: number }
+		| undefined;
 
-	const dueSoonObligations = await ctx.db
-		.query("obligations")
-		.withIndex("by_mortgage_and_date", (q) =>
-			q
-				.eq("mortgageId", mortgageId)
-				.gte("dueDate", now)
-				.lte("dueDate", schedulingCutoff)
-		)
-		.collect();
-
-	// 5. Create plan entries for obligations that don't already have one
-	const planEntryIds: Id<"collectionPlanEntries">[] = [];
-	const reusedPlanEntryIds: Id<"collectionPlanEntries">[] = [];
-	let generatedPlanEntries = 0;
-	let reusedPlanEntries = 0;
-
-	// Load existing non-cancelled plan entries to check for duplicates
-	// (obligationIds is an array field — no index available, must scan)
-	const nonCancelledStatuses = [
-		"planned",
-		"executing",
-		"completed",
-		"rescheduled",
-	] as const;
-	const existingPlanEntries = (
-		await Promise.all(
-			nonCancelledStatuses.map((status) =>
-				ctx.db
-					.query("collectionPlanEntries")
-					.withIndex("by_status", (q) => q.eq("status", status))
-					.collect()
-			)
-		)
-	).flat();
-
-	for (const obligation of dueSoonObligations) {
-		// Check if this obligation already has a non-cancelled plan entry
-		const existingEntry = existingPlanEntries.find(
-			(entry) =>
-				entry.status !== "cancelled" &&
-				entry.obligationIds.includes(obligation._id)
-		);
-
-		if (existingEntry) {
-			reusedPlanEntries++;
-			reusedPlanEntryIds.push(existingEntry._id);
-			continue;
-		}
-
-		const planEntryId = await ctx.db.insert("collectionPlanEntries", {
-			obligationIds: [obligation._id],
-			amount: obligation.amount,
-			method: "manual",
-			scheduledDate: obligation.dueDate,
-			status: "planned",
-			source: "default_schedule",
-			createdAt: now,
-		});
-
-		planEntryIds.push(planEntryId);
-		generatedPlanEntries++;
-	}
+	// 5. Generate initial plan entries through canonical schedule-rule semantics
+	const schedulingResult = await scheduleInitialEntriesImpl(ctx, {
+		mortgageId,
+		delayDays: scheduleRuleParameters?.delayDays ?? 5,
+		ruleId: rules.ruleIdsByName.schedule_rule,
+	});
 
 	return {
 		obligationIds,
-		planEntryIds,
+		planEntryIds: schedulingResult.createdPlanEntryIds,
 		generated: {
 			obligations: generatedObligations,
-			planEntries: generatedPlanEntries,
+			planEntries: schedulingResult.created,
 		},
 		reused: {
 			obligations: reusedObligations,
-			planEntries: reusedPlanEntries,
-			planEntryIds: reusedPlanEntryIds,
+			planEntries: schedulingResult.reused,
+			planEntryIds: schedulingResult.reusedPlanEntryIds,
 		},
 	};
 }

--- a/docs/architecture/unified-payment-rails-technical-design.md
+++ b/docs/architecture/unified-payment-rails-technical-design.md
@@ -19,7 +19,8 @@ This design is intentionally grounded in the current codebase, not just the prod
 - Two implementations exist today:
   - `ManualPaymentMethod` in [convex/payments/methods/manual.ts](../../convex/payments/methods/manual.ts)
   - `MockPADMethod` in [convex/payments/methods/mockPAD.ts](../../convex/payments/methods/mockPAD.ts)
-- Runtime method lookup exists in [convex/payments/methods/registry.ts](../../convex/payments/methods/registry.ts).
+- Runtime method lookup exists in [convex/payments/methods/registry.ts](../../convex/payments/methods/registry.ts) as a compatibility-only shim.
+- Canonical provider resolution belongs to the transfer-domain registry in [convex/payments/transfers/providers/registry.ts](../../convex/payments/transfers/providers/registry.ts).
 - Collection attempts are already modeled as a governed entity with a lifecycle in [convex/engine/machines/collectionAttempt.machine.ts](../../convex/engine/machines/collectionAttempt.machine.ts).
 - Collection attempt effects already fan out to obligations and retry rules in [convex/engine/effects/collectionAttempt.ts](../../convex/engine/effects/collectionAttempt.ts).
 - Obligation settlement already schedules lender dispersal creation in [convex/engine/effects/obligation.ts](../../convex/engine/effects/obligation.ts).

--- a/docs/technical-design/unified-payment-rails.md
+++ b/docs/technical-design/unified-payment-rails.md
@@ -98,6 +98,8 @@ provider work. The aligned repo contract is:
 
 - `TransferProvider` is canonical for new inbound provider integrations
 - `PaymentMethod` remains transitional compatibility
+- `PaymentMethodAdapter` and `methods/registry.ts` are explicit compatibility
+  shims, not normal extension points for new provider work
 - Collection Attempts remain business execution records even when transfer
   infrastructure performs provider work
 

--- a/specs/03-implement-collection-plan-collection-attempt-execution-spine/PRD.md
+++ b/specs/03-implement-collection-plan-collection-attempt-execution-spine/PRD.md
@@ -1,0 +1,92 @@
+# 03. Implement Collection Plan -> Collection Attempt Execution Spine
+
+> **Canonical Source of Truth**: https://www.notion.so/337fc1b44024812291bac97a93ca6e10
+>
+> This PRD is a compressed working context snapshot extracted from the Notion spec.
+> Always defer to the Notion page for the latest requirements. This file serves as
+> a local reference to reduce Notion API calls during implementation.
+
+## Overview
+This workstream operationalizes the page-02 execution contract by turning the
+existing `executePlanEntry` API into the live production path for mortgage
+collections. It must discover due plan entries, execute them through the
+canonical command, initiate downstream transfer execution through Unified
+Payment Rails, and advance Collection Attempt state through governed
+transitions without collapsing debt, strategy, and execution boundaries.
+
+## Features
+| ID | Feature | Description | Priority |
+|----|---------|-------------|----------|
+| F-1 | Due-entry discovery and runner | Find due `planned` plan entries and execute them in bounded, replay-safe production batches. | P0 |
+| F-2 | Canonical spine enforcement | Make `executePlanEntry` the only production attempt-creation path for collections. | P0 |
+| F-3 | Transfer initiation handoff | Move from transfer-request creation to real downstream transfer initiation with no manual follow-up step. | P0 |
+| F-4 | Collection Attempt GT advancement | Reflect real initiation outcomes back onto Collection Attempts through governed transitions. | P0 |
+| F-5 | Retry and failure loop preservation | Preserve one-attempt-per-plan-entry while keeping failure paths compatible with retry-rule plan-entry creation. | P0 |
+| F-6 | Production-path integration coverage | Replace seed-only or manual-transition happy paths with tests that exercise the real execution spine. | P0 |
+
+## Requirements
+| ID | Requirement | Type | Acceptance Criteria |
+|----|-------------|------|---------------------|
+| REQ-1 | Production code discovers and executes due plan entries. | Functional | A scheduler-owned path selects due `planned` entries and executes them without manual seeding or direct inserts. |
+| REQ-2 | Every production execution goes through `executePlanEntry`. | Functional | No alternate production attempt-creation path bypasses the canonical page-02 contract. |
+| REQ-3 | Successful execution creates at most one Collection Attempt and at most one transfer request per plan entry. | Functional | Cron reruns and action retries remain replay-safe and do not duplicate business attempts. |
+| REQ-4 | The spine initiates downstream transfer execution through Unified Payment Rails. | Functional | A created transfer request is followed by canonical transfer initiation rather than stopping at insertion. |
+| REQ-5 | Collection Attempt state advances through GT based on real initiation outcomes. | Functional | Pending initiation, immediate confirmation, and initiation failure map to governed Collection Attempt transitions rather than ad hoc status patches. |
+| REQ-6 | Failure remains durable and observable. | Functional | Transfer-initiation failure persists on the attempt and is visible to retry, audit, and operator workflows. |
+| REQ-7 | Retry behavior continues to create replacement plan entries rather than duplicate attempts. | Functional | Failure flows preserve the one-attempt-per-plan-entry invariant and still feed rule-driven retry planning. |
+| REQ-8 | The AMPS / Payment Rails boundary stays intact. | Functional | AMPS does not call `TransferProvider` directly and Unified Payment Rails retains ownership of transfer lifecycle and settlement. |
+| REQ-9 | Mortgage lifecycle and cash posting boundaries stay intact. | Functional | This work does not make mortgage lifecycle or the ledgers collection-strategy-aware. |
+| REQ-10 | Integration tests validate the live production spine. | Functional | Tests cover due-entry discovery, execution, initiation, GT advancement, replay safety, and failure handling through the real path. |
+
+## Use Cases
+### UC-1: Scheduler executes due planned entries through the canonical spine
+- **Actor**: Scheduler-owned AMPS runner
+- **Precondition**: A `collectionPlanEntries` row is `planned`, due, and executable
+- **Flow**:
+  1. Scheduler selects due planned entries in a bounded batch
+  2. Runner calls `internal.payments.collectionPlan.execution.executePlanEntry`
+  3. The command creates the Collection Attempt and transfer request
+  4. The production spine initiates the downstream transfer
+- **Postcondition**: The plan entry is consumed into one live Collection Attempt with downstream initiation started
+- **E2E Test**: Backend integration test; browser e2e not required for this backend-only flow
+
+### UC-2: Async provider initiation moves the attempt into a real in-flight state
+- **Actor**: Scheduler-owned runner plus Unified Payment Rails
+- **Precondition**: The chosen provider returns a pending or provider-initiated result
+- **Flow**:
+  1. Production execution creates and initiates the transfer
+  2. Transfer initiation returns a provider reference without immediate settlement
+  3. The Collection Attempt transitions from `initiated` to `pending` via GT
+- **Postcondition**: The attempt is in a real in-flight state with stable linkage to the initiated transfer
+- **E2E Test**: Backend integration test; browser e2e not required
+
+### UC-3: Immediate confirmation or initiation failure is reflected back onto the attempt
+- **Actor**: Scheduler-owned runner plus Unified Payment Rails
+- **Precondition**: A due plan entry is executed and transfer initiation returns either immediate confirmation or a hard failure
+- **Flow**:
+  1. Production execution creates the attempt and transfer
+  2. Transfer initiation either confirms immediately or fails
+  3. The attempt is advanced through GT to the correct next state or durable failure state
+- **Postcondition**: Success and failure both remain auditable and do not require manual GT firing to keep the model consistent
+- **E2E Test**: Backend integration test; browser e2e not required
+
+## Schemas
+- `collectionPlanEntries`
+  - source strategy rows for due-entry discovery
+  - consumed through `status`, `collectionAttemptId`, and execution metadata added in page 02
+- `collectionAttempts`
+  - business execution records
+  - must remain the AMPS-owned source of truth for collection execution state
+- `transferRequests`
+  - Unified Payment Rails transfer execution records
+  - linked to attempts via `collectionAttemptId` and to plan entries via `planEntryId`
+- cron / runner inputs
+  - bounded batch size
+  - stable scheduler idempotency per run and per plan entry
+
+## Out of Scope
+- Transfer settlement, cash posting, and downstream reconciliation semantics owned by page 04
+- Initial mortgage activation/bootstrap entry creation owned by page 06
+- Broader schema redesign for retry lineage and reschedule metadata owned by page 11
+- New frontend routes or operator UI beyond what future admin wrappers may need
+- Any direct `TransferProvider` usage from AMPS

--- a/specs/03-implement-collection-plan-collection-attempt-execution-spine/design.md
+++ b/specs/03-implement-collection-plan-collection-attempt-execution-spine/design.md
@@ -1,0 +1,135 @@
+# 03. Implement Collection Plan -> Collection Attempt Execution Spine — Design
+
+> Derived from: https://www.notion.so/337fc1b44024812291bac97a93ca6e10
+
+## Types & Interfaces
+
+### Existing canonical execution contract
+The page-02 contract in `convex/payments/collectionPlan/executionContract.ts`
+remains authoritative for:
+- `ExecutePlanEntryArgs`
+- `ExecutePlanEntryResult`
+- replay-safe outcome taxonomy
+- execution-source and transfer-handoff helpers
+
+Page 03 builds on that contract rather than redefining it.
+
+### New runner-facing contract
+The production runner needs:
+- a due-entry selection shape
+  - `planEntryId`
+  - `scheduledDate`
+  - `method`
+  - `amount`
+- a batch execution result shape
+  - selected count
+  - attempted count
+  - skipped / ineligible count
+  - created count
+  - already-executed count
+  - failed-initiation count
+
+### Attempt state advancement mapping
+Planned mapping for real initiation outcomes:
+- transfer initiated with provider reference
+  - fire `DRAW_INITIATED` on `collectionAttempt`
+- transfer immediately confirmed
+  - fire `FUNDS_SETTLED` on `collectionAttempt`
+- transfer initiation failure
+  - fire `DRAW_FAILED` on `collectionAttempt`
+
+Any mapping must use GT transitions via `executeTransition`, not direct attempt
+status patching.
+
+## Database Schema
+
+### Existing schema sufficient for phase-03 baseline
+Page 02 already added the minimum execution metadata needed for the spine:
+- `collectionPlanEntries.executedAt`
+- `collectionPlanEntries.executionIdempotencyKey`
+- `collectionPlanEntries.collectionAttemptId`
+- `collectionAttempts.triggerSource`
+- `collectionAttempts.executionRequestedAt`
+- `collectionAttempts.executionIdempotencyKey`
+- `collectionAttempts.requestedByActorType`
+- `collectionAttempts.requestedByActorId`
+- `collectionAttempts.executionReason`
+- `collectionAttempts.transferRequestId`
+
+### Likely query/index work
+The current `collectionPlanEntries` indexes support:
+- `by_status`
+- `by_scheduled_date`
+
+The due-entry runner should prefer `by_scheduled_date` plus status filtering or a
+purpose-built helper that minimizes full-table scans of planned entries.
+
+## Architecture
+
+### Data Flow
+`convex/crons.ts`
+-> collection-plan due runner action
+-> due-entry query / bounded batch selection
+-> `executePlanEntry`
+-> transfer request creation
+-> `initiateTransferInternal`
+-> transfer-initiation outcome classification
+-> `executeTransition` on `collectionAttempt`
+-> existing collection-attempt GT effects for payment receipt / retry loop
+
+### Component Structure
+No new frontend component structure is required for the initial page-03 spine.
+
+### API Surface
+
+#### Reads (Queries/GET)
+| Function | Args | Returns | Description |
+|----------|------|---------|-------------|
+| `getPlanEntriesByStatus` or successor due-entry helper | `status`, optional `scheduledBefore`, optional limit | due plan-entry rows | Load due planned entries for runner-owned execution |
+
+#### Writes (Mutations/POST)
+| Function | Args | Returns | Description |
+|----------|------|---------|-------------|
+| `executePlanEntry` | canonical page-02 execution args | structured execution result | Only production attempt-creation path |
+| collection-attempt transition helper(s) | attempt id + event payload | GT transition result | Advance attempts from real initiation outcomes |
+
+#### Side Effects (Actions/Jobs)
+| Function | Args | Returns | Description |
+|----------|------|---------|-------------|
+| new due-entry runner action | batch size, optional cursor/run metadata | runner summary | Select and execute due entries |
+| `initiateTransferInternal` | `transferId` | transfer transition result | Canonical Payment Rails initiation step |
+| cron registration in `convex/crons.ts` | schedule config | n/a | Run the due-entry spine continuously in production |
+
+### Routing
+No route changes are required for the initial implementation. Scheduler and
+backend integration tests are the primary delivery surface.
+
+## Implementation Decisions
+
+### Canonical executor remains the only attempt-creation path
+`executePlanEntry` already exists and should stay the sole production path for
+turning plan entries into Collection Attempts. The runner calls it; it does not
+reimplement it.
+
+### Prefer immediate follow-up initiation in the same spine
+The current repo truth already creates a transfer request inside
+`executePlanEntry`. Page 03 should extend that live spine to call
+`initiateTransferInternal` immediately after request creation unless the code
+review shows a hard reason to split it.
+
+### Governed transitions, not status patches
+`collectionAttempts.status` should only change through GT transitions once the
+attempt exists. Page 03 should remove or isolate any remaining ad hoc attempt
+status patching from the normal initiation path.
+
+### Preserve the older confirmed-attempt bridge as legacy compatibility
+`emitPaymentReceived` currently creates a bridged transfer on attempt
+confirmation. Page 03 should not break that path abruptly, but it should make
+the new plan-entry execution spine the canonical happy path and document any
+remaining legacy overlap for page 04 cleanup.
+
+### Backend integration coverage is higher-value than browser e2e
+This workstream is scheduler-heavy and backend-dominant. The most important
+tests should live in Convex integration suites that exercise due-entry
+selection, execution, transfer initiation, and GT advancement directly. Browser
+e2e is not the primary proof surface unless a real operator UI is added.

--- a/specs/03-implement-collection-plan-collection-attempt-execution-spine/gap-analysis.md
+++ b/specs/03-implement-collection-plan-collection-attempt-execution-spine/gap-analysis.md
@@ -1,0 +1,71 @@
+# 03. Implement Collection Plan -> Collection Attempt Execution Spine — Gap Analysis
+
+Re-fetched against the canonical Notion sources on 2026-04-03:
+
+- Spec: `https://www.notion.so/337fc1b44024812291bac97a93ca6e10`
+- Linked plan: `https://www.notion.so/337fc1b4402481ea8986cf11e4e7bce3`
+
+## Verdict
+
+Page 03 is implemented for the production execution spine described in the spec and linked implementation plan.
+
+The codebase now has a scheduler-owned due-entry runner, a canonical `executePlanEntry` path that both creates and initiates downstream transfers, governed Collection Attempt lifecycle advancement driven from real initiation outcomes, and retry-loop preservation through rule evaluation. Browser e2e coverage was not required because the production delivery surface for this page is backend scheduler/orchestration behavior, not a user-facing route.
+
+## Coverage Matrix
+
+| Spec item | Status | Evidence |
+| --- | --- | --- |
+| Production code can execute eligible plan entries into Collection Attempts | Implemented | `convex/payments/collectionPlan/runner.ts`, `convex/payments/collectionPlan/execution.ts`, `convex/crons.ts` |
+| Execution no longer depends on seed-only or test-only insertion paths | Implemented | Due entries are discovered via `getDuePlannedEntries` and executed through `processDuePlanEntries` -> `executePlanEntry` |
+| Layer boundary between Collection Plan and Collection Attempts remains explicit | Implemented | `executePlanEntry` remains the AMPS-owned command; downstream transfer ownership stays in Unified Payment Rails |
+| Every production execution flows through the canonical page-02 command | Implemented | `processDuePlanEntries` calls `internal.payments.collectionPlan.execution.executePlanEntry` only |
+| Successful execution creates one Collection Attempt and at most one downstream transfer request | Implemented | Replay-safe handoff keys plus runner/execution tests prove one-attempt / one-transfer behavior |
+| The production path initiates downstream transfer execution | Implemented | `executePlanEntry` now calls `initiateTransferInternal` after transfer-request creation |
+| Collection Attempt state advances through GT based on real initiation outcomes | Implemented | `advanceAttemptForTransferState`, `progressAttemptFailure`, `collectionAttempt.machine.ts`, `engine/transition.ts` |
+| Failure paths stay durable and feed retry-rule behavior | Implemented | `scheduleRetryEntry`, retry follow-up transitions, runner/execution failure-path tests |
+| AMPS does not call `TransferProvider` directly | Implemented | All provider initiation remains inside `convex/payments/transfers/mutations.ts` |
+| Unified Payment Rails remains owner of transfer lifecycle and settlement effects | Implemented | Page-03 work stops at initiation-path orchestration; transfer settlement/cash posting remains downstream |
+| Mortgage lifecycle remains obligation-driven | Implemented | No page-03 code patches mortgage state directly |
+| Scheduler path is replay-safe for cron reruns | Implemented | `getDuePlannedEntries` selects only `planned`; `executePlanEntry` replay safety remains enforced |
+| Execution observability explains selection and outcomes | Implemented | Runner summary logging plus execution/handoff audit logs |
+| Backend integration coverage exercises the live spine | Implemented | `convex/payments/collectionPlan/__tests__/execution.test.ts`, `convex/payments/collectionPlan/__tests__/runner.test.ts`, `src/test/convex/engine/transition.test.ts` |
+
+## Use Case Coverage
+
+| Use case | Status | Evidence |
+| --- | --- | --- |
+| UC-1: Scheduler discovers due entries and executes them | Implemented | `runner.test.ts` manual-path coverage |
+| UC-2: Replay and cron reruns do not duplicate attempts/transfers | Implemented | `execution.test.ts` replay case, `runner.test.ts` rerun case |
+| UC-3: Failure execution remains durable and continues into retry planning | Implemented | `execution.test.ts` failure case, `runner.test.ts` retry-loop case |
+
+## Key Design Outcomes Verified
+
+- The due-entry runner is wired in `convex/crons.ts`.
+- The scheduler path does not insert Collection Attempts directly.
+- Transfer initiation happens immediately after transfer-request creation through Unified Payment Rails.
+- Collection Attempt transitions are driven through governed transitions, not direct status patches.
+- Built-in XState actions are no longer mis-scheduled as effects, which prevents duplicate guarded-branch effects and noisy `incrementRetryCount` warnings.
+- The legacy bridge-transfer path is treated as compatibility-only and skipped when a real `transferRequestId` is already linked to the attempt.
+
+## Intentional Scope Boundaries Preserved
+
+- Page 03 owns initiation-path orchestration only.
+- Broader settlement-path reconciliation remains a page-04 concern.
+- Browser e2e coverage was intentionally not added because this page delivers backend orchestration, not UI behavior.
+
+## Residual Notes
+
+1. Older low-level payment-chain suites under `src/test/convex/payments/` still include manual GT-driving scenarios. That is now compatibility coverage, not the primary verification surface for page 03.
+2. Focused manual-path spine tests still emit downstream fixture warnings from unrelated seeded-environment gaps such as missing borrower receivable accounts and no active mortgage positions for dispersal creation. These warnings do not indicate page-03 spine failures.
+
+## Verification Evidence
+
+- `bun run test convex/payments/collectionPlan/__tests__/execution.test.ts convex/payments/collectionPlan/__tests__/runner.test.ts convex/engine/machines/__tests__/collectionAttempt.test.ts src/test/convex/engine/transition.test.ts`
+- `bun check`
+- `bunx convex codegen`
+- `bun typecheck`
+- GitNexus `detect_changes(scope=\"all\")` reported `risk_level: medium` for the final diff on repo `fairlendapp`
+
+## Final Assessment
+
+No blocking gaps remain for the page-03 objective. The production execution spine from due Collection Plan entry to live Collection Attempt initiation is now present, verified, and aligned with the current Notion spec and linked implementation plan as of 2026-04-03.

--- a/specs/03-implement-collection-plan-collection-attempt-execution-spine/tasks.md
+++ b/specs/03-implement-collection-plan-collection-attempt-execution-spine/tasks.md
@@ -1,0 +1,36 @@
+# 03. Implement Collection Plan -> Collection Attempt Execution Spine — Tasks
+
+> Spec: https://www.notion.so/337fc1b44024812291bac97a93ca6e10
+> Generated: 2026-04-03
+>
+> If every task below is checked, the spec is fully implemented, tested, and verified.
+
+## Phase 1: Schema & Data Layer
+- [x] T-001: Capture local PRD/design/tasks artifacts for the page-03 execution spine. (F-1, F-2, F-3, F-4, F-5, F-6)
+- [x] T-002: Add or refine the due-entry discovery query path for bounded selection of due `planned` plan entries. (UC-1, REQ-1, REQ-2, F-1)
+- [x] T-003: Add any minimal persistence or metadata support needed for runner observability and replay-safe batch execution. (REQ-1, REQ-3, REQ-6, F-1, F-6)
+
+## Phase 2: Backend Functions
+- [x] T-010: Run impact analysis on the shared page-02 execution surfaces and collection-attempt lifecycle symbols before modifying them. (REQ-2, REQ-5, REQ-8, F-2, F-4)
+- [x] T-011: Implement a scheduler-owned due-entry runner action that executes due plan entries in bounded batches through `executePlanEntry`. (UC-1, REQ-1, REQ-2, REQ-3, F-1, F-2)
+- [x] T-012: Wire the due-entry runner into `convex/crons.ts` with retry-safe scheduling semantics and basic execution observability. (UC-1, REQ-1, REQ-6, F-1, F-6)
+- [x] T-013: Extend the production spine so successful `executePlanEntry` runs also initiate the downstream transfer through `initiateTransferInternal`. (UC-1, UC-2, UC-3, REQ-4, REQ-8, F-3)
+- [x] T-014: Map transfer-initiation outcomes back onto `collectionAttempt` through GT transitions instead of direct status patches. (UC-2, UC-3, REQ-5, REQ-6, F-4)
+- [x] T-015: Preserve retry-loop invariants so failure paths continue to create replacement plan entries rather than duplicate attempts from the same plan entry. (UC-3, REQ-7, F-5)
+- [x] T-016: Audit and deprecate any older production collection-attempt creation or confirmation paths that bypass the canonical page-03 spine. (REQ-2, REQ-8, REQ-9, F-2, F-5)
+
+## Phase 3: Frontend — Routes & Components
+- [x] T-020: Verify whether this workstream can remain backend-only, or identify the minimum admin/manual wrapper work needed for later convergence on the same spine. (REQ-2, REQ-6, F-2)
+
+## Phase 4: E2E Tests
+- [x] T-030: Assess whether browser e2e coverage is applicable, given that the primary delivery surface is scheduler/backend orchestration. (REQ-10, F-6)
+- [x] T-031: Add backend integration tests for due-entry discovery -> `executePlanEntry` -> transfer initiation -> Collection Attempt GT advancement. (UC-1, UC-2, REQ-1, REQ-2, REQ-4, REQ-5, REQ-10, F-1, F-3, F-4, F-6)
+- [x] T-032: Add replay and cron-rerun tests proving one-attempt-per-plan-entry and replay-safe transfer initiation. (UC-1, REQ-3, REQ-10, F-2, F-6)
+- [x] T-033: Add failure-path integration tests proving transfer-initiation failure stays durable on the attempt and continues to feed the retry loop. (UC-3, REQ-6, REQ-7, REQ-10, F-4, F-5, F-6)
+- [x] T-034: Document why browser e2e is unnecessary if backend integration coverage fully exercises the production spine. (REQ-10, F-6)
+
+## Phase 5: Verification
+- [x] T-040: Re-fetch the Notion spec and linked implementation plan to verify the final code still matches the current contract and page-03 scope. (F-1, F-2, F-3, F-4, F-5, F-6)
+- [x] T-041: Create `gap-analysis.md`. (REQ-1, REQ-2, REQ-3, REQ-4, REQ-5, REQ-6, REQ-7, REQ-8, REQ-9, REQ-10)
+- [x] T-042: Present the gap analysis to the user. (REQ-1, REQ-2, REQ-3, REQ-4, REQ-5, REQ-6, REQ-7, REQ-8, REQ-9, REQ-10)
+- [x] T-043: Final `bun check`, `bun typecheck`, and `bunx convex codegen` pass. (REQ-1, REQ-2, REQ-3, REQ-4, REQ-5, REQ-6, REQ-7, REQ-8, REQ-9, REQ-10)

--- a/specs/04-reconcile-collection-attempts-with-transfer-execution-and-cash-posting/PRD.md
+++ b/specs/04-reconcile-collection-attempts-with-transfer-execution-and-cash-posting/PRD.md
@@ -1,0 +1,107 @@
+# 04. Reconcile Collection Attempts with Transfer Execution and Cash Posting
+
+> **Canonical Source of Truth**: https://www.notion.so/337fc1b4402481a48a13ee61e289e8f0
+>
+> This PRD is a compressed working context snapshot extracted from the Notion spec.
+> Always defer to the Notion page for the latest requirements. This file serves as
+> a local reference to reduce Notion API calls during implementation.
+
+## Overview
+This workstream closes the remaining gap between the page-03 execution spine and
+the actual settlement lifecycle in Unified Payment Rails. The end state is one
+canonical inbound reconciliation story: a Collection Attempt remains the AMPS
+business execution record, transfer lifecycle stays inside Payment Rails, and
+confirmed, failed, cancelled, and reversed outcomes reconcile back into AMPS
+without duplicate cash meaning or bridge-era ambiguity.
+
+## Features
+| ID | Feature | Description | Priority |
+|----|---------|-------------|----------|
+| F-1 | Transfer-to-attempt reconciliation seam | Add one canonical reconciliation path from transfer lifecycle outcomes back into the originating Collection Attempt. | P0 |
+| F-2 | Single confirmed-settlement consequence path | Ensure confirmed inbound collections drive one obligation-application path and one borrower cash-posting path. | P0 |
+| F-3 | Failure and cancellation coherence | Map failed or cancelled transfer execution back onto the same Collection Attempt without double-interpreting the money event. | P0 |
+| F-4 | Reversal cascade unification | Make attempt-linked transfer reversals cascade once through Collection Attempt reversal and downstream ledger repair. | P0 |
+| F-5 | Bridge-path retirement or fencing | Remove or sharply fence the older attempt-confirmed-to-bridge-transfer path so it is no longer the canonical production story. | P0 |
+| F-6 | Canonical-flow integration coverage | Prove the stable inbound path with backend integration coverage and compatibility-labeled regression tests. | P0 |
+
+## Requirements
+| ID | Requirement | Type | Acceptance Criteria |
+|----|-------------|------|---------------------|
+| REQ-1 | Transfer lifecycle outcomes must reconcile to the linked Collection Attempt. | Functional | Attempt-linked inbound transfers can map confirmed, failed, cancelled, and reversed outcomes back to the originating attempt without manual GT shortcuts. |
+| REQ-2 | Confirmed inbound collections must produce one business settlement outcome. | Functional | The same money event cannot independently settle both transfer and attempt in ways that create duplicate business meaning. |
+| REQ-3 | Obligation application must stay downstream of the Collection Attempt boundary. | Functional | Obligations are applied from the canonical attempt settlement path and do not depend on transfer modules understanding plan-entry strategy semantics. |
+| REQ-4 | Borrower cash posting must occur exactly once for attempt-linked inbound collections. | Functional | Attempt-linked inbound settlement cannot create duplicate `CASH_RECEIVED` journals even when both attempt and transfer events are observed. |
+| REQ-5 | Settlement-layer modules must not require plan-entry awareness to post money. | Functional | Transfer and cash-ledger modules reconcile from stable transfer or attempt references rather than strategy-layer concepts. |
+| REQ-6 | Failed and cancelled inbound transfers must remain durable and auditable. | Functional | Failure or cancellation is reflected on the attempt with durable audit history and without creating confirmed-money side effects. |
+| REQ-7 | Reversals must cascade once and preserve corrective downstream behavior. | Functional | An attempt-linked inbound transfer reversal drives one Collection Attempt reversal and one ledger-repair cascade with no double reversal. |
+| REQ-8 | Legacy bridge behavior must be removed or explicitly compatibility-only. | Functional | `emitPaymentReceived` no longer defines the canonical inbound transfer story, and any retained compatibility logic is fenced and documented as legacy. |
+| REQ-9 | Reconciliation and healing logic must reflect the canonical path. | Functional | Attempt-linked confirmed transfers are not treated as bridge-era orphan exceptions without validating the attempt-owned settlement consequences. |
+| REQ-10 | Integration tests must cover the canonical inbound reconciliation path. | Functional | Tests prove confirmed, failed, cancelled or skipped, reversed, and compatibility-edge behavior through the real settlement seam. |
+
+## Use Cases
+### UC-1: Provider-settled inbound transfer confirms the originating Collection Attempt
+- **Actor**: Unified Payment Rails transfer lifecycle plus AMPS reconciliation seam
+- **Precondition**: A plan entry has already created a Collection Attempt and linked transfer request via page 03
+- **Flow**:
+  1. Provider initiation places the transfer into `pending` or `processing`
+  2. A later transfer settlement event confirms the transfer in Payment Rails
+  3. The canonical reconciliation seam resolves the linked `collectionAttemptId`
+  4. The Collection Attempt transitions to `confirmed`
+  5. Obligation application and borrower cash posting run once from the attempt-owned consequence path
+- **Postcondition**: One confirmed inbound collection yields one stable attempt outcome, one obligation-application path, and one cash-posting path
+- **E2E Test**: Backend integration test; browser e2e not required
+
+### UC-2: Failed or cancelled transfer execution feeds durable attempt failure semantics
+- **Actor**: Unified Payment Rails transfer lifecycle plus AMPS retry logic
+- **Precondition**: A Collection Attempt is linked to an inbound transfer that fails or is cancelled before settlement
+- **Flow**:
+  1. Transfer lifecycle produces a failed or cancelled outcome
+  2. The canonical reconciliation seam maps that outcome back to the same attempt
+  3. The attempt advances through governed failure semantics and existing retry rules when appropriate
+- **Postcondition**: The attempt remains the business-layer execution record for the failed collection and no cash or obligation posting occurs
+- **E2E Test**: Backend integration test; browser e2e not required
+
+### UC-3: Reversed inbound transfer triggers one attempt reversal and one ledger repair cascade
+- **Actor**: Unified Payment Rails reversal lifecycle plus AMPS reversal logic
+- **Precondition**: An inbound transfer and its linked Collection Attempt were previously confirmed
+- **Flow**:
+  1. Transfer lifecycle emits a reversal outcome
+  2. The canonical reconciliation seam maps reversal back to the linked Collection Attempt
+  3. The attempt transitions to `reversed`
+  4. The durable attempt reversal cascade repairs cash and obligation state once
+- **Postcondition**: Business and settlement layers remain aligned after reversal with explicit auditability
+- **E2E Test**: Backend integration test; browser e2e not required
+
+### UC-4: Legacy bridge-era inbound behavior is retired or fenced
+- **Actor**: Internal reconciliation and test suites
+- **Precondition**: Old tests or seed paths still assume `emitPaymentReceived` can create a transfer after the attempt settles
+- **Flow**:
+  1. Canonical attempt-linked transfer settlement is established as the only production path
+  2. Bridge-era behavior is either removed or reduced to explicit compatibility handling
+  3. Tests and reconciliation logic are rewritten to validate the canonical path first
+- **Postcondition**: The repo no longer presents two production stories for the same inbound money movement
+- **E2E Test**: Backend integration regression or compatibility test; browser e2e not required
+
+## Schemas
+- `collectionAttempts`
+  - remains the AMPS-owned business execution record
+  - already links to `planEntryId` and `transferRequestId`
+  - owns business settlement and reversal semantics
+- `transferRequests`
+  - remains the Unified Payment Rails execution record
+  - already links back to `collectionAttemptId`
+  - owns provider initiation, transfer lifecycle, and settlement timestamps
+- `cash_ledger_journal_entries`
+  - must show exactly one inbound `CASH_RECEIVED` meaning for attempt-linked collections
+  - must remain reversible via one stable posting group
+- `obligations`
+  - continue to receive payment application and corrective reversal consequences from the attempt-owned path
+- reconciliation/healing metadata
+  - existing transfer-healing attempts and audit trails should align to the new canonical path rather than bridge-only assumptions
+
+## Out of Scope
+- Converging the inbound provider boundary on `TransferProvider` beyond what page 05 already owns
+- Broader schema normalization and contract cleanup deferred to page 11
+- Mortgage lifecycle and ledger-boundary redesign outside the attempt/transfer seam owned by page 14
+- Final repo-wide deprecation cleanup and exhaustive verification owned by page 15
+- New frontend flows or browser UX work unless implementation exposes an unavoidable operator surface

--- a/specs/04-reconcile-collection-attempts-with-transfer-execution-and-cash-posting/design.md
+++ b/specs/04-reconcile-collection-attempts-with-transfer-execution-and-cash-posting/design.md
@@ -1,0 +1,159 @@
+# 04. Reconcile Collection Attempts with Transfer Execution and Cash Posting — Design
+
+> Derived from: https://www.notion.so/337fc1b4402481a48a13ee61e289e8f0
+
+## Types & Interfaces
+
+### Existing domain records stay authoritative
+The current page-03 surfaces remain the authoritative roots of the production
+flow:
+- `collectionAttempts` are the AMPS business execution records
+- `transferRequests` are the Unified Payment Rails execution records
+- `cash_ledger_journal_entries` remain the single money-posting evidence layer
+
+Page 04 should reconcile those records rather than introduce a parallel inbound
+execution record.
+
+### Proposed reconciliation coordinator contract
+The cleanest seam is a dedicated internal reconciliation helper or module that
+accepts transfer outcomes and resolves them into attempt-owned business
+transitions.
+
+Planned contract shape:
+- input
+  - `transferId`
+  - transfer outcome type such as `confirmed`, `failed`, `cancelled`, or `reversed`
+  - canonical payload fields already emitted by Payment Rails such as
+    `settledAt`, `reason`, `reversalRef`, and `effectiveDate`
+  - `source`
+- output
+  - whether a linked `collectionAttemptId` existed
+  - whether a Collection Attempt transition was fired
+  - attempt state before and after reconciliation
+  - whether downstream money or reversal consequences were attempt-owned
+
+This coordinator should be called by transfer lifecycle entrypoints rather than
+making transfer effects directly own business-layer semantics.
+
+### Canonical ownership split
+- Unified Payment Rails owns:
+  - `TransferRequest`
+  - provider initiation
+  - provider callbacks
+  - transfer state machine transitions
+  - transfer settlement and reversal facts
+- AMPS owns:
+  - `CollectionAttempt`
+  - business confirmation and reversal meaning
+  - obligation application
+  - borrower cash posting consequences
+
+## Database Schema
+
+### Existing schema is likely sufficient for the first page-04 pass
+The current linkage already exists:
+- `collectionAttempts.transferRequestId`
+- `transferRequests.collectionAttemptId`
+- `transferRequests.planEntryId`
+- transfer and attempt status fields plus audit timestamps
+
+The default plan is to avoid new tables or broad schema changes unless the code
+review shows a missing audit or idempotency field. Page 11 is the correct place
+for broader schema convergence.
+
+### Reconciliation-specific expectations
+- attempt-linked inbound transfers should not require a transfer-owned
+  `CASH_RECEIVED` journal
+- the canonical inbound journal should be discoverable through
+  `attemptId`-scoped or posting-group-scoped ledger entries
+- reversal lookup must remain idempotent whether it starts from
+  `attemptId` or `transferRequestId`
+
+## Architecture
+
+### Data Flow
+`collectionPlan.executePlanEntry`
+-> `collectionAttempts` created and linked to `transferRequests`
+-> provider initiation advances transfer state
+-> later transfer lifecycle event confirms, fails, cancels, or reverses transfer
+-> transfer lifecycle entrypoint delegates to a reconciliation coordinator
+-> coordinator fires governed `collectionAttempt` transition when linked
+-> `emitPaymentReceived` or `emitPaymentReversed` remains the attempt-owned
+   consequence path
+-> obligation application and cash-ledger repair occur once
+
+### Component Structure
+No frontend component work is expected for the initial page-04 implementation.
+The main code will likely live in:
+- `convex/engine/effects/transfer.ts`
+- a new or expanded internal reconciliation helper near
+  `convex/payments/collectionPlan/` or `convex/payments/transfers/`
+- `convex/engine/effects/collectionAttempt.ts`
+- `convex/payments/transfers/reconciliation.ts`
+- relevant integration tests under transfer, cash-ledger, and cross-entity suites
+
+### API Surface
+
+#### Reads (Queries/GET)
+| Function | Args | Returns | Description |
+|----------|------|---------|-------------|
+| existing transfer query helpers | `transferId` | transfer record | Load the linked transfer and attempt references for reconciliation |
+| existing attempt/plan-entry loaders or small internal helper | `attemptId` | attempt context | Support attempt-owned settlement and reversal consequences |
+
+#### Writes (Mutations/POST)
+| Function | Args | Returns | Description |
+|----------|------|---------|-------------|
+| new transfer-to-attempt reconciliation helper | transfer outcome payload | reconciliation result | Translate transfer lifecycle facts into Collection Attempt GT events |
+| existing `executeTransition` on `collectionAttempt` | attempt id + event payload | GT transition result | Preserve attempt-state ownership inside AMPS |
+| refined attempt effects | effect payload | side effects | Keep obligation application, overpayment handling, and reversal repair in the attempt-owned layer |
+
+#### Side Effects (Actions/Jobs)
+| Function | Args | Returns | Description |
+|----------|------|---------|-------------|
+| `publishTransferConfirmed` | transfer effect args | void | Settlement-layer entrypoint that must reconcile attempt-linked transfers without double cash posting |
+| `publishTransferFailed` and manual cancellation paths | transfer effect args | void | Failure or cancellation entrypoints that should map back to the linked attempt |
+| `publishTransferReversed` | transfer effect args | void | Reversal entrypoint that should drive attempt reversal for attempt-linked inbound transfers |
+| transfer reconciliation cron(s) | none or scheduled args | void | Healing logic that should validate canonical attempt-owned consequences instead of bridge-era shortcuts |
+
+### Routing
+No route changes are planned. This is backend orchestration and settlement
+reconciliation work.
+
+## Implementation Decisions
+
+### Prefer a dedicated reconciliation coordinator over scattered ad hoc callbacks
+The Notion implementation plan explicitly prefers a dedicated coordinator when
+it keeps AMPS and Payment Rails boundaries clearer. That is the recommended
+default here because transfer effects currently know too much about bridge-era
+cash-posting exceptions but too little about the linked attempt lifecycle.
+
+### Attempt-owned settlement stays canonical for attempt-linked inbound collections
+For attempt-linked inbound transfers, transfer confirmation should reconcile
+back into `collectionAttempt -> FUNDS_SETTLED`, and the attempt-owned
+`emitPaymentReceived` path should remain the only place that applies
+obligations, handles overpayment routing, and produces the business-layer cash
+meaning. Transfer effects should not create a second inbound cash story.
+
+### Remove or sharply fence the old bridge creator
+`emitPaymentReceived` currently creates a transfer when `attempt.transferRequestId`
+is absent. That should no longer be treated as a normal production path. The
+preferred direction is to retire it in greenfield scope or reduce it to an
+explicit compatibility/error path that is not exercised by canonical tests.
+
+### Reversal should mirror confirmation ownership
+If confirmation for attempt-linked inbound collections is attempt-owned, then
+reversal should also reconcile to `collectionAttempt -> PAYMENT_REVERSED` and
+let the durable attempt reversal cascade own downstream cash repair. Transfer
+effects may still persist transfer-level reversal facts, but they should not
+independently reverse attempt-owned inbound cash meaning.
+
+### Reconciliation healing must validate the canonical outcome, not bridge heuristics
+Current transfer reconciliation skips any transfer with `collectionAttemptId`.
+That was acceptable while bridge behavior dominated, but the canonical model
+should verify that the linked attempt consequences exist before treating the
+transfer as healthy.
+
+### Backend integration tests are the primary proof surface
+The core risks are duplicate journals, duplicate obligation application, drift
+between attempt and transfer status, and asymmetric reversal behavior. Those are
+best exercised in Convex integration suites, not browser e2e.

--- a/specs/04-reconcile-collection-attempts-with-transfer-execution-and-cash-posting/gap-analysis.md
+++ b/specs/04-reconcile-collection-attempts-with-transfer-execution-and-cash-posting/gap-analysis.md
@@ -1,0 +1,99 @@
+# 04. Reconcile Collection Attempts with Transfer Execution and Cash Posting — Gap Analysis
+
+Re-fetched against the canonical Notion sources on 2026-04-03:
+
+- Spec: `https://www.notion.so/337fc1b4402481a48a13ee61e289e8f0`
+- Linked plan: `https://www.notion.so/337fc1b4402481658522e53977e06633`
+
+## Verdict
+
+Page 04 is implemented for the canonical inbound reconciliation path described in
+the current Notion spec and linked implementation plan.
+
+The codebase now reconciles attempt-linked inbound transfer confirmations,
+failures, cancellations, and reversals back into Collection Attempt governed
+transitions, keeps obligation application and borrower cash posting owned by the
+attempt consequence path, and updates transfer-health detection so canonical
+attempt-owned journals count as healthy evidence instead of bridge-era
+exceptions. Browser e2e was intentionally not added because the delivery surface
+for this page is backend settlement orchestration and reconciliation behavior.
+
+## Coverage Matrix
+
+| Spec item | Status | Evidence |
+| --- | --- | --- |
+| Transfer lifecycle outcomes reconcile to the linked Collection Attempt | Implemented | `convex/payments/transfers/collectionAttemptReconciliation.ts`, `convex/engine/effects/transfer.ts`, `convex/engine/machines/transfer.machine.ts` |
+| Confirmed inbound collections produce one business settlement outcome | Implemented | `publishTransferConfirmed` now delegates attempt-linked inbound business meaning to the Collection Attempt path and skips duplicate inbound cash posting in `convex/engine/effects/transfer.ts` |
+| Obligation application remains downstream of the Collection Attempt boundary | Implemented | confirmed attempt-linked inbound settlement still flows through `emitPaymentReceived`; transfer modules no longer own obligation semantics for that path |
+| Borrower cash posting occurs exactly once for attempt-linked inbound collections | Implemented | attempt-owned settlement health uses `cash-receipt:${attemptId}` evidence in `convex/payments/transfers/collectionAttemptReconciliation.ts`; confirmed transfer effects avoid creating a second inbound cash story |
+| Settlement-layer modules do not require plan-entry awareness | Implemented | reconciliation uses stable `collectionAttemptId` / posting-group linkage rather than plan-entry strategy semantics |
+| Failed and cancelled inbound transfers remain durable and auditable | Implemented | `reconcileAttemptLinkedInboundFailure` and `reconcileAttemptLinkedInboundCancellation` patch provider status and drive governed attempt events |
+| Reversals cascade once and preserve downstream corrective behavior | Implemented | `reconcileAttemptLinkedInboundReversal` routes transfer reversals into attempt reversal; reversal health now checks attempt-owned reversal posting groups |
+| Legacy bridge behavior is compatibility-only, not canonical | Implemented | `emitPaymentReceived` already skips bridge creation when `transferRequestId` exists; canonical tests validate the attempt-linked transfer path while bridge-era wording was relabeled |
+| Reconciliation and healing logic reflect the canonical path | Implemented with residual compatibility note | `convex/payments/cashLedger/transferReconciliation.ts` and `convex/payments/transfers/reconciliation.ts` now validate attempt-owned settlement/reversal consequences before classifying attempt-linked inbound transfers as healthy or orphaned |
+| Integration coverage proves the canonical inbound path | Implemented | `convex/payments/transfers/__tests__/collectionAttemptReconciliation.integration.test.ts`, `convex/payments/cashLedger/__tests__/transferReconciliation.test.ts`, transfer-machine/effect/handler regression suites |
+
+## Use Case Coverage
+
+| Use case | Status | Evidence |
+| --- | --- | --- |
+| UC-1: Provider-settled inbound transfer confirms the originating Collection Attempt | Implemented | `collectionAttemptReconciliation.integration.test.ts` proves transfer confirmation settles the linked attempt once and leaves inbound cash posting on the attempt-owned path |
+| UC-2: Failed or cancelled transfer execution feeds durable attempt failure semantics | Implemented | failure and cancellation integration coverage proves no confirmed-money side effects and durable attempt lifecycle updates |
+| UC-3: Reversed inbound transfer triggers one attempt reversal and one ledger repair cascade | Implemented | reversal integration coverage plus attempt-owned reversal health checks in transfer reconciliation |
+| UC-4: Legacy bridge-era inbound behavior is retired or fenced | Implemented with compatibility scope | bridge-era reconciliation tests were relabeled away from canonical-path claims and `emitPaymentReceived` bridge creation remains fenced behind missing-link compatibility logic |
+
+## Key Design Outcomes Verified
+
+- A dedicated transfer-to-attempt reconciliation coordinator now owns the
+  attempt-linked inbound mapping seam.
+- Transfer confirmation, failure, cancellation, and reversal all route through
+  the same attempt-owned business boundary for inbound collections.
+- Confirmed inbound transfer effects no longer create a second business cash
+  meaning when a transfer is linked to a Collection Attempt.
+- Transfer-health detection now treats attempt-owned `CASH_RECEIVED` and
+  `REVERSAL` posting groups as canonical evidence for attempt-linked inbound
+  transfers.
+- Cancellation is now a first-class transfer-machine effect path instead of a
+  transfer-only terminal state with no attempt reconciliation.
+
+## Intentional Scope Boundaries Preserved
+
+- Page 04 remains backend-only.
+- No route or UI work was added.
+- No broader schema normalization was introduced; the existing attempt/transfer
+  linkage was sufficient for this page.
+- Unified Payment Rails still owns transfer execution facts; AMPS still owns the
+  business execution record and its downstream consequences.
+
+## Residual Notes
+
+1. The bridge-era `emitPaymentReceived` transfer creator still exists as an
+   explicit compatibility path when an older attempt lacks a linked
+   `transferRequestId`. Page 04 fences it and removes its canonical status, but
+   does not fully delete that compatibility code.
+2. The cash-ledger reconciliation cron still carries the existing
+   `pending_no_effect` placeholder retry result for unresolved confirmed-transfer
+   healing. Page 04 updates canonical detection and health classification, but
+   does not add a brand-new automated repair executor for every unhealthy case.
+3. GitNexus impact analysis partially resolved the touched surface:
+   `reconcileTransfer` resolved with `LOW` risk, while some effect exports were
+   not directly resolvable in the current index. Final scope verification used
+   `detect_changes(scope="all")` plus direct diff review for the remaining
+   symbols.
+
+## Verification Evidence
+
+- `bun run test convex/engine/effects/__tests__/transfer.test.ts convex/payments/transfers/__tests__/handlers.integration.test.ts convex/payments/transfers/__tests__/collectionAttemptReconciliation.integration.test.ts convex/payments/transfers/__tests__/transferMachine.test.ts convex/engine/machines/__tests__/transfer.machine.test.ts convex/payments/transfers/__tests__/reconciliation.test.ts convex/payments/cashLedger/__tests__/transferReconciliation.test.ts`
+- `bun check`
+- `bun typecheck`
+- `bunx convex codegen`
+- GitNexus `detect_changes(scope="all")` reported `risk_level: low` for repo `fairlendapp`
+
+## Final Assessment
+
+No blocking gaps remain for the page-04 objective. The production inbound
+reconciliation story is now coherent: Collection Attempts remain the business
+execution record, Unified Payment Rails remains the transfer execution record,
+attempt-linked inbound settlement and reversal consequences are single-owned,
+and the canonical path is covered by backend integration tests aligned to the
+current Notion spec as of 2026-04-03.

--- a/specs/04-reconcile-collection-attempts-with-transfer-execution-and-cash-posting/tasks.md
+++ b/specs/04-reconcile-collection-attempts-with-transfer-execution-and-cash-posting/tasks.md
@@ -1,0 +1,36 @@
+# 04. Reconcile Collection Attempts with Transfer Execution and Cash Posting — Tasks
+
+> Spec: https://www.notion.so/337fc1b4402481a48a13ee61e289e8f0
+> Generated: 2026-04-03
+>
+> If every task below is checked, the spec is fully implemented, tested, and verified.
+
+## Phase 1: Schema & Data Layer
+- [x] T-001: Capture local PRD, design, and task artifacts for the page-04 reconciliation seam. (F-1, F-2, F-3, F-4, F-5, F-6)
+- [x] T-002: Inventory the current attempt-linked inbound settlement, reversal, and bridge-era paths and document the canonical ownership rules in code comments or helper boundaries. (REQ-1, REQ-2, REQ-7, REQ-8, F-1, F-5)
+- [x] T-003: Add any minimal persistence or audit metadata required for attempt-linked transfer reconciliation, while deferring broader schema cleanup to page 11. (REQ-1, REQ-6, REQ-9, F-1)
+
+## Phase 2: Backend Functions
+- [x] T-010: Run impact analysis on shared collection-attempt, transfer, and cash-posting symbols before modifying them. (REQ-1, REQ-2, REQ-4, REQ-7, F-1, F-2, F-4)
+- [x] T-011: Implement a canonical transfer-outcome reconciliation coordinator that maps attempt-linked transfer confirmations, failures, cancellations, and reversals back into Collection Attempt GT events. (UC-1, UC-2, UC-3, REQ-1, REQ-2, REQ-6, REQ-7, F-1, F-3, F-4)
+- [x] T-012: Refactor transfer settlement and reversal effects so attempt-linked inbound transfers delegate business meaning to the Collection Attempt path instead of creating a second inbound cash story. (UC-1, UC-3, REQ-2, REQ-4, REQ-5, REQ-7, F-2, F-4)
+- [x] T-013: Enforce one canonical obligation-application and borrower-cash-posting trigger for confirmed attempt-linked inbound collections. (UC-1, REQ-3, REQ-4, REQ-5, F-2)
+- [x] T-014: Remove or sharply fence the legacy bridge-transfer creation path in `emitPaymentReceived`, and update reconciliation or healing logic so it reflects the canonical attempt-linked flow. (UC-4, REQ-8, REQ-9, F-5)
+- [x] T-015: Align failure and cancellation behavior across transfer and attempt lifecycles so retry semantics remain durable without posting money. (UC-2, REQ-1, REQ-6, F-3)
+- [x] T-016: Align reversal semantics so attempt-linked transfer reversals cascade once through Collection Attempt reversal and ledger repair. (UC-3, REQ-7, F-4)
+
+## Phase 3: Frontend — Routes & Components
+- [x] T-020: Verify that page 04 remains backend-only and identify any minimum admin/operator observability wrapper needed for later work without widening scope now. (REQ-6, REQ-9, F-1, F-3)
+
+## Phase 4: E2E Tests
+- [x] T-030: Assess whether browser e2e adds value, given that the critical delivery surface is backend reconciliation and settlement orchestration. (REQ-10, F-6)
+- [x] T-031: Add backend integration coverage for the canonical async settlement path: transfer confirms later, linked Collection Attempt settles once, obligations apply once, and borrower cash journals once. (UC-1, REQ-1, REQ-2, REQ-3, REQ-4, REQ-5, REQ-10, F-1, F-2, F-6)
+- [x] T-032: Add backend integration coverage for failed or cancelled attempt-linked inbound transfers proving durable attempt failure semantics with no confirmed-money side effects. (UC-2, REQ-1, REQ-6, REQ-10, F-3, F-6)
+- [x] T-033: Add backend integration coverage for attempt-linked inbound reversals proving one attempt reversal and one ledger-repair cascade. (UC-3, REQ-7, REQ-10, F-4, F-6)
+- [x] T-034: Rewrite or relabel bridge-era tests so they either validate explicit compatibility handling or are replaced by canonical-flow coverage, and document why browser e2e is unnecessary if backend coverage is sufficient. (UC-4, REQ-8, REQ-9, REQ-10, F-5, F-6)
+
+## Phase 5: Verification
+- [x] T-040: Re-fetch the Notion spec and linked implementation plan to verify the final code still matches the current page-04 contract. (F-1, F-2, F-3, F-4, F-5, F-6)
+- [x] T-041: Create `gap-analysis.md`. (REQ-1, REQ-2, REQ-3, REQ-4, REQ-5, REQ-6, REQ-7, REQ-8, REQ-9, REQ-10)
+- [x] T-042: Present the gap analysis to the user. (REQ-1, REQ-2, REQ-3, REQ-4, REQ-5, REQ-6, REQ-7, REQ-8, REQ-9, REQ-10)
+- [x] T-043: Final `bun check`, `bun typecheck`, and `bunx convex codegen` pass. (REQ-1, REQ-2, REQ-3, REQ-4, REQ-5, REQ-6, REQ-7, REQ-8, REQ-9, REQ-10)

--- a/specs/05-converge-inbound-provider-boundary-on-transferprovider/PRD.md
+++ b/specs/05-converge-inbound-provider-boundary-on-transferprovider/PRD.md
@@ -1,0 +1,91 @@
+# 05. Converge Inbound Provider Boundary on TransferProvider
+
+> **Canonical Source of Truth**: https://www.notion.so/337fc1b4402481ceb962ca7c2eada7af
+>
+> This PRD is a compressed working context snapshot extracted from the Notion spec.
+> Always defer to the Notion page for the latest requirements. This file serves as
+> a local reference to reduce Notion API calls during implementation.
+
+## Overview
+This workstream finishes the architectural convergence that earlier pages already
+started: inbound provider execution should be described, implemented, and tested
+through `TransferProvider`, while `PaymentMethod` remains an explicitly frozen
+compatibility abstraction. The goal is not to delete compatibility code
+prematurely, but to remove the impression that the repo supports two equal
+forward-looking inbound provider boundaries.
+
+## Features
+| ID | Feature | Description | Priority |
+|----|---------|-------------|----------|
+| F-1 | Canonical provider boundary | Treat `TransferProvider` as the only forward-looking inbound provider contract. | P0 |
+| F-2 | Production handoff convergence | Ensure AMPS-owned execution paths hand off into Unified Payment Rails, which then resolves providers through transfer-domain contracts only. | P0 |
+| F-3 | Compatibility fencing | Keep `PaymentMethod`, its registry, and adapter usage available only for explicit compatibility or migration edges. | P0 |
+| F-4 | Registry and adapter narrowing | Simplify provider resolution and make adapter usage clearly transitional instead of ambient architecture. | P0 |
+| F-5 | Docs and test convergence | Rewrite docs and tests so future contributors do not read `PaymentMethod` and `TransferProvider` as peer abstractions. | P0 |
+| F-6 | Verified migration posture | Leave a clear retirement path for remaining legacy surfaces without breaking legitimate compatibility use cases today. | P0 |
+
+## Requirements
+| ID | Requirement | Type | Acceptance Criteria |
+|----|-------------|------|---------------------|
+| REQ-1 | No new production inbound execution path may depend directly on `PaymentMethod`. | Functional | Canonical inbound execution and reconciliation surfaces resolve providers only through transfer-domain contracts and registries. |
+| REQ-2 | AMPS execution code must hand off into Unified Payment Rails rather than provider selection details. | Functional | Page-02/03/04 execution paths reference transfer request creation and initiation, not direct payment-method lookup. |
+| REQ-3 | Adapter usage must be explicit and compatibility-scoped. | Functional | `PaymentMethodAdapter` remains available only as an intentional bridge and is not presented as a normal provider extension point. |
+| REQ-4 | `TransferProvider` must be the only forward-looking provider abstraction in current docs and examples. | Functional | New docs, examples, and tests describe inbound provider work in transfer-domain terms. |
+| REQ-5 | Legacy `PaymentMethod` surfaces must remain compatibility-only until later retirement work. | Functional | Existing compatibility use cases keep working, but registries, mocks, and interfaces are labeled frozen or deprecated for new work. |
+| REQ-6 | Provider resolution must happen through the transfer-provider registry for canonical inbound paths. | Functional | Production initiation flows resolve provider implementations via `getTransferProvider` or an equivalent transfer-domain boundary. |
+| REQ-7 | Tests must stop implying equal architectural status between `PaymentMethod` and `TransferProvider`. | Functional | Legacy tests are relabeled as compatibility coverage; canonical tests target transfer-provider flows. |
+| REQ-8 | Compatibility warnings or comments must make the migration direction obvious. | Functional | Remaining legacy entrypoints include clear deprecation or compatibility guidance. |
+| REQ-9 | Convergence work must not break current manual or mock compatibility flows prematurely. | Functional | Adapter-backed or explicitly legacy tests still pass where compatibility is intentionally preserved. |
+| REQ-10 | Verification must compare final code against the live Notion page and linked implementation plan. | Functional | A final gap analysis confirms the current repo matches the page-05 contract or records any residual gaps. |
+
+## Use Cases
+### UC-1: New inbound execution work resolves a canonical TransferProvider
+- **Actor**: AMPS execution handoff plus Unified Payment Rails provider resolution
+- **Precondition**: A business-layer command creates or initiates an inbound transfer
+- **Flow**:
+  1. AMPS creates or advances business execution state
+  2. AMPS hands off into Unified Payment Rails
+  3. Unified Payment Rails resolves a `TransferProvider`
+  4. Provider initiation runs through the transfer-domain boundary
+- **Postcondition**: No new production inbound work depends directly on `PaymentMethod`
+- **E2E Test**: Backend/unit or integration coverage; browser e2e not required
+
+### UC-2: A legacy compatibility path still uses PaymentMethod through an explicit bridge
+- **Actor**: Compatibility-only registry or adapter path
+- **Precondition**: An older test, seed, or migration edge still depends on `PaymentMethod`
+- **Flow**:
+  1. Compatibility path opts into a legacy `PaymentMethod` implementation
+  2. Adapter or registry bridge makes the legacy dependency explicit
+  3. Docs and code comments explain that the path is transitional only
+- **Postcondition**: Compatibility still works, but does not present itself as the canonical architecture
+- **E2E Test**: Backend/unit compatibility test; browser e2e not required
+
+### UC-3: A future contributor reads the codebase and sees one canonical inbound provider story
+- **Actor**: Engineer extending inbound provider functionality
+- **Precondition**: They inspect provider interfaces, registries, docs, and examples
+- **Flow**:
+  1. Canonical interfaces and registries point to `TransferProvider`
+  2. Legacy `PaymentMethod` surfaces are clearly marked compatibility-only
+  3. Tests and examples reinforce the same boundary
+- **Postcondition**: The repo does not suggest two equal provider abstractions
+- **E2E Test**: Documentation and test-suite convergence; browser e2e not required
+
+## Schemas
+- `TransferProvider`
+  - canonical transfer-domain provider contract for new inbound work
+  - owned by Unified Payment Rails
+- `PaymentMethod`
+  - compatibility-only abstraction for older inbound collection flows
+  - should not receive new production provider features
+- provider registries
+  - transfer-domain registry remains canonical for provider resolution
+  - legacy methods registry remains compatibility-only until later removal
+- adapter boundary
+  - `PaymentMethodAdapter` exists only to bridge remaining compatibility use cases
+
+## Out of Scope
+- Implementing new real provider integrations such as Rotessa or other external processors
+- Broad schema normalization and contract retirement deferred to page 11
+- Reworking page-02/03/04 business execution semantics beyond boundary wording and provider-resolution ownership
+- Full deletion of every legacy `PaymentMethod` surface if compatibility still requires it
+- New frontend routes or browser UX work

--- a/specs/05-converge-inbound-provider-boundary-on-transferprovider/design.md
+++ b/specs/05-converge-inbound-provider-boundary-on-transferprovider/design.md
@@ -1,0 +1,127 @@
+# 05. Converge Inbound Provider Boundary on TransferProvider — Design
+
+> Derived from: https://www.notion.so/337fc1b4402481ceb962ca7c2eada7af
+
+## Types & Interfaces
+
+### Existing provider contracts stay explicit
+The repo already contains the intended split:
+- `convex/payments/transfers/interface.ts` defines `TransferProvider` as the
+  canonical provider contract for transfer-domain execution and new inbound work
+- `convex/payments/methods/interface.ts` defines `PaymentMethod` as legacy
+  inbound compatibility
+- `convex/payments/transfers/providers/adapter.ts` bridges a legacy
+  `PaymentMethod` implementation into the `TransferProvider` contract
+
+Page 05 should converge on that architecture rather than invent a third layer.
+
+### Canonical ownership boundary
+- AMPS owns:
+  - `CollectionPlan`
+  - `CollectionAttempt`
+  - business execution semantics
+  - handoff into Unified Payment Rails
+- Unified Payment Rails owns:
+  - `TransferRequest`
+  - `TransferProvider`
+  - provider resolution and initiation
+  - transfer lifecycle
+- Compatibility layer owns:
+  - `PaymentMethod`
+  - `PaymentMethodAdapter`
+  - legacy registry and migration shims only
+
+### Compatibility contract expectations
+- `PaymentMethod` should remain stable but frozen
+- `PaymentMethodAdapter` should remain narrowly scoped to inbound borrower
+  compatibility only
+- canonical docs and examples should reference `TransferProvider` first and
+  mention `PaymentMethod` only in a compatibility section
+
+## Database Schema
+
+### No schema changes are expected
+Page 05 is a provider-boundary convergence pass, not a storage redesign. The
+existing attempt, transfer, and ledger tables remain authoritative.
+
+### Expected metadata posture
+- deprecation or compatibility intent should be encoded primarily in code
+  comments, module boundaries, and tests
+- if small runtime warnings already exist on legacy mocks, prefer extending that
+  pattern rather than adding new tables or flags
+
+## Architecture
+
+### Data Flow
+`collectionPlan.executePlanEntry`
+-> Unified Payment Rails transfer-request creation
+-> transfer-domain registry resolves `TransferProvider`
+-> provider initiation executes in transfer infrastructure
+-> transfer lifecycle and reconciliation continue through page-03/04 seams
+
+Legacy compatibility flow:
+compatibility-only caller
+-> legacy `PaymentMethod` registry or concrete class
+-> optional `PaymentMethodAdapter`
+-> transfer-domain contract when bridging is still required
+
+### Component Structure
+No frontend component work is expected. The likely code surface is:
+- `convex/payments/transfers/interface.ts`
+- `convex/payments/transfers/providers/registry.ts`
+- `convex/payments/transfers/providers/adapter.ts`
+- `convex/payments/methods/interface.ts`
+- `convex/payments/methods/registry.ts`
+- `convex/payments/methods/manual.ts`
+- `convex/payments/methods/mockPAD.ts`
+- tests and docs that still describe `ManualPaymentMethod` or `PaymentMethod`
+  as primary architecture
+
+### API Surface
+
+#### Reads (Queries/GET)
+No new runtime query surface is expected.
+
+#### Writes (Mutations/POST)
+No new public API is required by default. Expected work is refactoring,
+fencing, and clarifying existing provider-resolution surfaces.
+
+#### Side Effects (Actions/Jobs)
+No new cron or async orchestration is expected. Existing initiation and
+reconciliation actions should continue to use transfer-domain provider
+resolution.
+
+### Routing
+No route changes are planned. This is backend/provider-boundary and
+documentation/test convergence work.
+
+## Implementation Decisions
+
+### Prefer convergence and fencing over premature deletion
+The Notion plan explicitly frames `PaymentMethod` as compatibility-only but not
+necessarily removable in one pass. The default should be:
+- remove ambiguity now
+- preserve explicitly required compatibility behavior
+- defer full retirement until follow-on cleanup pages
+
+### Canonical production paths should resolve providers only in the transfer domain
+The current repo truth already suggests this is mostly in place through
+`getTransferProvider`. Page 05 should verify and reinforce that rather than
+reshaping the execution spine.
+
+### Legacy registries should read as frozen compatibility shims
+`convex/payments/methods/registry.ts` currently warns readers toward the
+transfer-domain registry, which is good. The remaining convergence work is to
+make sure tests, comments, and helper names do not continue to imply peer
+architectural status.
+
+### Tests should separate canonical coverage from compatibility coverage
+Current signals suggest canonical transfer-provider tests already exist, while
+some older tests still talk about `ManualPaymentMethod` as the lifecycle story.
+Those should be rewritten or relabeled so contributors can distinguish:
+- canonical transfer-provider behavior
+- compatibility-only legacy behavior
+
+### Docs should describe AMPS as handing off to Payment Rails, not to providers
+This keeps pages 02, 03, and 04 aligned with page 05. Provider terminology
+should stay inside Unified Payment Rails documentation and implementation.

--- a/specs/05-converge-inbound-provider-boundary-on-transferprovider/gap-analysis.md
+++ b/specs/05-converge-inbound-provider-boundary-on-transferprovider/gap-analysis.md
@@ -1,0 +1,92 @@
+# 05. Converge Inbound Provider Boundary on TransferProvider — Gap Analysis
+
+Re-fetched against the canonical Notion sources on 2026-04-03:
+
+- Spec: `https://www.notion.so/337fc1b4402481ceb962ca7c2eada7af`
+- Linked plan: `https://www.notion.so/337fc1b4402481dc9efdcf83ffafd61e`
+
+## Verdict
+
+Page 05 is implemented for the canonical inbound provider-boundary convergence
+described in the current Notion spec and linked implementation plan.
+
+The codebase now presents `TransferProvider` as the single canonical inbound
+provider boundary, while `PaymentMethod`, `methods/registry.ts`, and
+`PaymentMethodAdapter` are explicitly narrowed to legacy compatibility support.
+Canonical inbound execution continues to hand off from AMPS into Unified
+Payment Rails, where the transfer domain resolves provider implementations
+through the transfer-provider registry. Browser e2e was intentionally not added
+because this page is backend contract, compatibility, and documentation
+convergence work.
+
+## Coverage Matrix
+
+| Spec item | Status | Evidence |
+| --- | --- | --- |
+| Canonical inbound execution resolves providers through `TransferProvider` | Implemented | `convex/payments/transfers/mutations.ts`, `convex/payments/transfers/interface.ts`, `convex/payments/transfers/providers/registry.ts` |
+| AMPS does not directly choose legacy `PaymentMethod` implementations for new inbound work | Implemented | transfer initiation comments and handoff posture in `convex/payments/transfers/mutations.ts`; no new canonical path was added through `convex/payments/methods/registry.ts` |
+| Legacy `PaymentMethod` contract is fenced as compatibility-only | Implemented | deprecated framing and legacy-code allowlist in `convex/payments/methods/interface.ts` |
+| Legacy registry only supports explicit compatibility codes | Implemented | runtime allowlist and narrowed builder flow in `convex/payments/methods/registry.ts` |
+| `PaymentMethodAdapter` reads as a shim, not a peer provider boundary | Implemented | adapter now rejects canonical provider codes and documents compatibility-only behavior in `convex/payments/transfers/providers/adapter.ts` |
+| Manual and mock compatibility surfaces steer contributors away from new usage | Implemented | deprecated compatibility framing in `convex/payments/methods/manual.ts` and `convex/payments/methods/mockPAD.ts` |
+| Tests no longer present `PaymentMethod` as the primary inbound architecture | Implemented | compatibility relabeling in `convex/payments/__tests__/methods.test.ts`, `convex/payments/transfers/providers/__tests__/adapter.test.ts`, `convex/engine/machines/__tests__/collectionAttempt.test.ts`, `src/test/convex/payments/endToEnd.test.ts` |
+| Docs show one canonical provider story with compatibility carve-out | Implemented | `docs/technical-design/unified-payment-rails.md`, `docs/architecture/unified-payment-rails-technical-design.md` |
+
+## Use Case Coverage
+
+| Use case | Status | Evidence |
+| --- | --- | --- |
+| UC-1: Canonical inbound transfer execution uses `TransferProvider` terminology and resolution | Implemented | transfer-domain registry remains canonical and page-05 tests/docs reinforce that path |
+| UC-2: Legacy manual and mock flows still work as compatibility behavior | Implemented | `methods.test.ts` and adapter compatibility coverage keep `manual` and `mock_pad` working while rejecting canonical provider codes |
+| UC-3: Future contributors see one production provider boundary and one compatibility seam | Implemented | doc updates, deprecated contract framing, and renamed tests remove peer-architecture ambiguity |
+
+## Key Design Outcomes Verified
+
+- `TransferProvider` remains the only production extension boundary for inbound
+  provider resolution.
+- `PaymentMethod` compatibility is now explicit in both type-level and runtime
+  surfaces.
+- The compatibility registry is narrow and rejects canonical provider codes
+  instead of silently acting like a second provider registry.
+- `PaymentMethodAdapter` now rejects canonical transfer-provider codes like
+  `pad_rotessa` and `mock_eft`, making the legacy bridge non-ambiguous.
+- Tests and docs now reinforce the retirement path instead of preserving older
+  peer-architecture language.
+
+## Intentional Scope Boundaries Preserved
+
+- Page 05 remains backend/docs/test convergence work only.
+- No route or UI work was added.
+- No schema rename or historical field-name cleanup was attempted.
+- Compatibility surfaces remain in place for legacy/manual/mock behavior instead
+  of being removed outright.
+
+## Residual Notes
+
+1. Historical schema and domain field names such as `collectionAttempts.method`
+   and `dispersalEntries.paymentMethod` still exist. They are legacy naming
+   artifacts, not the provider-resolution abstraction. Broader terminology
+   cleanup belongs to a later schema-focused page.
+2. `PaymentMethod`, the legacy registry, and the adapter remain in the repo on
+   purpose as compatibility surfaces. Page 05 narrows and labels them; it does
+   not delete them.
+3. GitNexus `detect_changes(scope="all")` reported `risk_level: medium`, but
+   that scope includes the already-dirty page-04 plus page-05 worktree rather
+   than page-05 in isolation.
+
+## Verification Evidence
+
+- `bun run test convex/payments/transfers/__tests__/mutations.test.ts convex/payments/transfers/providers/__tests__/adapter.test.ts convex/payments/__tests__/methods.test.ts convex/engine/machines/__tests__/collectionAttempt.test.ts src/test/convex/payments/endToEnd.test.ts`
+- `bun check`
+- `bun typecheck`
+- `bunx convex codegen`
+- GitNexus `detect_changes(scope="all")` reported `risk_level: medium` for repo `fairlendapp`
+
+## Final Assessment
+
+No blocking gaps remain for the page-05 objective. The production inbound
+provider story is now coherent: `TransferProvider` is the canonical contract,
+AMPS hands off into Unified Payment Rails without reviving a second provider
+boundary, legacy `PaymentMethod` surfaces are clearly compatibility-only, and
+the updated backend tests and docs reflect that single-boundary architecture as
+of 2026-04-03.

--- a/specs/05-converge-inbound-provider-boundary-on-transferprovider/tasks.md
+++ b/specs/05-converge-inbound-provider-boundary-on-transferprovider/tasks.md
@@ -1,0 +1,35 @@
+# 05. Converge Inbound Provider Boundary on TransferProvider — Tasks
+
+> Spec: https://www.notion.so/337fc1b4402481ceb962ca7c2eada7af
+> Generated: 2026-04-03
+>
+> If every task below is checked, the spec is fully implemented, tested, and verified.
+
+## Phase 1: Schema & Data Layer
+- [x] T-001: Capture local PRD, design, and task artifacts for the page-05 provider-boundary convergence pass. (F-1, F-2, F-3, F-4, F-5, F-6)
+- [x] T-002: Inventory remaining `PaymentMethod`-first production, compatibility, test, and doc call sites and classify each one as canonical, compatibility-only, or candidate for immediate migration. (REQ-1, REQ-3, REQ-4, REQ-5, REQ-7, F-1, F-3, F-5)
+- [x] T-003: Add any minimal deprecation or compatibility metadata needed to make the migration posture explicit without introducing new schema or runtime configuration. (REQ-5, REQ-8, F-3, F-6)
+
+## Phase 2: Backend Functions
+- [x] T-010: Run impact analysis on the shared provider interfaces, registries, and adapter surfaces before modifying them. (REQ-1, REQ-3, REQ-6, F-1, F-4)
+- [x] T-011: Verify and enforce that canonical inbound execution paths resolve providers only through transfer-domain provider contracts and registries. (UC-1, REQ-1, REQ-2, REQ-6, F-1, F-2)
+- [x] T-012: Remove, isolate, or freeze any remaining production inbound path that still resolves legacy `PaymentMethod` implementations directly. (UC-1, REQ-1, REQ-2, REQ-5, REQ-6, F-2, F-3)
+- [x] T-013: Narrow `PaymentMethodAdapter` and the legacy methods registry so they read as explicit compatibility shims rather than normal provider-extension surfaces. (UC-2, REQ-3, REQ-5, REQ-8, F-3, F-4)
+- [x] T-014: Update legacy manual and mock compatibility implementations so new work is steered toward `TransferProvider`-native paths. (REQ-4, REQ-5, REQ-8, REQ-9, F-3, F-4)
+- [x] T-015: Preserve any still-legitimate compatibility use cases without allowing them to present `PaymentMethod` and `TransferProvider` as peer production architecture. (UC-2, REQ-5, REQ-9, F-3, F-6)
+
+## Phase 3: Frontend — Routes & Components
+- [x] T-020: Verify that page 05 remains backend/docs/test convergence work with no route or UI changes required. (REQ-2, REQ-4, F-2, F-5)
+
+## Phase 4: E2E Tests
+- [x] T-030: Assess whether browser e2e adds value given that the delivery surface is backend/provider-boundary and documentation convergence. (REQ-10, F-5, F-6)
+- [x] T-031: Expand or rewrite backend/provider tests so canonical inbound provider resolution uses `TransferProvider` terminology and behavior. (UC-1, REQ-1, REQ-4, REQ-6, REQ-7, F-1, F-4, F-5)
+- [x] T-032: Relabel or restructure legacy `PaymentMethod` tests so they validate compatibility-only behavior instead of canonical architecture. (UC-2, REQ-5, REQ-7, REQ-9, F-3, F-5)
+- [x] T-033: Update older end-to-end or cross-entity tests that still present `ManualPaymentMethod` as the primary inbound lifecycle story. (UC-3, REQ-4, REQ-7, F-5)
+- [x] T-034: Update docs and examples so future contributors see a single canonical inbound provider boundary with a small explicit compatibility section. (UC-3, REQ-4, REQ-8, F-5, F-6)
+
+## Phase 5: Verification
+- [x] T-040: Re-fetch the Notion spec and linked implementation plan to verify the final code still matches the current page-05 contract. (F-1, F-2, F-3, F-4, F-5, F-6)
+- [x] T-041: Create `gap-analysis.md`. (REQ-1, REQ-2, REQ-3, REQ-4, REQ-5, REQ-6, REQ-7, REQ-8, REQ-9, REQ-10)
+- [x] T-042: Present the gap analysis to the user. (REQ-1, REQ-2, REQ-3, REQ-4, REQ-5, REQ-6, REQ-7, REQ-8, REQ-9, REQ-10)
+- [x] T-043: Final `bun check`, `bun typecheck`, and `bunx convex codegen` pass. (REQ-1, REQ-2, REQ-3, REQ-4, REQ-5, REQ-6, REQ-7, REQ-8, REQ-9, REQ-10)

--- a/specs/06-correct-activation-and-initial-scheduling-handoff/PRD.md
+++ b/specs/06-correct-activation-and-initial-scheduling-handoff/PRD.md
@@ -1,0 +1,90 @@
+# 06. Correct Activation and Initial Scheduling Handoff
+
+> **Canonical Source of Truth**: https://www.notion.so/337fc1b4402481738c5ecc14f4e08da9
+>
+> This PRD is a compressed working context snapshot extracted from the Notion spec.
+> Always defer to the Notion page for the latest requirements. This file serves as
+> a local reference to reduce Notion API calls during implementation.
+
+## Overview
+This workstream removes the remaining bootstrap-only shortcut for initial
+collection scheduling. Obligations must remain the first contractual truth, and
+the first `collectionPlanEntries` for a mortgage must be derived through the
+same rules-engine semantics used elsewhere instead of direct insertion logic in
+seed/bootstrap code.
+
+## Features
+| ID | Feature | Description | Priority |
+|----|---------|-------------|----------|
+| F-1 | Obligation-first activation | Preserve the sequence where mortgage terms generate obligations before collection strategy is derived. | P0 |
+| F-2 | Canonical scheduling handoff | Introduce one shared activation/bootstrap handoff for initial schedule generation. | P0 |
+| F-3 | Bootstrap convergence | Remove direct bootstrap insertion as a second source of truth for initial plan entries. | P0 |
+| F-4 | Rules-engine-derived initial entries | Ensure the first collection strategy is produced through schedule-rule semantics. | P0 |
+| F-5 | Idempotent reruns | Preserve safe reruns for bootstrap, activation, repair, and migration-style orchestration. | P0 |
+| F-6 | Downstream compatibility | Keep page-03 execution and page-07 rule behavior working against the canonical output. | P0 |
+
+## Requirements
+| ID | Requirement | Type | Acceptance Criteria |
+|----|-------------|------|---------------------|
+| REQ-1 | Obligation generation remains the first contractual step. | Functional | Activation/bootstrap creates or reuses obligations before attempting initial schedule generation. |
+| REQ-2 | Initial scheduling must be rules-engine-derived rather than directly inserted as bootstrap truth. | Functional | No production/bootstrap path directly inserts first `collectionPlanEntries` while bypassing schedule-rule semantics. |
+| REQ-3 | Seed/bootstrap flows may still exist, but they must call the same canonical scheduling logic as activation. | Functional | `seedPaymentData` and related orchestration use a shared scheduling contract rather than bespoke insertion code. |
+| REQ-4 | There must be no dual-source truth for initial plan creation after this change. | Functional | One shared path owns initial plan creation semantics across bootstrap and activation-style flows. |
+| REQ-5 | Activation must preserve the mortgage lifecycle boundary: mortgage truth remains obligation-driven, not collection-plan-driven. | Functional | Mortgage activation/lifecycle does not depend on plan-entry insertion to define contractual truth. |
+| REQ-6 | Collection rules must be present before initial scheduling runs. | Functional | Bootstrap/activation ensures the default scheduling rule exists before using canonical scheduling. |
+| REQ-7 | Initial scheduling reruns must be idempotent. | Functional | Re-running bootstrap or activation does not create duplicate initial `collectionPlanEntries`. |
+| REQ-8 | Canonical initial plan entries must remain consumable by the page-03 execution spine and compatible with page-07 rules. | Functional | Downstream execution and retry/late-fee flows require no special-case handling for newly generated initial entries. |
+| REQ-9 | Verification must compare the final repo against the live Notion spec and linked implementation plan. | Functional | A final gap analysis records coverage and any residual drift. |
+
+## Use Cases
+### UC-1: Bootstrap or activation creates the first collection strategy through the canonical handoff
+- **Actor**: Seed/bootstrap or future activation orchestration
+- **Precondition**: A mortgage exists and requires obligations plus initial schedule generation
+- **Flow**:
+  1. Mortgage terms are used to generate or reuse obligations
+  2. Default collection rules are present
+  3. Canonical scheduling logic evaluates the schedule rule for that mortgage
+  4. Initial `collectionPlanEntries` are created through that shared path
+- **Postcondition**: Initial scheduling is rule-driven and no bootstrap-only insertion path defines truth
+- **E2E Test**: Backend integration coverage; browser e2e not required
+
+### UC-2: Re-running bootstrap or repair does not duplicate initial entries
+- **Actor**: Admin/bootstrap rerun or repair workflow
+- **Precondition**: Obligations and initial plan entries may already exist
+- **Flow**:
+  1. The orchestration runs again for the same mortgage
+  2. Existing obligations are reused
+  3. Existing initial plan coverage is detected through canonical idempotency checks
+  4. No duplicate initial plan entries are created
+- **Postcondition**: The shared activation/bootstrap path is rerun-safe
+- **E2E Test**: Backend integration coverage; browser e2e not required
+
+### UC-3: Downstream execution and rule follow-ons continue to work against canonical output
+- **Actor**: Collection-plan runner and follow-on rules
+- **Precondition**: Initial plan entries were produced through the canonical activation/bootstrap handoff
+- **Flow**:
+  1. Page-03 execution discovers due `planned` entries
+  2. Canonical execution proceeds without bootstrap-specific handling
+  3. Retry and late-fee rules continue to operate from the same plan/obligation state model
+- **Postcondition**: Initial scheduling convergence does not break downstream execution or lifecycle boundaries
+- **E2E Test**: Backend integration coverage; browser e2e not required
+
+## Schemas
+- `obligations`
+  - remain the first contractual truth created from mortgage terms
+  - existing generated states and due-date windows remain authoritative
+- `collectionRules`
+  - `schedule_rule` remains the intended initial scheduling policy
+  - default rules must exist before canonical scheduling runs
+- `collectionPlanEntries`
+  - initial entries remain `planned`
+  - `source: "default_schedule"` and `ruleId` continue to record schedule-rule provenance
+- bootstrap outputs
+  - `seedPaymentData` and `seedAll` remain orchestration helpers, not alternate architectural truth
+
+## Out of Scope
+- New frontend routes, admin UX, or browser automation
+- Reworking page-03 execution semantics beyond ensuring it consumes canonical initial entries
+- Reworking retry or late-fee business semantics beyond preserving their compatibility with canonical initial schedule generation
+- Broad schema or terminology cleanup deferred to later pages
+- Full mortgage activation product flow if the repo still relies primarily on bootstrap/demo orchestration today

--- a/specs/06-correct-activation-and-initial-scheduling-handoff/design.md
+++ b/specs/06-correct-activation-and-initial-scheduling-handoff/design.md
@@ -1,0 +1,129 @@
+# 06. Correct Activation and Initial Scheduling Handoff — Design
+
+> Derived from: https://www.notion.so/337fc1b4402481738c5ecc14f4e08da9
+
+## Types & Interfaces
+
+### Existing orchestration split
+The repo already contains the important pieces, but they are not wired through a
+single handoff:
+- `convex/payments/obligations/generate.ts` and `generateImpl.ts` own
+  obligation generation from mortgage terms
+- `convex/payments/collectionPlan/rules/scheduleRule.ts` owns the intended
+  schedule-rule semantics for initial plan creation
+- `convex/seed/seedPaymentData.ts` still bypasses that rule logic and inserts
+  initial `collectionPlanEntries` directly
+- `convex/seed/seedAll.ts` calls `seedPaymentData`, but does not currently seed
+  default collection rules before doing so
+
+### Shared scheduling orchestration seam
+Because `scheduleRuleHandler` runs under an `ActionCtx` and `seedPaymentDataImpl`
+is currently a mutation implementation, page 06 should not try to make the
+mutation call `evaluateRules` directly. The repo-grounded shape is:
+- extract a shared initial-scheduling implementation module that encapsulates
+  schedule-rule semantics
+- let `scheduleRuleHandler` delegate to that shared implementation
+- let bootstrap/activation orchestration call that same shared implementation
+  through context-appropriate wrappers
+
+This keeps the semantics rule-driven without forcing bootstrap to bypass Convex
+context constraints.
+
+## Database Schema
+
+### No schema changes expected
+Page 06 is orchestration convergence work. Existing tables are sufficient:
+- `obligations`
+- `collectionRules`
+- `collectionPlanEntries`
+
+### Existing provenance fields should be reused
+- `collectionPlanEntries.source` should continue to use `"default_schedule"` for
+  initial schedule-rule-derived entries
+- `collectionPlanEntries.ruleId` should remain populated when the schedule rule
+  is the source of the entry
+- idempotency should continue to rely on existing obligation coverage checks
+  rather than introducing new tables or flags
+
+## Architecture
+
+### Data Flow
+bootstrap or activation orchestration
+-> ensure default collection rules exist
+-> generate or reuse obligations from mortgage terms
+-> shared initial scheduling orchestration applies schedule-rule semantics
+-> `collectionPlanEntries` are created through canonical rule-owned logic
+-> page-03 execution consumes due `planned` entries
+-> page-07 retry and late-fee rules continue to operate on the same model
+
+### Component Structure
+Likely code surface:
+- `convex/seed/seedPaymentData.ts`
+- `convex/seed/seedAll.ts`
+- `convex/payments/collectionPlan/seed.ts`
+- `convex/payments/collectionPlan/engine.ts`
+- `convex/payments/collectionPlan/rules/scheduleRule.ts`
+- `convex/payments/collectionPlan/mutations.ts`
+- `convex/obligations/queries.ts`
+- `convex/payments/obligations/generate.ts`
+- new shared orchestration/helper module for initial schedule generation
+- focused backend tests in payments/collectionPlan plus seed integration tests
+
+### API Surface
+
+#### Reads (Queries/GET)
+| Function | Args | Returns | Description |
+|----------|------|---------|-------------|
+| `getUpcomingInWindow` | `mortgageId?`, `dueBefore` | obligations | Existing rule input for upcoming obligations due in the scheduling window. |
+| `getPlannedEntriesForObligations` | `obligationIds[]` | obligation coverage map | Existing idempotency lookup for initial plan coverage. |
+| `getEnabledRules` | `trigger` | `collectionRules[]` | Existing rule lookup; page 06 may add wrapper usage rather than change the contract. |
+
+#### Writes (Mutations/POST)
+| Function | Args | Returns | Description |
+|----------|------|---------|-------------|
+| `generateObligations` / `generateObligationsImpl` | mortgage-derived inputs | obligation IDs | Existing obligation-first generation path that must remain canonical. |
+| `createEntry` | plan-entry fields | plan entry ID | Existing plan-entry creation primitive reused by the shared scheduling seam. |
+| `seedPaymentData` | `mortgageId` | bootstrap summary | Existing bootstrap entrypoint to be refactored onto canonical scheduling. |
+| `seedCollectionRules` | none | created/skipped counts | Existing default-rule seeding path that bootstrap/activation prerequisites should use. |
+
+#### Side Effects (Actions/Jobs)
+| Function | Args | Returns | Description |
+|----------|------|---------|-------------|
+| `evaluateRules` | trigger + mortgage/event scope | void | Existing rules-engine entrypoint; page 06 should keep it canonical while moving schedule semantics into a shared implementation seam. |
+| shared initial scheduling wrapper | mortgage scope + schedule parameters | created/reused summary | New or extracted orchestration seam used by both schedule-rule evaluation and bootstrap/activation. |
+
+### Routing
+No route changes are planned. This is backend orchestration and test work only.
+
+## Implementation Decisions
+
+### Extract shared schedule semantics instead of duplicating logic
+The Notion plan explicitly prefers a shared scheduling orchestration seam over
+letting bootstrap call rule internals directly. The repo also requires this,
+because a mutation cannot simply invoke the existing internal action as an
+implementation detail.
+
+### Keep obligation generation canonical and separate
+`generateObligationsImpl` already expresses the contractual truth of mortgage
+terms producing obligations. Page 06 should preserve that separation and avoid
+making collection-plan generation the driver of mortgage truth.
+
+### Bootstrap should ensure rule prerequisites, not invent plan entries
+`seedAll` and `seedPaymentData` should be responsible for:
+- making sure default rules exist
+- invoking canonical obligation generation
+- invoking canonical initial scheduling
+
+They should not remain special-case architectural exceptions.
+
+### Idempotency should remain obligation-coverage based
+The existing schedule-rule path already checks for planned-entry coverage per
+obligation. Page 06 should reuse that approach instead of inventing new
+idempotency metadata.
+
+### Browser e2e is not the right verification surface here
+This page changes backend lifecycle orchestration and bootstrap behavior. The
+highest-signal verification should come from unit and integration tests around:
+- shared scheduling semantics
+- bootstrap reruns
+- downstream page-03/page-07 compatibility

--- a/specs/06-correct-activation-and-initial-scheduling-handoff/gap-analysis.md
+++ b/specs/06-correct-activation-and-initial-scheduling-handoff/gap-analysis.md
@@ -1,0 +1,58 @@
+# Gap Analysis — 06. Correct Activation and Initial Scheduling Handoff
+
+## Verification Date
+- Re-fetched against the live Notion execution page and linked implementation plan on April 4, 2026.
+
+## Spec Verdict
+- Implemented.
+
+## What Changed
+- Added one shared canonical default-rule seeding seam in `convex/payments/collectionPlan/defaultRules.ts`.
+- Added one shared canonical initial-scheduling seam in `convex/payments/collectionPlan/initialScheduling.ts`.
+- Refactored `scheduleRule` handling to delegate to the shared internal scheduling mutation instead of carrying a private scheduling implementation.
+- Refactored `seedPaymentData` to generate or reuse obligations first, ensure collection rules exist, then invoke canonical initial scheduling instead of directly inserting initial `collectionPlanEntries`.
+- Preserved idempotent bootstrap behavior by treating non-cancelled plan entries as existing coverage for upcoming obligations.
+
+## Acceptance Criteria Check
+- `activation produces obligations through the canonical path`
+  - Satisfied. `seedPaymentData` still treats obligations as the first contractual step and only schedules after obligation generation or reuse completes.
+- `initial scheduling is rules-engine-derived rather than separately seeded as truth`
+  - Satisfied. `scheduleRule` now delegates to the shared internal scheduling mutation, and bootstrap uses the same scheduling implementation.
+- `activation and scheduling no longer have dual-source truth`
+  - Satisfied for the implemented bootstrap/activation handoff seam. Initial plan creation now flows through one shared scheduling module rather than a direct bootstrap-only insert path.
+
+## Requirement Coverage
+- REQ-1 obligations-first contractual truth
+  - Covered by the refactored `seedPaymentData` flow and integration tests.
+- REQ-2 initial scheduling must be rule-driven
+  - Covered by `scheduleRule` delegation and the shared `scheduleInitialEntriesImpl`.
+- REQ-3 bootstrap remains a prerequisite/orchestration layer, not a separate truth path
+  - Covered by `seedCollectionRulesImpl` plus bootstrap delegation into canonical scheduling.
+- REQ-4 no dual-source truth for initial plan creation
+  - Covered by removing direct initial plan-entry insertion from `seedPaymentData`.
+- REQ-5 no UI work required
+  - Covered. No route or component changes were needed.
+- REQ-6 collection rules are present before scheduling
+  - Covered by bootstrap ensuring default rules before initial scheduling runs.
+- REQ-7 rerun safety
+  - Covered by obligation coverage checks over non-cancelled plan entries and rerun tests.
+- REQ-8 downstream compatibility with page-03/page-07 behavior
+  - Covered by focused downstream regression tests for the existing execution spine and rules tests.
+- REQ-9 testing/verification
+  - Covered by focused backend tests plus final repository verification gates.
+
+## Residual Notes
+- This page corrects the activation/bootstrap handoff seam. It does not fully productize a separate mortgage activation UX or workflow.
+- Bootstrap remains a helper/orchestration path for local/demo data, but it no longer acts as an architectural exception for initial plan creation.
+- GitNexus did not resolve every handler export cleanly in the current index, so final confidence relies on focused regression tests plus repository-wide change detection rather than full symbol-level blast-radius reporting for every touched handler.
+
+## Test Evidence
+- Focused backend regression slice passed:
+  - `bun run test convex/payments/__tests__/rules.test.ts src/test/convex/seed/seedPaymentData.test.ts src/test/convex/seed/seedAll.test.ts convex/payments/collectionPlan/__tests__/execution.test.ts convex/payments/collectionPlan/__tests__/runner.test.ts`
+- Repository verification gates passed:
+  - `bun check`
+  - `bun typecheck`
+  - `bunx convex codegen`
+
+## Final Assessment
+- No blocking page-06 gaps remain.

--- a/specs/06-correct-activation-and-initial-scheduling-handoff/tasks.md
+++ b/specs/06-correct-activation-and-initial-scheduling-handoff/tasks.md
@@ -1,0 +1,36 @@
+# 06. Correct Activation and Initial Scheduling Handoff — Tasks
+
+> Spec: https://www.notion.so/337fc1b4402481738c5ecc14f4e08da9
+> Generated: 2026-04-04
+>
+> If every task below is checked, the spec is fully implemented, tested, and verified.
+
+## Phase 1: Schema & Data Layer
+- [x] T-001: Capture local PRD, design, and task artifacts for the page-06 activation/scheduling handoff pass. (F-1, F-2, F-3, F-4, F-5, F-6)
+- [x] T-002: Inventory the current bootstrap, obligation-generation, rules-engine, and rule-seeding call sites that participate in initial schedule creation. (REQ-1, REQ-2, REQ-3, REQ-4, REQ-6, F-1, F-2, F-3)
+- [x] T-003: Lock the shared orchestration design for canonical initial scheduling without introducing new schema. (REQ-2, REQ-3, REQ-4, REQ-7, F-2, F-4, F-5)
+
+## Phase 2: Backend Functions
+- [x] T-010: Run impact analysis on the shared scheduling, bootstrap, and obligation-generation surfaces before editing them. (REQ-2, REQ-3, REQ-4, REQ-8, F-2, F-3, F-6)
+- [x] T-011: Extract or introduce a shared initial-scheduling orchestration seam that embodies schedule-rule semantics and can be called from both rule evaluation and bootstrap/activation flows. (UC-1, REQ-2, REQ-3, REQ-4, F-2, F-4)
+- [x] T-012: Refactor `scheduleRule` handling to delegate to the shared canonical initial-scheduling seam instead of owning a private implementation path. (UC-1, REQ-2, REQ-4, F-2, F-4)
+- [x] T-013: Refactor `seedPaymentData` so it generates or reuses obligations first and then invokes canonical initial scheduling instead of directly inserting initial `collectionPlanEntries`. (UC-1, REQ-1, REQ-2, REQ-3, REQ-4, REQ-5, F-1, F-2, F-3, F-4)
+- [x] T-014: Ensure bootstrap/activation prerequisites seed or verify default collection rules before canonical initial scheduling runs. (UC-1, REQ-3, REQ-6, F-2, F-3)
+- [x] T-015: Preserve rerun safety so bootstrap, repair, or activation-style re-entry does not duplicate initial plan entries. (UC-2, REQ-4, REQ-7, F-5)
+- [x] T-016: Verify that page-03 execution and page-07 follow-on rules consume canonical initial entries without special-case handling. (UC-3, REQ-8, F-6)
+
+## Phase 3: Frontend — Routes & Components
+- [x] T-020: Verify that page 06 remains backend orchestration work with no route or UI changes required. (REQ-5, F-1, F-3)
+
+## Phase 4: E2E Tests
+- [x] T-030: Assess whether browser e2e adds value for this backend activation/bootstrap orchestration change. (REQ-9, F-6)
+- [x] T-031: Add or extend backend tests for the shared initial-scheduling seam and schedule-rule delegation. (UC-1, REQ-2, REQ-4, REQ-7, F-2, F-4, F-5)
+- [x] T-032: Add integration coverage proving bootstrap/activation-style orchestration creates obligations first and initial plan entries second through the canonical path. (UC-1, REQ-1, REQ-2, REQ-3, REQ-5, REQ-6, F-1, F-2, F-3, F-4)
+- [x] T-033: Add rerun/idempotency coverage proving repeated bootstrap or repair execution does not duplicate initial entries. (UC-2, REQ-4, REQ-7, F-5)
+- [x] T-034: Add downstream compatibility coverage for page-03 execution and page-07 rule behavior against canonical initial entries. (UC-3, REQ-8, F-6)
+
+## Phase 5: Verification
+- [x] T-040: Re-fetch the Notion spec and linked implementation plan to verify final code still matches the current page-06 contract. (F-1, F-2, F-3, F-4, F-5, F-6)
+- [x] T-041: Create `gap-analysis.md`. (REQ-1, REQ-2, REQ-3, REQ-4, REQ-5, REQ-6, REQ-7, REQ-8, REQ-9)
+- [x] T-042: Present the gap analysis to the user. (REQ-1, REQ-2, REQ-3, REQ-4, REQ-5, REQ-6, REQ-7, REQ-8, REQ-9)
+- [x] T-043: Final `bun check`, `bun typecheck`, and `bunx convex codegen` pass. (REQ-1, REQ-2, REQ-3, REQ-4, REQ-5, REQ-6, REQ-7, REQ-8, REQ-9)

--- a/specs/07-expand-collection-rule-model-and-complete-retry-late-fee-behaviors/PRD.md
+++ b/specs/07-expand-collection-rule-model-and-complete-retry-late-fee-behaviors/PRD.md
@@ -1,0 +1,92 @@
+# 07. Expand Collection Rule Model and Complete Retry/Late-Fee Behaviors
+
+> **Canonical Source of Truth**: https://www.notion.so/337fc1b440248176af0ec126b8aac764
+>
+> This PRD is a compressed working context snapshot extracted from the Notion spec.
+> Always defer to the Notion page for the latest requirements. This file serves as
+> a local reference to reduce Notion API calls during implementation.
+
+## Overview
+Page 07 upgrades `collectionRules` from a thin generic record into a typed, admin-operable strategy model while preserving the working schedule, retry, and late-fee behaviors already present in the repo. The immediate goal is not new collection behavior; it is to make the rule contract explicit, deterministic, and extensible so pages 08, 09, 10, and 12 can build on it without another architectural rewrite.
+
+## Features
+| ID | Feature | Description | Priority |
+|----|---------|-------------|----------|
+| F-1 | Typed Rule Contract | Replace implicit `name`/`parameters` interpretation with explicit rule kinds, metadata, and strongly separated config. | P0 |
+| F-2 | Behavior Preservation | Preserve existing schedule, retry, and late-fee semantics while migrating representation. | P0 |
+| F-3 | Deterministic Rule Evaluation | Keep enablement, priority, trigger matching, and ordering deterministic and auditable. | P0 |
+| F-4 | Future Extension Readiness | Make the rule model ready for balance pre-check, reschedule, workout, and admin operations without implementing those later pages here. | P1 |
+
+## Requirements
+| ID | Requirement | Type | Acceptance Criteria |
+|----|-------------|------|---------------------|
+| REQ-1 | Existing schedule, retry, and late-fee behavior must continue to work. | Functional | Current schedule, retry, and late-fee tests still pass after the model refactor. |
+| REQ-2 | Rule type must be explicit and machine-verifiable. | Functional | Engine dispatch no longer depends on freeform `name`; typed kinds/config are validated. |
+| REQ-3 | Rule configuration must be understandable and operable by admins. | Functional | Shared rule envelope includes admin-readable metadata rather than only opaque parameter blobs. |
+| REQ-4 | The model must support future balance pre-check, reschedule, and workout capabilities. | Functional | Schema and engine admit future rule kinds without introducing another generic escape hatch. |
+| REQ-5 | Rule evaluation order and enablement must remain deterministic. | Functional | Ordering remains stable under typed rule queries and evaluation helpers. |
+| REQ-6 | Seed/default rule creation and any migration path must be idempotent. | Functional | Default typed rules can be seeded repeatedly without duplication or semantic drift. |
+| REQ-7 | The rule system must remain strategy-layer configuration, not debt truth. | Non-functional | Contractual truth stays in obligations/plan entries/attempts; rules only decide strategy outcomes. |
+| REQ-8 | Late-fee behavior must stay compatible with the existing mortgage fee configuration source. | Functional | Late-fee rule typing does not break fee lookup via `mortgageFees`. |
+| REQ-9 | Page 07 should not require admin UI or route work ahead of page 12. | Non-functional | No new route/component work is required unless code inspection proves otherwise. |
+
+## Use Cases
+### UC-1: Schedule Rule Creates Initial Entries Through Typed Configuration
+- **Actor**: System scheduler / activation orchestration
+- **Precondition**: Active schedule rule exists and matching obligations are in scope
+- **Flow**:
+  1. Engine loads active rules for the schedule trigger.
+  2. Engine dispatches by explicit rule kind.
+  3. Schedule rule reads typed config and creates initial collection plan entries.
+- **Postcondition**: Planned entries are created with the same behavior as today, but through a typed rule contract.
+- **E2E Test**: Backend integration coverage during implementation
+
+### UC-2: Retry Rule Schedules Deterministic Replacement Entries
+- **Actor**: System on collection failure
+- **Precondition**: A collection attempt fails and emits retry-eligible context
+- **Flow**:
+  1. Engine evaluates active event rules.
+  2. Retry rule matches `COLLECTION_FAILED`.
+  3. Retry rule applies typed backoff configuration and lineage checks.
+  4. A retry plan entry is created exactly once when allowed.
+- **Postcondition**: Retry scheduling remains idempotent, deterministic, and lineage-preserving.
+- **E2E Test**: Backend integration coverage during implementation
+
+### UC-3: Late-Fee Rule Creates Fee Obligations Through Typed Rule Semantics
+- **Actor**: System on overdue obligation event
+- **Precondition**: A late-fee rule is active and applicable mortgage fee configuration exists
+- **Flow**:
+  1. Engine evaluates active event rules.
+  2. Late-fee rule matches `OBLIGATION_OVERDUE`.
+  3. Rule reads typed config and resolves the existing mortgage fee source of truth.
+  4. A late-fee obligation is created only when no duplicate exists.
+- **Postcondition**: Late-fee obligations are still created correctly, but the rule contract is explicit and admin-readable.
+- **E2E Test**: Backend integration coverage during implementation
+
+### UC-4: Future Rule Kinds Can Be Added Without Reopening Generic Model Drift
+- **Actor**: Future engineering/admin extension work
+- **Precondition**: Typed rule contract is in place
+- **Flow**:
+  1. A new rule kind is introduced in the typed schema.
+  2. Engine dispatch extends through the typed registry.
+  3. Shared metadata and evaluation helpers continue to work.
+- **Postcondition**: Future pages extend the rule system rather than bypassing it.
+- **E2E Test**: Schema/contract coverage during implementation
+
+## Schemas
+- `collectionRules`
+  - Current repo shape: `name`, `trigger`, `condition`, `action`, `parameters`, `priority`, `enabled`, timestamps
+  - Target page-07 shape: typed rule envelope plus rule-specific config and deterministic metadata
+- `collectionPlanEntries`
+  - Existing `source` and `ruleId` linkage remain part of the behavioral contract
+- `obligations`
+  - Late-fee creation remains downstream of the rule engine and compatible with current obligation creation logic
+- `mortgageFees`
+  - Existing late-fee fee configuration remains the source of fee economics unless code changes prove that page 07 must absorb it
+
+## Out of Scope
+- Borrower balance pre-check behavior itself
+- Borrower reschedule behavior itself
+- Workout plan behavior itself
+- Admin UI/routes for managing rules
+- Renaming every legacy literal such as `source: "retry_rule"` unless implementation necessity forces it

--- a/specs/07-expand-collection-rule-model-and-complete-retry-late-fee-behaviors/design.md
+++ b/specs/07-expand-collection-rule-model-and-complete-retry-late-fee-behaviors/design.md
@@ -1,0 +1,140 @@
+# 07. Expand Collection Rule Model and Complete Retry/Late-Fee Behaviors — Design
+
+> Derived from: https://www.notion.so/337fc1b440248176af0ec126b8aac764
+
+## Types & Interfaces
+
+### Proposed Rule Envelope
+```ts
+type CollectionRuleKind =
+	| "schedule"
+	| "retry"
+	| "late_fee"
+	| "balance_pre_check"
+	| "reschedule_policy"
+	| "workout_policy";
+
+type CollectionRuleStatus = "draft" | "active" | "disabled" | "archived";
+
+type CollectionRuleScope =
+	| { scopeType: "global" }
+	| { scopeType: "mortgage"; mortgageId: Id<"mortgages"> };
+
+type ScheduleRuleConfig = {
+	kind: "schedule";
+	delayDays: number;
+};
+
+type RetryRuleConfig = {
+	kind: "retry";
+	maxRetries: number;
+	backoffBaseDays: number;
+};
+
+type LateFeeRuleConfig = {
+	kind: "late_fee";
+	feeCode: "late_fee";
+	feeSurface: "borrower_charge";
+};
+
+type FutureRuleConfig =
+	| { kind: "balance_pre_check"; mode: "placeholder" }
+	| { kind: "reschedule_policy"; mode: "placeholder" }
+	| { kind: "workout_policy"; mode: "placeholder" };
+
+type CollectionRuleConfig =
+	| ScheduleRuleConfig
+	| RetryRuleConfig
+	| LateFeeRuleConfig
+	| FutureRuleConfig;
+
+type CollectionRuleRecord = {
+	kind: CollectionRuleKind;
+	trigger: "schedule" | "event";
+	status: CollectionRuleStatus;
+	code: string;
+	displayName: string;
+	description?: string;
+	scope: CollectionRuleScope;
+	priority: number;
+	version: number;
+	effectiveFrom?: number;
+	effectiveTo?: number;
+	config: CollectionRuleConfig;
+	createdAt: number;
+	updatedAt: number;
+	createdByActorId?: string;
+	updatedByActorId?: string;
+};
+```
+
+### Current-to-Target Mapping
+- `name` becomes a compatibility slug or seed code, not the dispatch key
+- `enabled` folds into typed `status`
+- `parameters` is replaced by a typed `config` union
+- `action` and freeform `condition` should not remain the primary engine contract
+
+## Database Schema
+
+### `collectionRules`
+Current repo shape in `convex/schema.ts` is too generic:
+- `name`
+- `trigger`
+- `condition`
+- `action`
+- `parameters`
+- `priority`
+- `enabled`
+
+Planned page-07 direction:
+- add typed fields for `kind`, `status`, `code`, `displayName`, `scope`, `version`, `effectiveFrom`, `effectiveTo`
+- replace freeform `parameters` with a typed `config` validator
+- keep migration/compatibility only as long as needed for seeds/tests and current dev data
+- add indexes that support deterministic active-rule lookup by trigger and ordering metadata
+
+Potential index direction:
+- `by_trigger_status_priority` or equivalent active-rule lookup index
+- optional scope-aware indexes if mortgage-scoped rules are introduced in the same pass
+
+## Architecture
+
+### Data Flow
+Trigger input -> `evaluateRules` -> active typed rule query -> rule matching/filter helpers -> typed handler registry -> schedule/retry/late-fee side effects
+
+### Component Structure
+- No route/component work is expected in page 07
+- Admin-readable metadata is added to the backend model now so page 12 can expose it later
+
+### API Surface
+
+#### Reads (Queries/GET)
+| Function | Args | Returns | Description |
+|----------|------|---------|-------------|
+| `getEnabledRules` | trigger + possibly scope/asOf | typed active rules | Canonical active-rule selection with deterministic ordering |
+| `getRetryEntryForPlanEntry` | `planEntryId` | existing retry entry or null | Retry idempotency guard |
+
+#### Writes (Mutations/POST)
+| Function | Args | Returns | Description |
+|----------|------|---------|-------------|
+| `seedCollectionRules` | none | created/skipped summary | Seeds canonical typed defaults idempotently |
+| `createEntry` / `scheduleInitialEntries` | existing args | existing results | Downstream write seams preserved while rules become typed |
+| obligation creation mutation | existing args | obligation id | Late-fee behavior remains downstream of typed rule dispatch |
+
+#### Side Effects (Actions/Jobs)
+| Function | Args | Returns | Description |
+|----------|------|---------|-------------|
+| `evaluateRules` | trigger + context | void | Loads active typed rules and dispatches by explicit kind |
+| `scheduleRuleHandler.evaluate` | rule + mortgage context | void | Creates initial plan entries from typed schedule config |
+| `retryRuleHandler.evaluate` | rule + failure payload | void | Creates retry entries from typed retry config |
+| `lateFeeRuleHandler.evaluate` | rule + overdue payload | void | Creates late-fee obligations using typed rule config plus mortgage fee config |
+
+### Routing
+- None expected for page 07
+
+## Implementation Decisions
+- Preserve current business behavior even if the internal rule representation changes aggressively.
+- Keep late-fee economic configuration in `mortgageFees` for now. Page 07 should type the collection-rule strategy boundary, not duplicate the fee product model.
+- Prefer one typed rule contract used by schema, seeds, handlers, tests, and future admin surfaces.
+- Use engine dispatch keyed by explicit `kind`, not by `name`.
+- Keep page-07 scope backend-only unless code inspection proves page-12-like admin endpoints are required earlier.
+- GitNexus did not resolve the handler exports cleanly in the current index, so implementation should rely on focused diff review plus regression tests around the engine, schema, seed helpers, and rule handlers.

--- a/specs/07-expand-collection-rule-model-and-complete-retry-late-fee-behaviors/gap-analysis.md
+++ b/specs/07-expand-collection-rule-model-and-complete-retry-late-fee-behaviors/gap-analysis.md
@@ -1,0 +1,73 @@
+# Gap Analysis — 07. Expand Collection Rule Model and Complete Retry/Late-Fee Behaviors
+
+## Verification Date
+- Re-fetched against the live Notion execution page and linked implementation plan on April 4, 2026.
+
+## Spec Verdict
+- Implemented.
+
+## Coverage Matrix
+
+### Features
+| ID | Status | Evidence |
+| --- | --- | --- |
+| F-1 Typed Rule Contract | Implemented | `convex/payments/collectionPlan/ruleContract.ts`, `convex/schema.ts`, `convex/payments/collectionPlan/defaultRules.ts` |
+| F-2 Behavior Preservation | Implemented | `convex/payments/collectionPlan/rules/scheduleRule.ts`, `convex/payments/collectionPlan/rules/retryRule.ts`, `convex/payments/collectionPlan/rules/lateFeeRule.ts`, `convex/payments/__tests__/rules.test.ts` |
+| F-3 Deterministic Rule Evaluation | Implemented | `convex/payments/collectionPlan/queries.ts`, `convex/payments/collectionPlan/engine.ts`, `convex/payments/collectionPlan/__tests__/engine.test.ts` |
+| F-4 Future Extension Readiness | Implemented | placeholder kinds/config in `convex/payments/collectionPlan/ruleContract.ts` and typed schema support in `convex/schema.ts` |
+
+### Requirements
+| ID | Status | Evidence |
+| --- | --- | --- |
+| REQ-1 Existing schedule, retry, and late-fee behavior continues to work | Implemented | rule-handler regressions in `convex/payments/__tests__/rules.test.ts`; downstream flow coverage in `src/test/convex/payments/crossEntity.test.ts` and `src/test/convex/payments/endToEnd.test.ts` |
+| REQ-2 Rule type is explicit and machine-verifiable | Implemented | discriminated typed config and kind helpers in `convex/payments/collectionPlan/ruleContract.ts`; engine dispatch now keys off `kind` in `convex/payments/collectionPlan/engine.ts` |
+| REQ-3 Rule configuration is understandable and operable by admins | Implemented | shared metadata fields `code`, `displayName`, `description`, `status`, `scope`, `version`, `effectiveFrom`, `effectiveTo` in `convex/schema.ts` and default seeds in `convex/payments/collectionPlan/defaultRules.ts` |
+| REQ-4 Future balance pre-check, reschedule, and workout capabilities are supported | Implemented | placeholder rule kinds/config validators and registry readiness in `convex/payments/collectionPlan/ruleContract.ts` and `convex/payments/collectionPlan/engine.ts` |
+| REQ-5 Rule evaluation order and enablement remain deterministic | Implemented | active/effective/scope matching plus stable sort in `convex/payments/collectionPlan/queries.ts` and `convex/payments/collectionPlan/ruleContract.ts`; regression in `convex/payments/collectionPlan/__tests__/engine.test.ts` |
+| REQ-6 Seed/default rule creation and migration stay idempotent | Implemented | legacy-aware backfill and typed default seeding in `convex/payments/collectionPlan/defaultRules.ts`; seed regressions in `src/test/convex/seed/seedPaymentData.test.ts` and `convex/payments/collectionPlan/__tests__/engine.test.ts` |
+| REQ-7 Rules remain strategy-layer configuration, not debt truth | Implemented | no change to plan entry, attempt, or obligation truth paths; rules only select scheduling/retry/late-fee actions through existing seams |
+| REQ-8 Late-fee behavior remains compatible with `mortgageFees` | Implemented | `convex/payments/collectionPlan/rules/lateFeeRule.ts` still resolves fee economics via `fees/queries:getActiveMortgageFee`; covered in `convex/payments/__tests__/rules.test.ts` |
+| REQ-9 No page-12 admin UI/route work is required here | Implemented | backend-only delivery; no route/component changes were needed |
+
+### Use Cases
+| ID | Status | Evidence |
+| --- | --- | --- |
+| UC-1 Schedule Rule Creates Initial Entries Through Typed Configuration | Implemented | `convex/payments/collectionPlan/rules/scheduleRule.ts`, `convex/seed/seedPaymentData.ts`, `convex/payments/__tests__/rules.test.ts`, `src/test/convex/seed/seedPaymentData.test.ts` |
+| UC-2 Retry Rule Schedules Deterministic Replacement Entries | Implemented | `convex/payments/collectionPlan/rules/retryRule.ts`, `convex/payments/__tests__/rules.test.ts`, `src/test/convex/payments/crossEntity.test.ts`, `src/test/convex/payments/endToEnd.test.ts` |
+| UC-3 Late-Fee Rule Creates Fee Obligations Through Typed Rule Semantics | Implemented | `convex/payments/collectionPlan/rules/lateFeeRule.ts`, `convex/payments/__tests__/rules.test.ts`, `src/test/convex/payments/crossEntity.test.ts` |
+| UC-4 Future Rule Kinds Can Be Added Without Reopening Generic Model Drift | Implemented | future placeholder kinds/config plus deterministic active-rule matching coverage in `convex/payments/collectionPlan/ruleContract.ts` and `convex/payments/collectionPlan/__tests__/engine.test.ts` |
+
+## What Changed
+- Added one canonical typed collection-rule contract in `convex/payments/collectionPlan/ruleContract.ts`.
+- Expanded `collectionRules` in `convex/schema.ts` with typed metadata, scope, status, config, and effective-window fields while keeping legacy fields for compatibility.
+- Reworked default rule seeding in `convex/payments/collectionPlan/defaultRules.ts` to backfill legacy rows, preserve existing behavior, and emit typed defaults idempotently.
+- Refactored active-rule selection in `convex/payments/collectionPlan/queries.ts` so canonical enablement comes from typed status/effective/scope logic rather than the legacy `enabled` bit.
+- Refactored `convex/payments/collectionPlan/engine.ts` to dispatch handlers by explicit rule kind instead of `rule.name`.
+- Migrated schedule, retry, and late-fee handlers onto typed rule config while preserving their existing downstream side effects.
+- Moved shared test fixtures onto the canonical seed path in `src/test/convex/payments/helpers.ts`.
+
+## Spec Changes Since Extraction
+- No material changes were found between the local PRD/design snapshot and the live Notion pages re-fetched on April 4, 2026.
+
+## Intentional Scope Boundaries Preserved
+- Browser e2e was intentionally not added. This page is backend model, seed, engine, and regression-test work.
+- No admin UI or route surface was introduced ahead of page 12.
+- Future rule kinds are represented as typed extension points only; balance pre-check, borrower reschedule, and workout behavior remain deferred to later pages.
+
+## Residual Notes
+- `enabled`, `name`, `action`, and `parameters` remain in the schema as compatibility fields for legacy rows and current development data, but the canonical contract is now `kind` + typed `config` + typed metadata.
+- The `collectionRules` table still uses the legacy `by_trigger` index shape. Page 07 keeps active-rule selection correct by querying by trigger and applying canonical typed filtering in memory, which avoids another schema rewrite while the project is still greenfield.
+- GitNexus did not resolve the shared handler exports cleanly in the current index, so final confidence relies on focused regression coverage plus final diff/change review rather than complete symbol-level blast-radius output.
+
+## Test Evidence
+- Focused typed-rule coverage passed:
+  - `bun run test convex/payments/collectionPlan/__tests__/engine.test.ts convex/payments/__tests__/rules.test.ts src/test/convex/seed/seedPaymentData.test.ts`
+- Downstream compatibility coverage passed:
+  - `bun run test convex/payments/collectionPlan/__tests__/execution.test.ts convex/payments/collectionPlan/__tests__/runner.test.ts src/test/convex/seed/seedAll.test.ts src/test/convex/payments/crossEntity.test.ts src/test/convex/payments/endToEnd.test.ts`
+- Final repository verification gates passed:
+  - `bun check`
+  - `bun typecheck`
+  - `bunx convex codegen`
+
+## Final Assessment
+- No blocking page-07 gaps remain.

--- a/specs/07-expand-collection-rule-model-and-complete-retry-late-fee-behaviors/tasks.md
+++ b/specs/07-expand-collection-rule-model-and-complete-retry-late-fee-behaviors/tasks.md
@@ -1,0 +1,40 @@
+# 07. Expand Collection Rule Model and Complete Retry/Late-Fee Behaviors — Tasks
+
+> Spec: https://www.notion.so/337fc1b440248176af0ec126b8aac764
+> Generated: 2026-04-04
+>
+> If every task below is checked, the spec is fully implemented, tested, and verified.
+
+## Phase 1: Schema & Data Layer
+- [ ] T-001: Capture local PRD, design, and task artifacts for the page-07 typed collection-rule pass. (F-1, F-2, F-3, F-4)
+- [ ] T-002: Inventory the current `collectionRules` schema, engine dispatch, rule handlers, seed helpers, and downstream dependency surfaces for schedule/retry/late-fee behavior. (REQ-1, REQ-2, REQ-5, REQ-8, F-1, F-2, F-3)
+- [ ] T-003: Lock the typed rule-envelope and typed rule-config design, including future extension placeholders, without over-building page-08/09/10 behavior. (REQ-2, REQ-3, REQ-4, REQ-7, F-1, F-4)
+- [ ] T-004: Run impact analysis on the shared schema, engine, seed, and rule surfaces before editing them. If GitNexus cannot resolve symbols cleanly, record that and compensate with focused regression coverage. (REQ-1, REQ-2, REQ-5, F-1, F-2, F-3)
+- [ ] T-005: Expand the `collectionRules` schema and validators to support explicit rule kind, admin-operable metadata, typed config, deterministic status/effective-window semantics, and future extension points. (REQ-2, REQ-3, REQ-4, REQ-5, F-1, F-3, F-4)
+- [ ] T-006: Update default-rule seeding and test seed helpers to emit the canonical typed rule representation idempotently. (REQ-1, REQ-6, F-1, F-2)
+
+## Phase 2: Backend Functions
+- [ ] T-010: Refactor the collection rule engine to dispatch by explicit rule kind rather than freeform `name`. (UC-1, UC-2, UC-3, REQ-2, REQ-5, F-1, F-3)
+- [ ] T-011: Preserve schedule-rule behavior while migrating it to the typed rule config contract. (UC-1, REQ-1, REQ-2, REQ-5, F-2)
+- [ ] T-012: Preserve retry-rule behavior while migrating it to the typed rule config contract and keeping retry lineage/idempotency intact. (UC-2, REQ-1, REQ-2, REQ-5, REQ-6, F-2, F-3)
+- [ ] T-013: Preserve late-fee-rule behavior while migrating it to the typed rule contract and keeping mortgage-fee resolution authoritative. (UC-3, REQ-1, REQ-2, REQ-8, F-2)
+- [ ] T-014: Add shared rule selection and matching helpers for active status, effective window, scope, and deterministic ordering. (REQ-3, REQ-5, REQ-7, F-1, F-3)
+- [ ] T-015: Ensure the typed rule model and engine registry are ready for future balance pre-check, reschedule, and workout rule kinds without implementing those behaviors here. (UC-4, REQ-4, F-4)
+- [ ] T-016: Verify the page-06 activation handoff and page-03 execution spine still consume schedule/retry/late-fee outcomes without special-case regressions. (REQ-1, REQ-5, REQ-7, F-2, F-3)
+
+## Phase 3: Frontend — Routes & Components
+- [ ] T-020: Verify that page 07 remains backend model/engine work and that admin UI/query surfaces can stay deferred to page 12. (REQ-3, REQ-9, F-4)
+
+## Phase 4: E2E Tests
+- [ ] T-030: Assess whether browser e2e adds value for this backend rule-model refactor; default to backend integration and contract tests unless code inspection proves otherwise. (REQ-1, REQ-9, F-2, F-3)
+- [ ] T-031: Add or extend contract tests for the typed collection-rule schema, default seeds, and engine dispatch. (REQ-2, REQ-3, REQ-5, REQ-6, F-1, F-3)
+- [ ] T-032: Add regression coverage proving schedule-rule behavior is preserved under the typed model. (UC-1, REQ-1, REQ-2, REQ-5, F-2)
+- [ ] T-033: Add regression coverage proving retry-rule behavior remains correct, idempotent, and lineage-preserving under the typed model. (UC-2, REQ-1, REQ-2, REQ-5, REQ-6, F-2, F-3)
+- [ ] T-034: Add regression coverage proving late-fee behavior remains correct and idempotent under the typed model. (UC-3, REQ-1, REQ-2, REQ-8, F-2)
+- [ ] T-035: Add coverage for deterministic enablement, priority, effective-window, and future-extension semantics in the typed rule system. (UC-4, REQ-4, REQ-5, F-3, F-4)
+
+## Phase 5: Verification
+- [ ] T-040: Re-fetch the Notion spec and linked implementation plan to verify final code still matches the current page-07 contract. (F-1, F-2, F-3, F-4)
+- [ ] T-041: Create `gap-analysis.md`. (REQ-1, REQ-2, REQ-3, REQ-4, REQ-5, REQ-6, REQ-7, REQ-8, REQ-9)
+- [ ] T-042: Present the gap analysis to the user. (REQ-1, REQ-2, REQ-3, REQ-4, REQ-5, REQ-6, REQ-7, REQ-8, REQ-9)
+- [ ] T-043: Final `bun check`, `bun typecheck`, and `bunx convex codegen` pass. (REQ-1, REQ-2, REQ-3, REQ-4, REQ-5, REQ-6, REQ-7, REQ-8, REQ-9)

--- a/specs/07-expand-collection-rule-model-and-complete-retry-late-fee-behaviors/tasks.md
+++ b/specs/07-expand-collection-rule-model-and-complete-retry-late-fee-behaviors/tasks.md
@@ -6,35 +6,35 @@
 > If every task below is checked, the spec is fully implemented, tested, and verified.
 
 ## Phase 1: Schema & Data Layer
-- [ ] T-001: Capture local PRD, design, and task artifacts for the page-07 typed collection-rule pass. (F-1, F-2, F-3, F-4)
-- [ ] T-002: Inventory the current `collectionRules` schema, engine dispatch, rule handlers, seed helpers, and downstream dependency surfaces for schedule/retry/late-fee behavior. (REQ-1, REQ-2, REQ-5, REQ-8, F-1, F-2, F-3)
-- [ ] T-003: Lock the typed rule-envelope and typed rule-config design, including future extension placeholders, without over-building page-08/09/10 behavior. (REQ-2, REQ-3, REQ-4, REQ-7, F-1, F-4)
-- [ ] T-004: Run impact analysis on the shared schema, engine, seed, and rule surfaces before editing them. If GitNexus cannot resolve symbols cleanly, record that and compensate with focused regression coverage. (REQ-1, REQ-2, REQ-5, F-1, F-2, F-3)
-- [ ] T-005: Expand the `collectionRules` schema and validators to support explicit rule kind, admin-operable metadata, typed config, deterministic status/effective-window semantics, and future extension points. (REQ-2, REQ-3, REQ-4, REQ-5, F-1, F-3, F-4)
-- [ ] T-006: Update default-rule seeding and test seed helpers to emit the canonical typed rule representation idempotently. (REQ-1, REQ-6, F-1, F-2)
+- [x] T-001: Capture local PRD, design, and task artifacts for the page-07 typed collection-rule pass. (F-1, F-2, F-3, F-4)
+- [x] T-002: Inventory the current `collectionRules` schema, engine dispatch, rule handlers, seed helpers, and downstream dependency surfaces for schedule/retry/late-fee behavior. (REQ-1, REQ-2, REQ-5, REQ-8, F-1, F-2, F-3)
+- [x] T-003: Lock the typed rule-envelope and typed rule-config design, including future extension placeholders, without over-building page-08/09/10 behavior. (REQ-2, REQ-3, REQ-4, REQ-7, F-1, F-4)
+- [x] T-004: Run impact analysis on the shared schema, engine, seed, and rule surfaces before editing them. If GitNexus cannot resolve symbols cleanly, record that and compensate with focused regression coverage. (REQ-1, REQ-2, REQ-5, F-1, F-2, F-3)
+- [x] T-005: Expand the `collectionRules` schema and validators to support explicit rule kind, admin-operable metadata, typed config, deterministic status/effective-window semantics, and future extension points. (REQ-2, REQ-3, REQ-4, REQ-5, F-1, F-3, F-4)
+- [x] T-006: Update default-rule seeding and test seed helpers to emit the canonical typed rule representation idempotently. (REQ-1, REQ-6, F-1, F-2)
 
 ## Phase 2: Backend Functions
-- [ ] T-010: Refactor the collection rule engine to dispatch by explicit rule kind rather than freeform `name`. (UC-1, UC-2, UC-3, REQ-2, REQ-5, F-1, F-3)
-- [ ] T-011: Preserve schedule-rule behavior while migrating it to the typed rule config contract. (UC-1, REQ-1, REQ-2, REQ-5, F-2)
-- [ ] T-012: Preserve retry-rule behavior while migrating it to the typed rule config contract and keeping retry lineage/idempotency intact. (UC-2, REQ-1, REQ-2, REQ-5, REQ-6, F-2, F-3)
-- [ ] T-013: Preserve late-fee-rule behavior while migrating it to the typed rule contract and keeping mortgage-fee resolution authoritative. (UC-3, REQ-1, REQ-2, REQ-8, F-2)
-- [ ] T-014: Add shared rule selection and matching helpers for active status, effective window, scope, and deterministic ordering. (REQ-3, REQ-5, REQ-7, F-1, F-3)
-- [ ] T-015: Ensure the typed rule model and engine registry are ready for future balance pre-check, reschedule, and workout rule kinds without implementing those behaviors here. (UC-4, REQ-4, F-4)
-- [ ] T-016: Verify the page-06 activation handoff and page-03 execution spine still consume schedule/retry/late-fee outcomes without special-case regressions. (REQ-1, REQ-5, REQ-7, F-2, F-3)
+- [x] T-010: Refactor the collection rule engine to dispatch by explicit rule kind rather than freeform `name`. (UC-1, UC-2, UC-3, REQ-2, REQ-5, F-1, F-3)
+- [x] T-011: Preserve schedule-rule behavior while migrating it to the typed rule config contract. (UC-1, REQ-1, REQ-2, REQ-5, F-2)
+- [x] T-012: Preserve retry-rule behavior while migrating it to the typed rule config contract and keeping retry lineage/idempotency intact. (UC-2, REQ-1, REQ-2, REQ-5, REQ-6, F-2, F-3)
+- [x] T-013: Preserve late-fee-rule behavior while migrating it to the typed rule contract and keeping mortgage-fee resolution authoritative. (UC-3, REQ-1, REQ-2, REQ-8, F-2)
+- [x] T-014: Add shared rule selection and matching helpers for active status, effective window, scope, and deterministic ordering. (REQ-3, REQ-5, REQ-7, F-1, F-3)
+- [x] T-015: Ensure the typed rule model and engine registry are ready for future balance pre-check, reschedule, and workout rule kinds without implementing those behaviors here. (UC-4, REQ-4, F-4)
+- [x] T-016: Verify the page-06 activation handoff and page-03 execution spine still consume schedule/retry/late-fee outcomes without special-case regressions. (REQ-1, REQ-5, REQ-7, F-2, F-3)
 
 ## Phase 3: Frontend — Routes & Components
-- [ ] T-020: Verify that page 07 remains backend model/engine work and that admin UI/query surfaces can stay deferred to page 12. (REQ-3, REQ-9, F-4)
+- [x] T-020: Verify that page 07 remains backend model/engine work and that admin UI/query surfaces can stay deferred to page 12. (REQ-3, REQ-9, F-4)
 
 ## Phase 4: E2E Tests
-- [ ] T-030: Assess whether browser e2e adds value for this backend rule-model refactor; default to backend integration and contract tests unless code inspection proves otherwise. (REQ-1, REQ-9, F-2, F-3)
-- [ ] T-031: Add or extend contract tests for the typed collection-rule schema, default seeds, and engine dispatch. (REQ-2, REQ-3, REQ-5, REQ-6, F-1, F-3)
-- [ ] T-032: Add regression coverage proving schedule-rule behavior is preserved under the typed model. (UC-1, REQ-1, REQ-2, REQ-5, F-2)
-- [ ] T-033: Add regression coverage proving retry-rule behavior remains correct, idempotent, and lineage-preserving under the typed model. (UC-2, REQ-1, REQ-2, REQ-5, REQ-6, F-2, F-3)
-- [ ] T-034: Add regression coverage proving late-fee behavior remains correct and idempotent under the typed model. (UC-3, REQ-1, REQ-2, REQ-8, F-2)
-- [ ] T-035: Add coverage for deterministic enablement, priority, effective-window, and future-extension semantics in the typed rule system. (UC-4, REQ-4, REQ-5, F-3, F-4)
+- [x] T-030: Assess whether browser e2e adds value for this backend rule-model refactor; default to backend integration and contract tests unless code inspection proves otherwise. (REQ-1, REQ-9, F-2, F-3)
+- [x] T-031: Add or extend contract tests for the typed collection-rule schema, default seeds, and engine dispatch. (REQ-2, REQ-3, REQ-5, REQ-6, F-1, F-3)
+- [x] T-032: Add regression coverage proving schedule-rule behavior is preserved under the typed model. (UC-1, REQ-1, REQ-2, REQ-5, F-2)
+- [x] T-033: Add regression coverage proving retry-rule behavior remains correct, idempotent, and lineage-preserving under the typed model. (UC-2, REQ-1, REQ-2, REQ-5, REQ-6, F-2, F-3)
+- [x] T-034: Add regression coverage proving late-fee behavior remains correct and idempotent under the typed model. (UC-3, REQ-1, REQ-2, REQ-8, F-2)
+- [x] T-035: Add coverage for deterministic enablement, priority, effective-window, and future-extension semantics in the typed rule system. (UC-4, REQ-4, REQ-5, F-3, F-4)
 
 ## Phase 5: Verification
-- [ ] T-040: Re-fetch the Notion spec and linked implementation plan to verify final code still matches the current page-07 contract. (F-1, F-2, F-3, F-4)
-- [ ] T-041: Create `gap-analysis.md`. (REQ-1, REQ-2, REQ-3, REQ-4, REQ-5, REQ-6, REQ-7, REQ-8, REQ-9)
-- [ ] T-042: Present the gap analysis to the user. (REQ-1, REQ-2, REQ-3, REQ-4, REQ-5, REQ-6, REQ-7, REQ-8, REQ-9)
-- [ ] T-043: Final `bun check`, `bun typecheck`, and `bunx convex codegen` pass. (REQ-1, REQ-2, REQ-3, REQ-4, REQ-5, REQ-6, REQ-7, REQ-8, REQ-9)
+- [x] T-040: Re-fetch the Notion spec and linked implementation plan to verify final code still matches the current page-07 contract. (F-1, F-2, F-3, F-4)
+- [x] T-041: Create `gap-analysis.md`. (REQ-1, REQ-2, REQ-3, REQ-4, REQ-5, REQ-6, REQ-7, REQ-8, REQ-9)
+- [x] T-042: Present the gap analysis to the user. (REQ-1, REQ-2, REQ-3, REQ-4, REQ-5, REQ-6, REQ-7, REQ-8, REQ-9)
+- [x] T-043: Final `bun check`, `bun typecheck`, and `bunx convex codegen` pass. (REQ-1, REQ-2, REQ-3, REQ-4, REQ-5, REQ-6, REQ-7, REQ-8, REQ-9)

--- a/src/test/convex/engine/transition.test.ts
+++ b/src/test/convex/engine/transition.test.ts
@@ -17,6 +17,12 @@ import {
 	seedDefaultGovernedActors,
 } from "../onboarding/helpers";
 import {
+	seedBorrowerProfile,
+	seedCollectionAttempt,
+	seedObligation,
+	seedPlanEntry,
+} from "../payments/helpers";
+import {
 	getAuditJournalForEntity,
 	getEntity,
 } from "./helpers";
@@ -884,6 +890,50 @@ describe("transition engine", () => {
 			expect.stringContaining('No handler registered for effect "missingEffect"')
 		);
 		expect((await getRequest(t, requestId))?.status).toBe("approved");
+	});
+
+	it("does not warn or schedule effects for XState assign actions", async () => {
+		const t = createGovernedTestConvex();
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const borrowerId = await seedBorrowerProfile(t);
+		const mortgageId = await seedMortgage(t);
+		const obligationId = await seedObligation(t, mortgageId, borrowerId, {
+			status: "due",
+		});
+		const planEntryId = await seedPlanEntry(t, {
+			obligationIds: [obligationId],
+			amount: 300_000,
+			method: "manual",
+		});
+		const attemptId = await seedCollectionAttempt(t, {
+			planEntryId,
+			method: "manual",
+			amount: 300_000,
+		});
+
+		const result = await t.mutation(
+			internal.engine.transitionMutation.transitionMutation,
+			{
+				entityType: "collectionAttempt",
+				entityId: attemptId,
+				eventType: "DRAW_FAILED",
+				payload: { reason: "NSF", code: "R01" },
+				source: {
+					actorType: "system",
+					channel: "scheduler",
+				},
+			}
+		);
+
+		expect(result.success).toBe(true);
+		expect(result.newState).toBe("failed");
+		expect(result.effectsScheduled ?? []).toEqual([]);
+		expect(warnSpy).not.toHaveBeenCalledWith(
+			expect.stringContaining('No handler registered for effect "incrementRetryCount"')
+		);
+
+		const attempt = await t.run((ctx) => ctx.db.get(attemptId));
+		expect(attempt?.machineContext?.retryCount).toBe(1);
 	});
 
 	it("schedules nested compound-state effects for deal sub-state transitions", async () => {

--- a/src/test/convex/payments/crossEntity.test.ts
+++ b/src/test/convex/payments/crossEntity.test.ts
@@ -223,8 +223,13 @@ describe("AC2: failure chain (attempt permanent_fail -> COLLECTION_FAILED -> Ret
 	it("attempt DRAW_INITIATED -> pending -> DRAW_FAILED -> failed -> MAX_RETRIES_EXCEEDED -> permanent_fail, retry rule creates new plan entry", async () => {
 		const t = createGovernedTestConvex();
 		await seedDefaultGovernedActors(t);
-		const { obligationId } = await seedBaseEntities(t);
+		const { mortgageId, obligationId } = await seedBaseEntities(t);
 		const rules = await seedCollectionRules(t);
+		await t.run(async (ctx) => {
+			await ctx.db.patch(rules.retryRuleId, {
+				scope: { scopeType: "mortgage", mortgageId },
+			});
+		});
 
 		const obligation = await t.run(async (ctx) => ctx.db.get(obligationId));
 		const amount = obligation!.amount;
@@ -294,6 +299,7 @@ describe("AC2: failure chain (attempt permanent_fail -> COLLECTION_FAILED -> Ret
 		expect(retryEntry).toBeDefined();
 		expect(retryEntry?.status).toBe("planned");
 		expect(retryEntry?.rescheduledFromId).toBe(planEntryId);
+		expect(retryEntry?.ruleId).toBe(rules.retryRuleId);
 
 		// Verify the scheduled date has backoff applied
 		// retryCount=1 (incremented by DRAW_FAILED), baseDays=3

--- a/src/test/convex/payments/endToEnd.test.ts
+++ b/src/test/convex/payments/endToEnd.test.ts
@@ -42,11 +42,11 @@ async function seedBaseEntities(t: GovernedTestConvex) {
 }
 
 // ══════════════════════════════════════════════════════════════════════════════
-// AC4: ManualPaymentMethod Full Lifecycle
-// seed → obligation due → plan entry → attempt initiated → FUNDS_SETTLED → confirmed → PAYMENT_APPLIED → obligation settled → PAYMENT_CONFIRMED → mortgage active
+// AC4: Legacy manual compatibility lifecycle
+// Compatibility-only attempt flow: seed → obligation due → plan entry → attempt initiated → FUNDS_SETTLED → confirmed → PAYMENT_APPLIED → obligation settled → PAYMENT_CONFIRMED → mortgage active
 // ══════════════════════════════════════════════════════════════════════════════
 
-describe("AC4: ManualPaymentMethod full lifecycle", () => {
+describe("AC4: legacy manual compatibility lifecycle", () => {
 	beforeEach(() => {
 		vi.useFakeTimers();
 	});
@@ -57,7 +57,7 @@ describe("AC4: ManualPaymentMethod full lifecycle", () => {
 		vi.useRealTimers();
 	});
 
-	it("should complete full manual payment lifecycle: initiated → confirmed → settled → mortgage active", async () => {
+	it("should complete the legacy manual compatibility lifecycle: initiated → confirmed → settled → mortgage active", async () => {
 		const t = createGovernedTestConvex();
 		await seedDefaultGovernedActors(t);
 		const { mortgageId, obligationId } = await seedBaseEntities(t);
@@ -80,7 +80,7 @@ describe("AC4: ManualPaymentMethod full lifecycle", () => {
 			machineContext: { attemptId: "", retryCount: 0, maxRetries: 3 },
 		});
 
-		// Step 1: Fire FUNDS_SETTLED on attempt → confirmed (ManualPaymentMethod immediate path)
+		// Step 1: Fire FUNDS_SETTLED on attempt → confirmed (legacy manual compatibility path)
 		const result = await fireTransition(
 			t,
 			"collectionAttempt",
@@ -216,11 +216,11 @@ describe("AC4: ManualPaymentMethod full lifecycle", () => {
 });
 
 // ══════════════════════════════════════════════════════════════════════════════
-// AC5: MockPADMethod Async Path
-// Same lifecycle but with async `pending` state: initiated → pending → confirmed
+// AC5: Legacy mock PAD compatibility path
+// Compatibility-only attempt flow with async `pending` state: initiated → pending → confirmed
 // ══════════════════════════════════════════════════════════════════════════════
 
-describe("AC5: MockPADMethod async path (initiated → pending → confirmed)", () => {
+describe("AC5: legacy mock PAD compatibility path (initiated → pending → confirmed)", () => {
 	beforeEach(() => {
 		vi.useFakeTimers();
 	});

--- a/src/test/convex/payments/helpers.ts
+++ b/src/test/convex/payments/helpers.ts
@@ -52,46 +52,25 @@ export interface SeededRules {
 export async function seedCollectionRules(
 	t: GovernedTestConvex,
 ): Promise<SeededRules> {
-	const now = Date.now();
+	await t.mutation(internal.payments.collectionPlan.seed.seedCollectionRules, {});
 
-	const scheduleRuleId = await t.run(async (ctx) =>
-		ctx.db.insert("collectionRules", {
-			name: "schedule_rule",
-			trigger: "schedule",
-			action: "create_plan_entry",
-			parameters: { delayDays: 5 },
-			priority: 10,
-			enabled: true,
-			createdAt: now,
-			updatedAt: now,
-		}),
+	const rules = await t.run(async (ctx) =>
+		ctx.db.query("collectionRules").collect()
 	);
 
-	const retryRuleId = await t.run(async (ctx) =>
-		ctx.db.insert("collectionRules", {
-			name: "retry_rule",
-			trigger: "event",
-			action: "create_retry_entry",
-			parameters: { maxRetries: 3, backoffBaseDays: 3 },
-			priority: 20,
-			enabled: true,
-			createdAt: now,
-			updatedAt: now,
-		}),
-	);
+	const scheduleRuleId = rules.find(
+		(rule) => (rule.code ?? rule.name) === "schedule_rule"
+	)?._id;
+	const retryRuleId = rules.find(
+		(rule) => (rule.code ?? rule.name) === "retry_rule"
+	)?._id;
+	const lateFeeRuleId = rules.find(
+		(rule) => (rule.code ?? rule.name) === "late_fee_rule"
+	)?._id;
 
-	const lateFeeRuleId = await t.run(async (ctx) =>
-		ctx.db.insert("collectionRules", {
-			name: "late_fee_rule",
-			trigger: "event",
-			action: "create_late_fee",
-			parameters: { feeAmountCents: 5000, dueDays: 30, graceDays: 45 },
-			priority: 30,
-			enabled: true,
-			createdAt: now,
-			updatedAt: now,
-		}),
-	);
+	if (!scheduleRuleId || !retryRuleId || !lateFeeRuleId) {
+		throw new Error("Expected canonical collection rules to be seeded");
+	}
 
 	return { scheduleRuleId, retryRuleId, lateFeeRuleId };
 }

--- a/src/test/convex/payments/helpers.ts
+++ b/src/test/convex/payments/helpers.ts
@@ -58,19 +58,21 @@ export async function seedCollectionRules(
 		ctx.db.query("collectionRules").collect()
 	);
 
-	const scheduleRuleId = rules.find(
-		(rule) => (rule.code ?? rule.name) === "schedule_rule"
-	)?._id;
-	const retryRuleId = rules.find(
-		(rule) => (rule.code ?? rule.name) === "retry_rule"
-	)?._id;
-	const lateFeeRuleId = rules.find(
-		(rule) => (rule.code ?? rule.name) === "late_fee_rule"
-	)?._id;
+	const getCanonicalRuleId = (ruleCode: string) => {
+		const matches = rules.filter(
+			(rule) => (rule.code ?? rule.name) === ruleCode
+		);
+		if (matches.length !== 1) {
+			throw new Error(
+				`Expected exactly one canonical ${ruleCode} rule, found ${matches.length}`
+			);
+		}
+		return matches[0]._id;
+	};
 
-	if (!scheduleRuleId || !retryRuleId || !lateFeeRuleId) {
-		throw new Error("Expected canonical collection rules to be seeded");
-	}
+	const scheduleRuleId = getCanonicalRuleId("schedule_rule");
+	const retryRuleId = getCanonicalRuleId("retry_rule");
+	const lateFeeRuleId = getCanonicalRuleId("late_fee_rule");
 
 	return { scheduleRuleId, retryRuleId, lateFeeRuleId };
 }

--- a/src/test/convex/seed/seedPaymentData.test.ts
+++ b/src/test/convex/seed/seedPaymentData.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from "vitest";
+import { internal } from "../../../../convex/_generated/api";
+import type { Id } from "../../../../convex/_generated/dataModel";
+import { createTestConvex } from "../../auth/helpers";
+
+const MS_PER_DAY = 86_400_000;
+
+function addDays(date: Date, days: number): string {
+	const copy = new Date(date);
+	copy.setUTCDate(copy.getUTCDate() + days);
+	return copy.toISOString().slice(0, 10);
+}
+
+async function seedMortgageWithBorrower(
+	t: ReturnType<typeof createTestConvex>
+): Promise<Id<"mortgages">> {
+	return t.run(async (ctx) => {
+		const userId = await ctx.db.insert("users", {
+			authId: "seed-payment-data-user",
+			email: "seed-payment-data@example.com",
+			firstName: "Seed",
+			lastName: "Payment",
+		});
+
+		const propertyId = await ctx.db.insert("properties", {
+			streetAddress: "123 Canonical Path",
+			city: "Toronto",
+			province: "ON",
+			postalCode: "M5V 1A1",
+			propertyType: "residential",
+			createdAt: Date.now(),
+		});
+
+		const brokerId = await ctx.db.insert("brokers", {
+			status: "active",
+			userId,
+			orgId: "org_test_seed_payment_data",
+			createdAt: Date.now(),
+		});
+
+		const borrowerId = await ctx.db.insert("borrowers", {
+			status: "active",
+			userId,
+			orgId: "org_test_seed_payment_data",
+			createdAt: Date.now(),
+		});
+
+		const firstPaymentDate = addDays(new Date(), 3);
+		const maturityDate = firstPaymentDate;
+		const principal = 50_000_000;
+		const interestRate = 0.08;
+		const paymentAmount = Math.round((interestRate * principal) / 12);
+
+		const mortgageId = await ctx.db.insert("mortgages", {
+			status: "active",
+			orgId: "org_test_seed_payment_data",
+			propertyId,
+			principal,
+			interestRate,
+			rateType: "fixed",
+			termMonths: 1,
+			amortizationMonths: 1,
+			paymentAmount,
+			paymentFrequency: "monthly",
+			loanType: "conventional",
+			lienPosition: 1,
+			interestAdjustmentDate: firstPaymentDate,
+			termStartDate: firstPaymentDate,
+			maturityDate,
+			firstPaymentDate,
+			brokerOfRecordId: brokerId,
+			createdAt: Date.now(),
+		});
+
+		await ctx.db.insert("mortgageBorrowers", {
+			mortgageId,
+			borrowerId,
+			role: "primary",
+			addedAt: Date.now(),
+		});
+
+		return mortgageId;
+	});
+}
+
+describe("seedPaymentDataInternal", () => {
+	it("seeds default collection rules and creates initial entries with schedule-rule provenance", async () => {
+		const t = createTestConvex();
+		const mortgageId = await seedMortgageWithBorrower(t);
+
+		const result = await t.mutation(
+			internal.seed.seedPaymentData.seedPaymentDataInternal,
+			{ mortgageId }
+		);
+
+		expect(result.generated.obligations).toBe(1);
+		expect(result.generated.planEntries).toBe(1);
+
+		const state = await t.run(async (ctx) => {
+			const rules = await ctx.db.query("collectionRules").collect();
+			const entries = await ctx.db.query("collectionPlanEntries").collect();
+			return { rules, entries };
+		});
+
+		expect(state.rules.map((rule) => rule.name).sort()).toEqual([
+			"late_fee_rule",
+			"retry_rule",
+			"schedule_rule",
+		]);
+		expect(state.entries).toHaveLength(1);
+		expect(state.entries[0]?.source).toBe("default_schedule");
+		expect(state.entries[0]?.ruleId).toBeDefined();
+	});
+
+	it("is rerun-safe for canonical initial scheduling", async () => {
+		const t = createTestConvex();
+		const mortgageId = await seedMortgageWithBorrower(t);
+
+		await t.mutation(internal.seed.seedPaymentData.seedPaymentDataInternal, {
+			mortgageId,
+		});
+		const secondRun = await t.mutation(
+			internal.seed.seedPaymentData.seedPaymentDataInternal,
+			{ mortgageId }
+		);
+
+		expect(secondRun.generated.obligations).toBe(0);
+		expect(secondRun.generated.planEntries).toBe(0);
+		expect(secondRun.reused.obligations).toBe(1);
+		expect(secondRun.reused.planEntries).toBe(1);
+
+		const state = await t.run(async (ctx) => {
+			const rules = await ctx.db.query("collectionRules").collect();
+			const entries = await ctx.db.query("collectionPlanEntries").collect();
+			return { ruleCount: rules.length, entryCount: entries.length };
+		});
+
+		expect(state.ruleCount).toBe(3);
+		expect(state.entryCount).toBe(1);
+	});
+
+	it("uses the live schedule_rule delayDays parameter for bootstrap scheduling", async () => {
+		const t = createTestConvex();
+		const mortgageId = await seedMortgageWithBorrower(t);
+
+		const customScheduleRuleId = await t.run(async (ctx) =>
+			ctx.db.insert("collectionRules", {
+				name: "schedule_rule",
+				trigger: "schedule",
+				action: "create_plan_entry",
+				parameters: { delayDays: 9 },
+				priority: 10,
+				enabled: true,
+				createdAt: Date.now(),
+				updatedAt: Date.now(),
+			})
+		);
+
+		await t.mutation(internal.seed.seedPaymentData.seedPaymentDataInternal, {
+			mortgageId,
+		});
+
+		const state = await t.run(async (ctx) => {
+			const obligation = await ctx.db
+				.query("obligations")
+				.withIndex("by_mortgage", (q) => q.eq("mortgageId", mortgageId))
+				.first();
+			const entry = await ctx.db
+				.query("collectionPlanEntries")
+				.withIndex("by_status", (q) => q.eq("status", "planned"))
+				.first();
+			return { obligation, entry };
+		});
+
+		expect(state.entry?.ruleId).toBe(customScheduleRuleId);
+		expect(state.entry?.scheduledDate).toBe(
+			(state.obligation?.dueDate ?? 0) - 9 * MS_PER_DAY
+		);
+	});
+});

--- a/src/test/convex/seed/seedPaymentData.test.ts
+++ b/src/test/convex/seed/seedPaymentData.test.ts
@@ -102,10 +102,23 @@ describe("seedPaymentDataInternal", () => {
 			return { rules, entries };
 		});
 
-		expect(state.rules.map((rule) => rule.name).sort()).toEqual([
+		expect(state.rules.map((rule) => rule.code ?? rule.name).sort()).toEqual([
 			"late_fee_rule",
 			"retry_rule",
 			"schedule_rule",
+		]);
+		expect(
+			state.rules
+				.map((rule) => ({
+					code: rule.code,
+					kind: rule.kind,
+					status: rule.status,
+				}))
+				.sort((left, right) => (left.code ?? "").localeCompare(right.code ?? ""))
+		).toEqual([
+			{ code: "late_fee_rule", kind: "late_fee", status: "active" },
+			{ code: "retry_rule", kind: "retry", status: "active" },
+			{ code: "schedule_rule", kind: "schedule", status: "active" },
 		]);
 		expect(state.entries).toHaveLength(1);
 		expect(state.entries[0]?.source).toBe("default_schedule");
@@ -165,13 +178,21 @@ describe("seedPaymentDataInternal", () => {
 				.query("obligations")
 				.withIndex("by_mortgage", (q) => q.eq("mortgageId", mortgageId))
 				.first();
+			const scheduleRule = await ctx.db.get(customScheduleRuleId);
 			const entry = await ctx.db
 				.query("collectionPlanEntries")
 				.withIndex("by_status", (q) => q.eq("status", "planned"))
 				.first();
-			return { obligation, entry };
+			return { obligation, scheduleRule, entry };
 		});
 
+		expect(state.scheduleRule?.kind).toBe("schedule");
+		expect(state.scheduleRule?.code).toBe("schedule_rule");
+		expect(state.scheduleRule?.status).toBe("active");
+		expect(state.scheduleRule?.config).toEqual({
+			kind: "schedule",
+			delayDays: 9,
+		});
 		expect(state.entry?.ruleId).toBe(customScheduleRuleId);
 		expect(state.entry?.scheduledDate).toBe(
 			(state.obligation?.dueDate ?? 0) - 9 * MS_PER_DAY


### PR DESCRIPTION
collection attempt execution spine

Link transfer execution to collection attempt reconciliation

- add canonical initial scheduling and default collection rules
- route transfer confirm/fail/cancel/reverse events through attempt reconciliation
- update payment method compatibility and reconciliation coverage

Add typed collection-rule engine and seed migration

- Introduce typed rule contract, engine dispatch, and rule config helpers
- Backfill and seed collection rules with canonical metadata
- Add tests for deterministic selection and legacy rule migration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Automated collection plan execution with scheduled batch processing of due payment entries
  * Enhanced collection attempt reconciliation with transfer lifecycle outcomes
  * Typed collection rule system with schedule, retry, and late-fee rule configurations
  * Improved transfer cancellation and reversal handling with attempt state synchronization

* **Bug Fixes**
  * Strengthened idempotency guarantees for payment execution reruns
  * Enhanced failure durability and observability for collection attempts
  * Corrected retry scheduling and late-fee obligation creation logic

* **Improvements**
  * Unified collection plan execution through canonical payment rails
  * Deterministic rule enablement and priority ordering
<!-- end of auto-generated comment: release notes by coderabbit.ai -->