### PR TITLE
Hydrate CRM relation cell payloads across table and detail views

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -44,6 +44,7 @@ import type * as crm_objectDefs from "../crm/objectDefs.js";
 import type * as crm_recordLinks from "../crm/recordLinks.js";
 import type * as crm_recordQueries from "../crm/recordQueries.js";
 import type * as crm_records from "../crm/records.js";
+import type * as crm_relationCellPayloads from "../crm/relationCellPayloads.js";
 import type * as crm_systemAdapters_bootstrap from "../crm/systemAdapters/bootstrap.js";
 import type * as crm_systemAdapters_columnResolver from "../crm/systemAdapters/columnResolver.js";
 import type * as crm_systemAdapters_queryAdapter from "../crm/systemAdapters/queryAdapter.js";
@@ -341,6 +342,7 @@ declare const fullApi: ApiFromModules<{
   "crm/recordLinks": typeof crm_recordLinks;
   "crm/recordQueries": typeof crm_recordQueries;
   "crm/records": typeof crm_records;
+  "crm/relationCellPayloads": typeof crm_relationCellPayloads;
   "crm/systemAdapters/bootstrap": typeof crm_systemAdapters_bootstrap;
   "crm/systemAdapters/columnResolver": typeof crm_systemAdapters_columnResolver;
   "crm/systemAdapters/queryAdapter": typeof crm_systemAdapters_queryAdapter;

--- a/convex/crm/__tests__/viewEngine.test.ts
+++ b/convex/crm/__tests__/viewEngine.test.ts
@@ -44,6 +44,62 @@ async function seedLeadFixture(t: CrmTestHarness): Promise<CrmTestFixture> {
 	});
 }
 
+async function seedRelationFixture(t: CrmTestHarness) {
+	const sourceFixture = await seedObjectWithFields(t, {
+		name: "deal_relation",
+		fields: [{ name: "name", fieldType: "text", isRequired: true }],
+	});
+	const targetFixture = await seedObjectWithFields(t, {
+		name: "property_relation",
+		fields: [{ name: "address", fieldType: "text", isRequired: true }],
+	});
+	const relationFieldId = await asAdmin(t).mutation(
+		api.crm.fieldDefs.createField,
+		{
+			fieldType: "text",
+			label: "Property",
+			name: "property",
+			objectDefId: sourceFixture.objectDefId,
+			relation: {
+				cardinality: "many_to_many",
+				relationName: "Property",
+				targetObjectDefId: targetFixture.objectDefId,
+			},
+		}
+	);
+	const linkTypeDefId = await asAdmin(t).mutation(
+		api.crm.linkTypes.createLinkType,
+		{
+			cardinality: "many_to_many",
+			name: "Property",
+			sourceObjectDefId: sourceFixture.objectDefId,
+			targetObjectDefId: targetFixture.objectDefId,
+		}
+	);
+	const dealRecordId = await seedRecord(t, sourceFixture.objectDefId, {
+		name: "Loan Alpha",
+	});
+	const propertyRecordId = await seedRecord(t, targetFixture.objectDefId, {
+		address: "12 Oak Street",
+	});
+
+	await asAdmin(t).mutation(api.crm.recordLinks.createLink, {
+		linkTypeDefId,
+		sourceId: dealRecordId as string,
+		sourceKind: "record",
+		targetId: propertyRecordId as string,
+		targetKind: "record",
+	});
+
+	return {
+		dealRecordId,
+		propertyRecordId,
+		relationFieldId,
+		sourceFixture,
+		targetFixture,
+	};
+}
+
 // ═══════════════════════════════════════════════════════════════════════
 // View Engine
 // ═══════════════════════════════════════════════════════════════════════
@@ -323,6 +379,63 @@ describe("View Engine", () => {
 					value: 500_000,
 				})
 			);
+		});
+
+		it("hydrates relation cell payloads for normalized table rows and record detail surfaces", async () => {
+			const fixture = await seedRelationFixture(t);
+
+			const result = await asAdmin(t).query(
+				api.crm.viewQueries.queryViewRecords,
+				{
+					viewDefId: fixture.sourceFixture.defaultViewId,
+					limit: 25,
+				}
+			);
+
+			const relationRow = result.page.rows.find(
+				(row) => row.record._id === (fixture.dealRecordId as string)
+			);
+			expect(relationRow).toBeDefined();
+
+			const relationCell = relationRow?.cells.find(
+				(cell) => cell.fieldName === "property"
+			);
+			expect(relationCell?.fieldDefId).toBe(fixture.relationFieldId);
+			expect(relationCell?.displayValue).toEqual({
+				cardinality: "many_to_many",
+				items: [
+					{
+						label: "12 Oak Street",
+						objectDefId: fixture.targetFixture.objectDefId,
+						recordId: fixture.propertyRecordId as string,
+						recordKind: "record",
+					},
+				],
+				kind: "relation",
+			});
+			expect(relationCell?.value).toBeUndefined();
+
+			const detailSurface = await asAdmin(t).query(
+				api.crm.recordQueries.getRecordDetailSurface,
+				{
+					objectDefId: fixture.sourceFixture.objectDefId,
+					recordId: fixture.dealRecordId as string,
+					recordKind: "record",
+				}
+			);
+
+			expect(detailSurface.record.fields.property).toEqual({
+				cardinality: "many_to_many",
+				items: [
+					{
+						label: "12 Oak Street",
+						objectDefId: fixture.targetFixture.objectDefId,
+						recordId: fixture.propertyRecordId as string,
+						recordKind: "record",
+					},
+				],
+				kind: "relation",
+			});
 		});
 	});
 

--- a/convex/crm/__tests__/viewEngine.test.ts
+++ b/convex/crm/__tests__/viewEngine.test.ts
@@ -383,6 +383,13 @@ describe("View Engine", () => {
 
 		it("hydrates relation cell payloads for normalized table rows and record detail surfaces", async () => {
 			const fixture = await seedRelationFixture(t);
+			const unlinkedDealRecordId = await seedRecord(
+				t,
+				fixture.sourceFixture.objectDefId,
+				{
+					name: "Loan Beta",
+				}
+			);
 
 			const result = await asAdmin(t).query(
 				api.crm.viewQueries.queryViewRecords,
@@ -396,6 +403,11 @@ describe("View Engine", () => {
 				(row) => row.record._id === (fixture.dealRecordId as string)
 			);
 			expect(relationRow).toBeDefined();
+			const scalarCell = relationRow?.cells.find(
+				(cell) => cell.fieldName === "name"
+			);
+			expect(scalarCell?.displayValue).toBeUndefined();
+			expect(scalarCell?.value).toBe("Loan Alpha");
 
 			const relationCell = relationRow?.cells.find(
 				(cell) => cell.fieldName === "property"
@@ -434,6 +446,35 @@ describe("View Engine", () => {
 						recordKind: "record",
 					},
 				],
+				kind: "relation",
+			});
+
+			const unlinkedRelationRow = result.page.rows.find(
+				(row) => row.record._id === (unlinkedDealRecordId as string)
+			);
+			expect(unlinkedRelationRow).toBeDefined();
+
+			const emptyRelationCell = unlinkedRelationRow?.cells.find(
+				(cell) => cell.fieldName === "property"
+			);
+			expect(emptyRelationCell?.displayValue).toEqual({
+				cardinality: "many_to_many",
+				items: [],
+				kind: "relation",
+			});
+			expect(emptyRelationCell?.value).toBeUndefined();
+
+			const emptyDetailSurface = await asAdmin(t).query(
+				api.crm.recordQueries.getRecordDetailSurface,
+				{
+					objectDefId: fixture.sourceFixture.objectDefId,
+					recordId: unlinkedDealRecordId as string,
+					recordKind: "record",
+				}
+			);
+			expect(emptyDetailSurface.record.fields.property).toEqual({
+				cardinality: "many_to_many",
+				items: [],
 				kind: "relation",
 			});
 		});

--- a/convex/crm/recordQueries.ts
+++ b/convex/crm/recordQueries.ts
@@ -7,6 +7,7 @@ import {
 	buildNormalizedFieldDefinitions,
 	materializeRecordComputedFields,
 } from "./entityViewFields";
+import { materializeRelationFieldValues } from "./relationCellPayloads";
 import {
 	getNativeRecordById,
 	type NativeRecordPage,
@@ -1010,28 +1011,37 @@ export const getRecordDetailSurface = crmQuery
 			objectDef,
 			objectDefId: objectDef._id,
 		});
-		const record = materializeRecordComputedFields(
-			await loadReferencedRecord({
-				activeFieldDefs,
-				ctx,
-				objectDef,
-				orgId,
-				recordId: args.recordId,
-				recordKind: args.recordKind,
-			}),
-			adapterContract
-		);
+		const fields = buildNormalizedFieldDefinitions({
+			adapterContract,
+			applyLayoutVisibility: false,
+			currentLayout: "table",
+			fieldDefs: activeFieldDefs,
+			objectDefId: objectDef._id,
+			viewIsDefault: true,
+		});
+		const [record] = await materializeRelationFieldValues({
+			ctx,
+			fields,
+			objectDef,
+			orgId,
+			records: [
+				materializeRecordComputedFields(
+					await loadReferencedRecord({
+						activeFieldDefs,
+						ctx,
+						objectDef,
+						orgId,
+						recordId: args.recordId,
+						recordKind: args.recordKind,
+					}),
+					adapterContract
+				),
+			],
+		});
 
 		return {
 			adapterContract,
-			fields: buildNormalizedFieldDefinitions({
-				adapterContract,
-				applyLayoutVisibility: false,
-				currentLayout: "table",
-				fieldDefs: activeFieldDefs,
-				objectDefId: objectDef._id,
-				viewIsDefault: true,
-			}),
+			fields,
 			objectDef,
 			record,
 		};

--- a/convex/crm/relationCellPayloads.ts
+++ b/convex/crm/relationCellPayloads.ts
@@ -47,13 +47,6 @@ function createPeerReferenceKey(reference: RelationPeerReference): string {
 	return `${reference.recordKind}:${reference.recordId}:${String(reference.objectDefId)}`;
 }
 
-function createScalarDisplayValue(value: unknown): EntityViewCellDisplayValue {
-	return {
-		kind: "scalar",
-		value,
-	};
-}
-
 async function loadActiveFieldDefs(
 	ctx: QueryCtx,
 	objectDefId: Id<"objectDefs">
@@ -131,20 +124,59 @@ async function loadLinksByType(args: {
 	ctx: QueryCtx;
 	linkTypeDefIds: readonly Id<"linkTypeDefs">[];
 	orgId: string;
+	records: readonly UnifiedRecord[];
 }): Promise<Map<string, RecordLinkDoc[]>> {
+	const allowedLinkTypeIds = new Set(
+		args.linkTypeDefIds.map((linkTypeDefId) => linkTypeDefId.toString())
+	);
 	const linksByType = new Map<string, RecordLinkDoc[]>();
+	const seenLinkIdsByType = new Map<string, Set<string>>();
 
 	await Promise.all(
-		args.linkTypeDefIds.map(async (linkTypeDefId) => {
-			const links = await args.ctx.db
-				.query("recordLinks")
-				.withIndex("by_link_type", (q) => q.eq("linkTypeDefId", linkTypeDefId))
-				.collect();
+		args.records.map(async (record) => {
+			const [outboundLinks, inboundLinks] = await Promise.all([
+				args.ctx.db
+					.query("recordLinks")
+					.withIndex("by_org_source", (q) =>
+						q
+							.eq("orgId", args.orgId)
+							.eq("sourceKind", record._kind)
+							.eq("sourceId", record._id)
+					)
+					.collect(),
+				args.ctx.db
+					.query("recordLinks")
+					.withIndex("by_org_target", (q) =>
+						q
+							.eq("orgId", args.orgId)
+							.eq("targetKind", record._kind)
+							.eq("targetId", record._id)
+					)
+					.collect(),
+			]);
 
-			linksByType.set(
-				linkTypeDefId.toString(),
-				links.filter((link) => link.orgId === args.orgId && !link.isDeleted)
-			);
+			for (const link of [...outboundLinks, ...inboundLinks]) {
+				if (link.isDeleted) {
+					continue;
+				}
+
+				const linkTypeDefKey = link.linkTypeDefId.toString();
+				if (!allowedLinkTypeIds.has(linkTypeDefKey)) {
+					continue;
+				}
+
+				const seenLinkIds =
+					seenLinkIdsByType.get(linkTypeDefKey) ?? new Set<string>();
+				if (seenLinkIds.has(link._id.toString())) {
+					continue;
+				}
+
+				seenLinkIds.add(link._id.toString());
+				seenLinkIdsByType.set(linkTypeDefKey, seenLinkIds);
+				const matchingLinks = linksByType.get(linkTypeDefKey) ?? [];
+				matchingLinks.push(link);
+				linksByType.set(linkTypeDefKey, matchingLinks);
+			}
 		})
 	);
 
@@ -320,26 +352,34 @@ async function resolveRelationItemsByKey(args: {
 }): Promise<Map<string, RelationCellItem | null>> {
 	const objectDefsById = new Map<string, ObjectDef>();
 	const activeFieldDefsByObjectId = new Map<string, FieldDef[]>();
+	const uniqueReferencesByKey = new Map<string, RelationPeerReference>();
 	const resolvedItemsByKey = new Map<string, RelationCellItem | null>();
 
 	for (const referencesForField of args.fieldReferences.values()) {
 		for (const reference of referencesForField.values()) {
 			const peerReferenceKey = createPeerReferenceKey(reference);
-			if (resolvedItemsByKey.has(peerReferenceKey)) {
-				continue;
-			}
-
-			resolvedItemsByKey.set(
-				peerReferenceKey,
-				await resolveRelationCellItem({
-					activeFieldDefsByObjectId,
-					ctx: args.ctx,
-					objectDefsById,
-					orgId: args.orgId,
-					reference,
-				})
-			);
+			uniqueReferencesByKey.set(peerReferenceKey, reference);
 		}
+	}
+
+	const resolvedEntries = await Promise.all(
+		[...uniqueReferencesByKey.entries()].map(
+			async ([peerReferenceKey, reference]) =>
+				[
+					peerReferenceKey,
+					await resolveRelationCellItem({
+						activeFieldDefsByObjectId,
+						ctx: args.ctx,
+						objectDefsById,
+						orgId: args.orgId,
+						reference,
+					}),
+				] as const
+		)
+	);
+
+	for (const [peerReferenceKey, resolvedItem] of resolvedEntries) {
+		resolvedItemsByKey.set(peerReferenceKey, resolvedItem);
 	}
 
 	return resolvedItemsByKey;
@@ -437,6 +477,7 @@ export async function buildRelationCellDisplayValueMap(args: {
 		ctx: args.ctx,
 		linkTypeDefIds: uniqueLinkTypeDefIds,
 		orgId: args.orgId,
+		records: args.records,
 	});
 
 	const currentRecordKeys = new Set(
@@ -504,10 +545,6 @@ export async function materializeRelationFieldValues(args: {
 		let changed = false;
 
 		for (const [fieldName, relationDisplayValue] of relationDisplayValues) {
-			if (relationDisplayValue.items.length === 0) {
-				continue;
-			}
-
 			nextFields[fieldName] = relationDisplayValue;
 			changed = true;
 		}
@@ -538,10 +575,6 @@ export function buildEntityViewCellDisplayValueMap(args: {
 			record._id
 		);
 		const displayValues = new Map<string, EntityViewCellDisplayValue>();
-
-		for (const [fieldName, value] of Object.entries(record.fields)) {
-			displayValues.set(fieldName, createScalarDisplayValue(value));
-		}
 
 		for (const [fieldName, relationDisplayValue] of relationDisplayValues ??
 			[]) {

--- a/convex/crm/relationCellPayloads.ts
+++ b/convex/crm/relationCellPayloads.ts
@@ -1,0 +1,555 @@
+import type { Doc, Id } from "../_generated/dataModel";
+import type { QueryCtx } from "../_generated/server";
+import { buildEntityViewAdapter } from "./entityViewFields";
+import { getNativeRecordById } from "./systemAdapters/queryAdapter";
+import type {
+	EntityViewCellDisplayValue,
+	NormalizedFieldDefinition,
+	RelationCellDisplayValue,
+	RelationCellItem,
+	UnifiedRecord,
+} from "./types";
+
+type FieldDef = Doc<"fieldDefs">;
+type LinkTypeDef = Doc<"linkTypeDefs">;
+type ObjectDef = Doc<"objectDefs">;
+type RecordLinkDoc = Doc<"recordLinks">;
+
+interface RelationFieldBinding {
+	cardinality: NonNullable<
+		NormalizedFieldDefinition["relation"]
+	>["cardinality"];
+	fieldName: string;
+	matches: Array<{
+		direction: "inbound" | "outbound";
+		linkTypeDefId: Id<"linkTypeDefs">;
+	}>;
+}
+
+interface RelationPeerReference {
+	objectDefId: Id<"objectDefs">;
+	recordId: string;
+	recordKind: "record" | "native";
+}
+
+function createRecordReferenceKey(
+	recordKind: "record" | "native",
+	recordId: string
+): string {
+	return `${recordKind}:${recordId}`;
+}
+
+function createFieldReferenceKey(recordKey: string, fieldName: string): string {
+	return `${recordKey}:${fieldName}`;
+}
+
+function createPeerReferenceKey(reference: RelationPeerReference): string {
+	return `${reference.recordKind}:${reference.recordId}:${String(reference.objectDefId)}`;
+}
+
+function createScalarDisplayValue(value: unknown): EntityViewCellDisplayValue {
+	return {
+		kind: "scalar",
+		value,
+	};
+}
+
+async function loadActiveFieldDefs(
+	ctx: QueryCtx,
+	objectDefId: Id<"objectDefs">
+): Promise<FieldDef[]> {
+	const allFieldDefs = await ctx.db
+		.query("fieldDefs")
+		.withIndex("by_object", (q) => q.eq("objectDefId", objectDefId))
+		.collect();
+
+	return allFieldDefs.filter((fieldDef) => fieldDef.isActive);
+}
+
+function resolveRelationFieldBindings(args: {
+	inboundLinkTypes: readonly LinkTypeDef[];
+	objectDef: ObjectDef;
+	outboundLinkTypes: readonly LinkTypeDef[];
+	relationFields: readonly Pick<
+		NormalizedFieldDefinition,
+		"name" | "relation"
+	>[];
+}): RelationFieldBinding[] {
+	return args.relationFields.flatMap((field) => {
+		const relation = field.relation;
+		if (!relation) {
+			return [];
+		}
+
+		const relationName = relation.relationName?.trim().toLowerCase();
+		const outboundMatches = args.outboundLinkTypes
+			.filter((linkTypeDef) => {
+				if (
+					relation.targetObjectDefId &&
+					linkTypeDef.targetObjectDefId !== relation.targetObjectDefId
+				) {
+					return false;
+				}
+
+				return relationName
+					? linkTypeDef.name.trim().toLowerCase() === relationName
+					: true;
+			})
+			.map((linkTypeDef) => ({
+				direction: "outbound" as const,
+				linkTypeDefId: linkTypeDef._id,
+			}));
+		const inboundMatches = args.inboundLinkTypes
+			.filter((linkTypeDef) => {
+				if (
+					relation.targetObjectDefId &&
+					linkTypeDef.sourceObjectDefId !== relation.targetObjectDefId
+				) {
+					return false;
+				}
+
+				return relationName
+					? linkTypeDef.name.trim().toLowerCase() === relationName
+					: true;
+			})
+			.map((linkTypeDef) => ({
+				direction: "inbound" as const,
+				linkTypeDefId: linkTypeDef._id,
+			}));
+
+		return [
+			{
+				fieldName: field.name,
+				cardinality: relation.cardinality,
+				matches: [...outboundMatches, ...inboundMatches],
+			},
+		];
+	});
+}
+
+async function loadLinksByType(args: {
+	ctx: QueryCtx;
+	linkTypeDefIds: readonly Id<"linkTypeDefs">[];
+	orgId: string;
+}): Promise<Map<string, RecordLinkDoc[]>> {
+	const linksByType = new Map<string, RecordLinkDoc[]>();
+
+	await Promise.all(
+		args.linkTypeDefIds.map(async (linkTypeDefId) => {
+			const links = await args.ctx.db
+				.query("recordLinks")
+				.withIndex("by_link_type", (q) => q.eq("linkTypeDefId", linkTypeDefId))
+				.collect();
+
+			linksByType.set(
+				linkTypeDefId.toString(),
+				links.filter((link) => link.orgId === args.orgId && !link.isDeleted)
+			);
+		})
+	);
+
+	return linksByType;
+}
+
+function getRecordDisplayLabel(args: {
+	activeFieldDefs: readonly FieldDef[];
+	objectDef: ObjectDef;
+	record: UnifiedRecord;
+}): string {
+	const adapterContract = buildEntityViewAdapter({
+		currentLayout: "table",
+		fieldDefs: args.activeFieldDefs,
+		objectDef: args.objectDef,
+		objectDefId: args.objectDef._id,
+	});
+
+	if (adapterContract.titleFieldName) {
+		const preferredValue = args.record.fields[adapterContract.titleFieldName];
+		if (
+			typeof preferredValue === "string" &&
+			preferredValue.trim().length > 0
+		) {
+			return preferredValue;
+		}
+	}
+
+	for (const fieldDef of args.activeFieldDefs) {
+		const value = args.record.fields[fieldDef.name];
+		if (typeof value === "string" && value.trim().length > 0) {
+			return value;
+		}
+	}
+
+	return args.record._id;
+}
+
+async function resolveRelationCellItem(args: {
+	activeFieldDefsByObjectId: Map<string, FieldDef[]>;
+	ctx: QueryCtx;
+	objectDefsById: Map<string, ObjectDef>;
+	orgId: string;
+	reference: RelationPeerReference;
+}): Promise<RelationCellItem | null> {
+	if (args.reference.recordKind === "record") {
+		const normalizedId = args.ctx.db.normalizeId(
+			"records",
+			args.reference.recordId
+		);
+		if (!normalizedId) {
+			return null;
+		}
+
+		const recordDoc = await args.ctx.db.get(normalizedId);
+		if (!recordDoc || recordDoc.orgId !== args.orgId || recordDoc.isDeleted) {
+			return null;
+		}
+
+		return {
+			label: recordDoc.labelValue ?? args.reference.recordId,
+			objectDefId: args.reference.objectDefId,
+			recordId: args.reference.recordId,
+			recordKind: args.reference.recordKind,
+		};
+	}
+
+	const objectDefKey = args.reference.objectDefId.toString();
+	let objectDef = args.objectDefsById.get(objectDefKey);
+	if (!objectDef) {
+		const loadedObjectDef = await args.ctx.db.get(args.reference.objectDefId);
+		if (
+			!loadedObjectDef ||
+			loadedObjectDef.orgId !== args.orgId ||
+			!loadedObjectDef.isActive
+		) {
+			return null;
+		}
+		objectDef = loadedObjectDef;
+		args.objectDefsById.set(objectDefKey, loadedObjectDef);
+	}
+
+	let activeFieldDefs = args.activeFieldDefsByObjectId.get(objectDefKey);
+	if (!activeFieldDefs) {
+		activeFieldDefs = await loadActiveFieldDefs(
+			args.ctx,
+			args.reference.objectDefId
+		);
+		args.activeFieldDefsByObjectId.set(objectDefKey, activeFieldDefs);
+	}
+
+	const record = await getNativeRecordById(
+		args.ctx,
+		objectDef,
+		activeFieldDefs,
+		args.orgId,
+		args.reference.recordId
+	);
+	if (!record) {
+		return null;
+	}
+
+	return {
+		label: getRecordDisplayLabel({
+			activeFieldDefs,
+			objectDef,
+			record,
+		}),
+		objectDefId: args.reference.objectDefId,
+		recordId: args.reference.recordId,
+		recordKind: args.reference.recordKind,
+	};
+}
+
+function collectFieldReferences(args: {
+	currentRecordKeys: ReadonlySet<string>;
+	linksByType: ReadonlyMap<string, readonly RecordLinkDoc[]>;
+	relationFieldBindings: readonly RelationFieldBinding[];
+}): Map<string, Map<string, RelationPeerReference>> {
+	const fieldReferences = new Map<string, Map<string, RelationPeerReference>>();
+
+	for (const binding of args.relationFieldBindings) {
+		for (const match of binding.matches) {
+			const links = args.linksByType.get(match.linkTypeDefId.toString()) ?? [];
+			for (const link of links) {
+				const currentKey =
+					match.direction === "outbound"
+						? createRecordReferenceKey(link.sourceKind, link.sourceId)
+						: createRecordReferenceKey(link.targetKind, link.targetId);
+				if (!args.currentRecordKeys.has(currentKey)) {
+					continue;
+				}
+
+				const peerReference: RelationPeerReference =
+					match.direction === "outbound"
+						? {
+								objectDefId: link.targetObjectDefId,
+								recordId: link.targetId,
+								recordKind: link.targetKind,
+							}
+						: {
+								objectDefId: link.sourceObjectDefId,
+								recordId: link.sourceId,
+								recordKind: link.sourceKind,
+							};
+				const fieldReferenceKey = createFieldReferenceKey(
+					currentKey,
+					binding.fieldName
+				);
+				const referencesForField =
+					fieldReferences.get(fieldReferenceKey) ??
+					new Map<string, RelationPeerReference>();
+
+				referencesForField.set(
+					createPeerReferenceKey(peerReference),
+					peerReference
+				);
+				fieldReferences.set(fieldReferenceKey, referencesForField);
+			}
+		}
+	}
+
+	return fieldReferences;
+}
+
+async function resolveRelationItemsByKey(args: {
+	ctx: QueryCtx;
+	fieldReferences: ReadonlyMap<
+		string,
+		ReadonlyMap<string, RelationPeerReference>
+	>;
+	orgId: string;
+}): Promise<Map<string, RelationCellItem | null>> {
+	const objectDefsById = new Map<string, ObjectDef>();
+	const activeFieldDefsByObjectId = new Map<string, FieldDef[]>();
+	const resolvedItemsByKey = new Map<string, RelationCellItem | null>();
+
+	for (const referencesForField of args.fieldReferences.values()) {
+		for (const reference of referencesForField.values()) {
+			const peerReferenceKey = createPeerReferenceKey(reference);
+			if (resolvedItemsByKey.has(peerReferenceKey)) {
+				continue;
+			}
+
+			resolvedItemsByKey.set(
+				peerReferenceKey,
+				await resolveRelationCellItem({
+					activeFieldDefsByObjectId,
+					ctx: args.ctx,
+					objectDefsById,
+					orgId: args.orgId,
+					reference,
+				})
+			);
+		}
+	}
+
+	return resolvedItemsByKey;
+}
+
+function buildRelationDisplayValuesForRecord(args: {
+	bindings: readonly RelationFieldBinding[];
+	fieldReferences: ReadonlyMap<
+		string,
+		ReadonlyMap<string, RelationPeerReference>
+	>;
+	record: UnifiedRecord;
+	resolvedItemsByKey: ReadonlyMap<string, RelationCellItem | null>;
+}): Map<string, RelationCellDisplayValue> {
+	const recordKey = createRecordReferenceKey(
+		args.record._kind,
+		args.record._id
+	);
+	const displayValues = new Map<string, RelationCellDisplayValue>();
+
+	for (const binding of args.bindings) {
+		const fieldReferenceKey = createFieldReferenceKey(
+			recordKey,
+			binding.fieldName
+		);
+		const referencesForField = args.fieldReferences.get(fieldReferenceKey);
+		const items = referencesForField
+			? [...referencesForField.values()].flatMap((reference) => {
+					const resolved = args.resolvedItemsByKey.get(
+						createPeerReferenceKey(reference)
+					);
+					return resolved ? [resolved] : [];
+				})
+			: [];
+
+		displayValues.set(binding.fieldName, {
+			cardinality: binding.cardinality,
+			items,
+			kind: "relation",
+		});
+	}
+
+	return displayValues;
+}
+
+export async function buildRelationCellDisplayValueMap(args: {
+	ctx: QueryCtx;
+	fields: readonly Pick<NormalizedFieldDefinition, "name" | "relation">[];
+	objectDef: ObjectDef;
+	orgId: string;
+	records: readonly UnifiedRecord[];
+}): Promise<Map<string, Map<string, RelationCellDisplayValue>>> {
+	if (args.records.length === 0) {
+		return new Map();
+	}
+
+	const relationFields = args.fields.filter((field) => field.relation);
+	if (relationFields.length === 0) {
+		return new Map();
+	}
+
+	const [outboundLinkTypes, inboundLinkTypes] = await Promise.all([
+		args.ctx.db
+			.query("linkTypeDefs")
+			.withIndex("by_org_source_object", (q) =>
+				q.eq("orgId", args.orgId).eq("sourceObjectDefId", args.objectDef._id)
+			)
+			.collect(),
+		args.ctx.db
+			.query("linkTypeDefs")
+			.withIndex("by_org_target_object", (q) =>
+				q.eq("orgId", args.orgId).eq("targetObjectDefId", args.objectDef._id)
+			)
+			.collect(),
+	]);
+
+	const relationFieldBindings = resolveRelationFieldBindings({
+		inboundLinkTypes,
+		objectDef: args.objectDef,
+		outboundLinkTypes,
+		relationFields,
+	});
+	if (relationFieldBindings.length === 0) {
+		return new Map();
+	}
+
+	const uniqueLinkTypeDefIds = [
+		...new Set(
+			relationFieldBindings.flatMap((binding) =>
+				binding.matches.map((match) => match.linkTypeDefId.toString())
+			)
+		),
+	].map((linkTypeDefId) => linkTypeDefId as Id<"linkTypeDefs">);
+	const linksByType = await loadLinksByType({
+		ctx: args.ctx,
+		linkTypeDefIds: uniqueLinkTypeDefIds,
+		orgId: args.orgId,
+	});
+
+	const currentRecordKeys = new Set(
+		args.records.map((record) =>
+			createRecordReferenceKey(record._kind, record._id)
+		)
+	);
+	const fieldReferences = collectFieldReferences({
+		currentRecordKeys,
+		linksByType,
+		relationFieldBindings,
+	});
+	const resolvedItemsByKey = await resolveRelationItemsByKey({
+		ctx: args.ctx,
+		fieldReferences,
+		orgId: args.orgId,
+	});
+
+	const displayValuesByRecordId = new Map<
+		string,
+		Map<string, RelationCellDisplayValue>
+	>();
+
+	for (const record of args.records) {
+		const displayValues = buildRelationDisplayValuesForRecord({
+			bindings: relationFieldBindings,
+			fieldReferences,
+			record,
+			resolvedItemsByKey,
+		});
+
+		if (displayValues.size > 0) {
+			displayValuesByRecordId.set(record._id, displayValues);
+		}
+	}
+
+	return displayValuesByRecordId;
+}
+
+export async function materializeRelationFieldValues(args: {
+	ctx: QueryCtx;
+	fields: readonly Pick<NormalizedFieldDefinition, "name" | "relation">[];
+	objectDef: ObjectDef;
+	orgId: string;
+	records: readonly UnifiedRecord[];
+}): Promise<UnifiedRecord[]> {
+	const relationDisplayValuesByRecordId =
+		await buildRelationCellDisplayValueMap({
+			ctx: args.ctx,
+			fields: args.fields,
+			objectDef: args.objectDef,
+			orgId: args.orgId,
+			records: args.records,
+		});
+
+	return args.records.map((record) => {
+		const relationDisplayValues = relationDisplayValuesByRecordId.get(
+			record._id
+		);
+		if (!relationDisplayValues) {
+			return record;
+		}
+
+		const nextFields = { ...record.fields };
+		let changed = false;
+
+		for (const [fieldName, relationDisplayValue] of relationDisplayValues) {
+			if (relationDisplayValue.items.length === 0) {
+				continue;
+			}
+
+			nextFields[fieldName] = relationDisplayValue;
+			changed = true;
+		}
+
+		return changed
+			? {
+					...record,
+					fields: nextFields,
+				}
+			: record;
+	});
+}
+
+export function buildEntityViewCellDisplayValueMap(args: {
+	records: readonly UnifiedRecord[];
+	relationDisplayValuesByRecordId?: ReadonlyMap<
+		string,
+		ReadonlyMap<string, RelationCellDisplayValue>
+	>;
+}): Map<string, Map<string, EntityViewCellDisplayValue>> {
+	const displayValuesByRecordId = new Map<
+		string,
+		Map<string, EntityViewCellDisplayValue>
+	>();
+
+	for (const record of args.records) {
+		const relationDisplayValues = args.relationDisplayValuesByRecordId?.get(
+			record._id
+		);
+		const displayValues = new Map<string, EntityViewCellDisplayValue>();
+
+		for (const [fieldName, value] of Object.entries(record.fields)) {
+			displayValues.set(fieldName, createScalarDisplayValue(value));
+		}
+
+		for (const [fieldName, relationDisplayValue] of relationDisplayValues ??
+			[]) {
+			displayValues.set(fieldName, relationDisplayValue);
+		}
+
+		displayValuesByRecordId.set(record._id, displayValues);
+	}
+
+	return displayValuesByRecordId;
+}

--- a/convex/crm/types.ts
+++ b/convex/crm/types.ts
@@ -234,7 +234,30 @@ export interface EntityViewAdapterContract {
 	variant: "dedicated" | "fallback";
 }
 
+export interface RelationCellItem {
+	label: string;
+	objectDefId: Id<"objectDefs">;
+	recordId: string;
+	recordKind: "record" | "native";
+}
+
+export interface ScalarCellDisplayValue {
+	kind: "scalar";
+	value: unknown;
+}
+
+export interface RelationCellDisplayValue {
+	cardinality: RelationMetadata["cardinality"];
+	items: RelationCellItem[];
+	kind: "relation";
+}
+
+export type EntityViewCellDisplayValue =
+	| ScalarCellDisplayValue
+	| RelationCellDisplayValue;
+
 export interface EntityViewCell {
+	displayValue?: EntityViewCellDisplayValue;
 	fieldDefId: Id<"fieldDefs">;
 	fieldName: string;
 	label: string;

--- a/convex/crm/viewQueries.ts
+++ b/convex/crm/viewQueries.ts
@@ -12,6 +12,10 @@ import {
 } from "./recordQueries";
 import { readExistingValue, writeValue } from "./records";
 import {
+	buildEntityViewCellDisplayValueMap,
+	buildRelationCellDisplayValueMap,
+} from "./relationCellPayloads";
+import {
 	type NativeRecordPage,
 	queryNativeRecords,
 	queryNativeTable,
@@ -19,6 +23,7 @@ import {
 import type {
 	EffectiveViewDefinition,
 	EntityViewAdapterContract,
+	EntityViewCellDisplayValue,
 	EntityViewPageResult,
 	EntityViewRow,
 	NormalizedFieldDefinition,
@@ -308,6 +313,10 @@ function buildViewQueryBase(state: ResolvedViewState) {
 }
 
 function buildPageResult(args: {
+	cellDisplayValuesByRecordId?: ReadonlyMap<
+		string,
+		ReadonlyMap<string, EntityViewCellDisplayValue>
+	>;
 	continueCursor: string | null;
 	isDone: boolean;
 	limit: number;
@@ -322,7 +331,11 @@ function buildPageResult(args: {
 		isDone: args.isDone,
 		limit: args.limit,
 		returnedCount: args.records.length,
-		rows: buildEntityViewRows(args.records, args.columns),
+		rows: buildEntityViewRows(
+			args.records,
+			args.columns,
+			args.cellDisplayValuesByRecordId
+		),
 		totalCount: args.totalCount,
 		totalCountExact: args.totalCountExact,
 		truncated: args.truncated,
@@ -551,7 +564,11 @@ function buildKanbanGroups(
 	kanbanGroups: KanbanGroupDoc[],
 	groupRecordMap: Map<string, UnifiedRecord[]>,
 	optionsLookup: Map<string, { label: string; color: string }>,
-	columns: ViewColumnDefinition[]
+	columns: ViewColumnDefinition[],
+	cellDisplayValuesByRecordId?: ReadonlyMap<
+		string,
+		ReadonlyMap<string, EntityViewCellDisplayValue>
+	>
 ): KanbanGroup[] {
 	return kanbanGroups.map((group) => {
 		const isNoValue = group.optionValue === KANBAN_NO_VALUE_SENTINEL;
@@ -563,7 +580,7 @@ function buildKanbanGroups(
 			label: isNoValue ? "No Value" : (optionInfo?.label ?? group.optionValue),
 			color: optionInfo?.color ?? "",
 			records,
-			rows: buildEntityViewRows(records, columns),
+			rows: buildEntityViewRows(records, columns, cellDisplayValuesByRecordId),
 			count: records.length,
 			isCollapsed: group.isCollapsed,
 		};
@@ -587,6 +604,14 @@ async function queryTableView(
 			paginateUnfilteredTableRecords(ctx, state, cursor ?? null, limit),
 			countUnfilteredRecords(ctx, state),
 		]);
+		const relationDisplayValuesByRecordId =
+			await buildRelationCellDisplayValueMap({
+				ctx,
+				fields: state.fields,
+				objectDef: state.objectDef,
+				orgId: state.viewDef.orgId,
+				records: pagedRecords.records,
+			});
 		const rows = pagedRecords.records.map((record) =>
 			projectRecordToVisibleColumns(record, state.columns)
 		);
@@ -596,6 +621,10 @@ async function queryTableView(
 			aggregates: [],
 			cursor: pagedRecords.continueCursor,
 			page: buildPageResult({
+				cellDisplayValuesByRecordId: buildEntityViewCellDisplayValueMap({
+					records: pagedRecords.records,
+					relationDisplayValuesByRecordId,
+				}),
 				continueCursor: pagedRecords.continueCursor,
 				isDone: pagedRecords.isDone,
 				limit,
@@ -622,6 +651,14 @@ async function queryTableView(
 	const page = filtered.slice(offset, offset + limit);
 	const nextOffset = offset + limit;
 	const isDone = nextOffset >= filtered.length;
+	const relationDisplayValuesByRecordId =
+		await buildRelationCellDisplayValueMap({
+			ctx,
+			fields: state.fields,
+			objectDef: state.objectDef,
+			orgId: state.viewDef.orgId,
+			records: page,
+		});
 	const rows = page.map((record) =>
 		projectRecordToVisibleColumns(record, state.columns)
 	);
@@ -635,6 +672,10 @@ async function queryTableView(
 		),
 		cursor: isDone ? null : `offset:${String(nextOffset)}`,
 		page: buildPageResult({
+			cellDisplayValuesByRecordId: buildEntityViewCellDisplayValueMap({
+				records: page,
+				relationDisplayValuesByRecordId,
+			}),
 			continueCursor: isDone ? null : `offset:${String(nextOffset)}`,
 			isDone,
 			limit,
@@ -666,6 +707,14 @@ async function queryKanbanView(
 		recordFilters,
 		state.fieldDefsById
 	);
+	const relationDisplayValuesByRecordId =
+		await buildRelationCellDisplayValueMap({
+			ctx,
+			fields: state.fields,
+			objectDef: state.objectDef,
+			orgId: state.viewDef.orgId,
+			records: filtered,
+		});
 	const optionsLookup = buildKanbanOptionsLookup(boundFieldDef);
 	const groupRecordMap = distributeKanbanRecords(
 		filtered,
@@ -684,7 +733,11 @@ async function queryKanbanView(
 			kanbanGroups,
 			groupRecordMap,
 			optionsLookup,
-			state.columns
+			state.columns,
+			buildEntityViewCellDisplayValueMap({
+				records: filtered,
+				relationDisplayValuesByRecordId,
+			})
 		),
 		totalCount: filtered.length,
 		totalCountExact: !assembled.truncated,

--- a/convex/crm/viewState.ts
+++ b/convex/crm/viewState.ts
@@ -12,6 +12,7 @@ import type {
 	AggregatePreset,
 	EffectiveViewDefinition,
 	EntityViewAdapterContract,
+	EntityViewCellDisplayValue,
 	EntityViewRow,
 	NormalizedFieldDefinition,
 	RecordFilter,
@@ -939,13 +940,18 @@ export function buildEntityViewRows(
 		_id: string;
 		_kind: "record" | "native";
 	}>,
-	columns: ViewColumnDefinition[]
+	columns: ViewColumnDefinition[],
+	displayValuesByRecordId?: ReadonlyMap<
+		string,
+		ReadonlyMap<string, EntityViewCellDisplayValue>
+	>
 ): EntityViewRow[] {
 	const visibleColumns = columns.filter((column) => column.isVisible);
 
 	return records.map((record) => ({
 		record,
 		cells: visibleColumns.map((column) => ({
+			displayValue: displayValuesByRecordId?.get(record._id)?.get(column.name),
 			fieldDefId: column.fieldDefId,
 			fieldName: column.name,
 			label: column.label,

--- a/specs/ENG-276/chunks/chunk-01-backend-relation-contract/context.md
+++ b/specs/ENG-276/chunks/chunk-01-backend-relation-contract/context.md
@@ -1,0 +1,27 @@
+# Chunk Context: chunk-01-backend-relation-contract
+
+## Goal
+- Add a stable typed relation payload to the shared view-engine contract and hydrate it from backend relation data for table and kanban consumers.
+
+## Relevant plan excerpts
+- "Backend view queries must return a typed, cell-ready relation payload for relation-backed fields, including target `recordId`, `recordKind`, `objectDefId`, and human-readable label text."
+- "Kanban cards must use the same relation value contract and presentation rules when a preview field is relation-backed."
+- "Calendar views and calendar query contracts remain out of scope for this issue and must not be expanded as part of the relation-cell work."
+
+## Implementation notes
+- `convex/crm/types.ts` currently models `EntityViewCell.value` as `unknown`, so the first step is to add typed relation payload variants without breaking scalar consumers.
+- `convex/crm/viewQueries.ts` currently returns raw `UnifiedRecord.fields` via `projectRecordToVisibleColumns` and `buildEntityViewRows`; relation hydration should happen before row projection so both table and kanban paths can reuse it.
+- `convex/crm/linkQueries.ts` and `convex/crm/recordQueries.ts` both contain linked-record resolution logic; prefer extracting or sharing a single label/object resolution helper rather than duplicating relation lookup rules again.
+- Keep the existing calendar query path untouched; only table and kanban payloads should change in this chunk.
+
+## Existing code touchpoints
+- `convex/crm/types.ts`
+- `convex/crm/viewState.ts`
+- `convex/crm/viewQueries.ts`
+- `convex/crm/linkQueries.ts`
+- `convex/crm/recordQueries.ts`
+- `convex/crm/__tests__/viewEngine.test.ts`
+
+## Validation
+- Backend tests in `convex/crm/__tests__/viewEngine.test.ts` should prove relation payload hydration for both a dedicated-like and fallback-like object path.
+- Existing table and kanban tests should remain green without touching calendar assertions.

--- a/specs/ENG-276/chunks/chunk-01-backend-relation-contract/context.md
+++ b/specs/ENG-276/chunks/chunk-01-backend-relation-contract/context.md
@@ -9,10 +9,11 @@
 - "Calendar views and calendar query contracts remain out of scope for this issue and must not be expanded as part of the relation-cell work."
 
 ## Implementation notes
-- `convex/crm/types.ts` currently models `EntityViewCell.value` as `unknown`, so the first step is to add typed relation payload variants without breaking scalar consumers.
-- `convex/crm/viewQueries.ts` currently returns raw `UnifiedRecord.fields` via `projectRecordToVisibleColumns` and `buildEntityViewRows`; relation hydration should happen before row projection so both table and kanban paths can reuse it.
+- `convex/crm/types.ts` still models `EntityViewCell.value` as `unknown`, while `displayValue` now carries typed relation payloads without breaking scalar consumers.
+- `convex/crm/viewQueries.ts` now hydrates relation display values before row projection so both table and kanban paths reuse the same typed payload contract.
 - `convex/crm/linkQueries.ts` and `convex/crm/recordQueries.ts` both contain linked-record resolution logic; prefer extracting or sharing a single label/object resolution helper rather than duplicating relation lookup rules again.
 - Keep the existing calendar query path untouched; only table and kanban payloads should change in this chunk.
+- Treat this file as architecture context, not lint-oriented code. When reviewing it, verify statements against the implemented backend behavior instead of flagging Markdown formatting noise.
 
 ## Existing code touchpoints
 - `convex/crm/types.ts`
@@ -23,5 +24,5 @@
 - `convex/crm/__tests__/viewEngine.test.ts`
 
 ## Validation
-- Backend tests in `convex/crm/__tests__/viewEngine.test.ts` should prove relation payload hydration for both a dedicated-like and fallback-like object path.
-- Existing table and kanban tests should remain green without touching calendar assertions.
+- Backend tests in `convex/crm/__tests__/viewEngine.test.ts` cover relation payload hydration for both populated and empty relation states.
+- Existing table and kanban coverage remains focused on the relation contract without expanding calendar assertions.

--- a/specs/ENG-276/chunks/chunk-01-backend-relation-contract/status.md
+++ b/specs/ENG-276/chunks/chunk-01-backend-relation-contract/status.md
@@ -1,0 +1,13 @@
+# Status: chunk-01-backend-relation-contract
+
+- Result: pending
+- Completed at: pending
+
+## Completed tasks
+- None yet
+
+## Validation
+- Not run yet
+
+## Notes
+- Pre-edit impact fallback indicates medium risk on `buildEntityViewRows` / `projectRecordToVisibleColumns` because both feed shared table/kanban payloads and `calendarQuery`.

--- a/specs/ENG-276/chunks/chunk-01-backend-relation-contract/status.md
+++ b/specs/ENG-276/chunks/chunk-01-backend-relation-contract/status.md
@@ -10,4 +10,4 @@
 - Not run yet
 
 ## Notes
-- Pre-edit impact fallback indicates medium risk on `buildEntityViewRows` / `projectRecordToVisibleColumns` because both feed shared table/kanban payloads and `calendarQuery`.
+- Pre-edit impact fallback: medium risk because shared payload-shape changes here can break data consistency and UI rendering across table, kanban, and adjacent calendar flows. `buildEntityViewRows` and `projectRecordToVisibleColumns` both emit/consume the shared payload contract touched by this chunk, and `calendarQuery` is a downstream consumer of the same view-engine data path. Mitigate by adding integration tests that cover table/kanban/calendar payloads, adding schema validation for shared payloads, and coordinating frontend/back-end contract changes through a versioned payload or explicit migration plan.

--- a/specs/ENG-276/chunks/chunk-01-backend-relation-contract/tasks.md
+++ b/specs/ENG-276/chunks/chunk-01-backend-relation-contract/tasks.md
@@ -1,0 +1,6 @@
+# Chunk: chunk-01-backend-relation-contract
+
+- [ ] T-001: Add shared relation cell payload types to `convex/crm/types.ts` and update the row/cell model to carry typed relation values.
+- [ ] T-002: Reuse or extract linked-record label/object resolution helpers so relation-backed view fields can hydrate consistent relation items.
+- [ ] T-003: Update backend table and kanban query assembly to emit relation-aware cell payloads without changing calendar contracts.
+- [ ] T-004: Add backend test coverage for relation payload hydration on dedicated and fallback entity paths.

--- a/specs/ENG-276/chunks/chunk-02-shared-relation-ui/context.md
+++ b/specs/ENG-276/chunks/chunk-02-shared-relation-ui/context.md
@@ -10,10 +10,11 @@
 - "Generic detail rendering handles relation payloads meaningfully so fallback detail sections do not degrade to raw JSON once relation values become structured."
 
 ## Implementation notes
-- `src/components/admin/shell/AdminEntityTableView.tsx` and `AdminEntityKanbanView.tsx` both still render via `renderAdminFieldValue(field, record.fields[column.name])`; both need to move to row/cell-aware rendering, ideally through one shared relation component.
-- `renderAdminFieldValue` currently formats only scalar/select-like values, so relation handling should be additive and not break non-relation cell output.
-- `RecordSidebar` already computes full-page fallbacks using `getDedicatedAdminRecordRoute` and generic `/admin/$entitytype/$recordid`; centralize that logic in a shared helper so `LinkedRecordsPanel` and new relation cells behave identically.
+- `src/components/admin/shell/AdminEntityTableView.tsx` and `AdminEntityKanbanView.tsx` are now row/cell-aware and route relation payloads through the shared `RelationCell` component.
+- `renderAdminFieldValue` still handles scalar/select-style values, while relation rendering is layered on through `RelationCell` so non-relation output stays unchanged.
+- Full-page fallback routing is centralized in `src/lib/admin-relation-navigation.ts`, keeping `RecordSidebar`, `LinkedRecordsPanel`, and relation cells aligned on dedicated-vs-generic detail routes.
 - Relation-chip clicks must stop propagation so row selection still works when clicking elsewhere in the row/card.
+- Treat this file as implementation context, not lint-oriented code. Verify relation rendering and fallback routing against the actual components before flagging documentation drift.
 
 ## Existing code touchpoints
 - `src/components/admin/shell/admin-view-types.ts`
@@ -28,4 +29,4 @@
 - `src/lib/admin-entity-routes.ts`
 
 ## Validation
-- Component tests should cover collapsed vs expanded relation display, single-open behavior, chip click propagation, and sidebar-vs-page fallback navigation.
+- Component tests cover collapsed vs expanded relation display, single-open behavior, and chip click propagation; route fallback behavior is verified through the admin shell navigation tests.

--- a/specs/ENG-276/chunks/chunk-02-shared-relation-ui/context.md
+++ b/specs/ENG-276/chunks/chunk-02-shared-relation-ui/context.md
@@ -1,0 +1,31 @@
+# Chunk Context: chunk-02-shared-relation-ui
+
+## Goal
+- Render relation-backed cells as reusable chips/links across table, kanban, and generic detail surfaces while preserving shared sidebar navigation semantics.
+
+## Relevant plan excerpts
+- "Multi-relation cells render a collapsed truncated state and an inline expanded state that pushes surrounding layout downward instead of using detached hover-only UI."
+- "Only one relation cell expansion may be open per rendered surface in MVP."
+- "Clicking a relation chip opens the related record in the shared detail sheet when the sidebar provider context is available, and falls back to the correct full detail page route when it is not."
+- "Generic detail rendering handles relation payloads meaningfully so fallback detail sections do not degrade to raw JSON once relation values become structured."
+
+## Implementation notes
+- `src/components/admin/shell/AdminEntityTableView.tsx` and `AdminEntityKanbanView.tsx` both still render via `renderAdminFieldValue(field, record.fields[column.name])`; both need to move to row/cell-aware rendering, ideally through one shared relation component.
+- `renderAdminFieldValue` currently formats only scalar/select-like values, so relation handling should be additive and not break non-relation cell output.
+- `RecordSidebar` already computes full-page fallbacks using `getDedicatedAdminRecordRoute` and generic `/admin/$entitytype/$recordid`; centralize that logic in a shared helper so `LinkedRecordsPanel` and new relation cells behave identically.
+- Relation-chip clicks must stop propagation so row selection still works when clicking elsewhere in the row/card.
+
+## Existing code touchpoints
+- `src/components/admin/shell/admin-view-types.ts`
+- `src/components/admin/shell/admin-view-rendering.tsx`
+- `src/components/admin/shell/AdminEntityTableView.tsx`
+- `src/components/admin/shell/AdminEntityKanbanView.tsx`
+- `src/components/admin/shell/FieldRenderer.tsx`
+- `src/components/admin/shell/RecordSidebar.tsx`
+- `src/components/admin/shell/LinkedRecordsPanel.tsx`
+- `src/components/admin/shell/RecordSidebarProvider.tsx`
+- `src/hooks/useAdminDetailSheet.tsx`
+- `src/lib/admin-entity-routes.ts`
+
+## Validation
+- Component tests should cover collapsed vs expanded relation display, single-open behavior, chip click propagation, and sidebar-vs-page fallback navigation.

--- a/specs/ENG-276/chunks/chunk-02-shared-relation-ui/status.md
+++ b/specs/ENG-276/chunks/chunk-02-shared-relation-ui/status.md
@@ -1,0 +1,13 @@
+# Status: chunk-02-shared-relation-ui
+
+- Result: pending
+- Completed at: pending
+
+## Completed tasks
+- None yet
+
+## Validation
+- Not run yet
+
+## Notes
+- Fallback impact analysis shows low-to-medium risk here: `renderAdminFieldValue` only feeds the two admin list surfaces, while sidebar navigation changes are localized to the admin shell.

--- a/specs/ENG-276/chunks/chunk-02-shared-relation-ui/tasks.md
+++ b/specs/ENG-276/chunks/chunk-02-shared-relation-ui/tasks.md
@@ -1,0 +1,7 @@
+# Chunk: chunk-02-shared-relation-ui
+
+- [ ] T-005: Update frontend admin view result types to consume typed row/cell payloads.
+- [ ] T-006: Create a shared relation-cell component with inline expansion and single-open state.
+- [ ] T-007: Add a shared relation navigation helper for sidebar-first navigation with full-page fallback.
+- [ ] T-008: Wire table and kanban surfaces to the relation-cell component without breaking row-click selection.
+- [ ] T-009: Update generic detail rendering so relation payloads render as relation UI instead of JSON.

--- a/specs/ENG-276/chunks/chunk-03-validation-and-regressions/context.md
+++ b/specs/ENG-276/chunks/chunk-03-validation-and-regressions/context.md
@@ -1,0 +1,27 @@
+# Chunk Context: chunk-03-validation-and-regressions
+
+## Goal
+- Prove the backend payload and shared admin-shell behavior work together and that unchanged surfaces, especially calendar and existing navigation flows, do not regress.
+
+## Relevant plan excerpts
+- "Validation includes backend relation payload hydration plus frontend expansion/navigation behavior."
+- "`bun check`, `bun typecheck`, and `bunx convex codegen` must pass."
+- "Automated tests cover backend relation hydration and frontend inline expansion/navigation for at least one dedicated entity and one fallback entity."
+
+## Implementation notes
+- Backend coverage belongs in `convex/crm/__tests__/viewEngine.test.ts`.
+- Frontend coverage should live in focused admin-shell tests rather than broad route tests when possible.
+- Storybook is not the primary proof point here unless a new reusable presentational primitive clearly benefits from it.
+- Final scope validation must compare the final diff against the planned backend/frontend touchpoints because GitNexus is unavailable.
+
+## Existing code touchpoints
+- `convex/crm/__tests__/viewEngine.test.ts`
+- `src/test/admin/admin-shell.test.ts`
+- `src/test/admin/field-renderer.test.tsx`
+- any new targeted relation-cell test file under `src/test/admin/`
+
+## Validation
+- `bun check`
+- `bun typecheck`
+- `bunx convex codegen`
+- targeted `bun run test` invocations for the touched backend/admin-shell scope

--- a/specs/ENG-276/chunks/chunk-03-validation-and-regressions/status.md
+++ b/specs/ENG-276/chunks/chunk-03-validation-and-regressions/status.md
@@ -1,0 +1,13 @@
+# Status: chunk-03-validation-and-regressions
+
+- Result: pending
+- Completed at: pending
+
+## Completed tasks
+- None yet
+
+## Validation
+- Not run yet
+
+## Notes
+- Final repo validation may still be affected by pre-existing workspace issues; record blockers explicitly if they appear.

--- a/specs/ENG-276/chunks/chunk-03-validation-and-regressions/tasks.md
+++ b/specs/ENG-276/chunks/chunk-03-validation-and-regressions/tasks.md
@@ -1,0 +1,8 @@
+# Chunk: chunk-03-validation-and-regressions
+
+- [ ] T-010: Add frontend component/unit coverage for inline expansion, one-open-at-a-time behavior, and relation navigation fallback.
+- [ ] T-011: Run `bun check`.
+- [ ] T-012: Run `bun typecheck`.
+- [ ] T-013: Run `bunx convex codegen`.
+- [ ] T-014: Run targeted tests for touched backend and admin-shell scope.
+- [ ] T-015: Reconcile the final change scope against the planned touchpoints using `git diff` and the fallback caller sweep.

--- a/specs/ENG-276/chunks/manifest.md
+++ b/specs/ENG-276/chunks/manifest.md
@@ -1,0 +1,7 @@
+# Chunk Manifest: ENG-276 - View Engine — Relation Cells, Inline Expansion, and Cross-Entity Navigation
+
+| Chunk | Tasks | Status | Notes |
+| ----- | ----- | ------ | ----- |
+| chunk-01-backend-relation-contract | T-001, T-002, T-003, T-004 | pending | typed relation payloads and backend hydration |
+| chunk-02-shared-relation-ui | T-005, T-006, T-007, T-008, T-009 | pending | table/kanban/detail rendering plus navigation reuse |
+| chunk-03-validation-and-regressions | T-010, T-011, T-012, T-013, T-014, T-015 | pending | frontend tests and repo validation |

--- a/specs/ENG-276/execution-checklist.md
+++ b/specs/ENG-276/execution-checklist.md
@@ -1,0 +1,46 @@
+# Execution Checklist: ENG-276 - View Engine — Relation Cells, Inline Expansion, and Cross-Entity Navigation
+
+## Requirements From Linear
+- [ ] Shared view-engine table and kanban surfaces render relation-backed fields as chips/links instead of raw scalar or JSON fallbacks.
+- [ ] Backend view queries return a typed, cell-ready relation payload for relation-backed fields, including target `recordId`, `recordKind`, `objectDefId`, and human-readable label text.
+- [ ] Multi-relation cells render a collapsed truncated state and an inline expanded state that pushes surrounding layout downward instead of using detached hover-only UI.
+- [ ] Only one relation cell expansion may be open per rendered surface in MVP.
+- [ ] Clicking a relation chip opens the related record in the shared detail sheet when the sidebar provider context is available, and falls back to the correct full detail page route when it is not.
+- [ ] Relation rendering and navigation are reusable across metadata-fallback entities and dedicated adapter entities without route-local exceptions.
+- [ ] Kanban cards use the same relation value contract and presentation rules when a preview field is relation-backed.
+- [ ] Generic detail rendering handles relation payloads meaningfully so fallback detail sections do not degrade to raw JSON once relation values become structured.
+- [ ] Existing row-click navigation, Relations tab navigation, and detail-sheet back-stack behavior continue to work.
+- [ ] Calendar-based views and calendar query contracts are out of scope for this issue and must not be expanded as part of the relation-cell work.
+- [ ] No new `any` types are introduced.
+- [ ] Validation includes backend relation payload hydration plus frontend expansion/navigation behavior.
+
+## Definition Of Done From Linear
+- [ ] Table cells for relation-backed fields display chip/link UI rather than raw ids, plain strings, or JSON.
+- [ ] Multi-relation table cells expand inline and only one expanded relation cell can be open at a time.
+- [ ] Relation chip clicks open related detail sheets across entity types from the shared admin view when feasible.
+- [ ] When sheet navigation is not feasible, relation chip clicks fall back to the correct dedicated or generic full detail page route.
+- [ ] Kanban relation preview fields use the same shared relation presentation and navigation rules.
+- [ ] Generated fallback detail rendering no longer JSON-dumps relation payloads.
+- [ ] Existing row-click detail navigation and `LinkedRecordsPanel` navigation still behave correctly after the new helper(s) land.
+- [ ] Calendar layouts remain unchanged.
+- [ ] `bun check` passes.
+- [ ] `bun typecheck` passes.
+- [ ] `bunx convex codegen` passes.
+- [ ] Automated tests cover backend relation hydration and frontend inline expansion/navigation for at least one dedicated entity and one fallback entity.
+
+## Agent Instructions
+- Keep this file current as work progresses.
+- Do not mark an item complete unless code, tests, and validation support it.
+- If an item is blocked or inapplicable, note the reason directly under the item.
+
+## Test Coverage Expectations
+- [ ] Unit tests added or updated where backend or domain logic changed
+- [ ] E2E tests added or updated where an operator or user workflow changed
+- [ ] Storybook stories added or updated where reusable UI changed
+  Storybook is likely not appropriate for this issue because the reusable behavior is primarily stateful relation-cell interaction already covered by component tests unless a new standalone presentational primitive materially benefits from story coverage.
+
+## Final Validation
+- [ ] All requirements are satisfied
+- [ ] All definition-of-done items are satisfied
+- [ ] Required quality gates passed
+- [ ] Test coverage expectations were met or explicitly justified

--- a/specs/ENG-276/summary.md
+++ b/specs/ENG-276/summary.md
@@ -1,0 +1,27 @@
+# Summary: ENG-276 - View Engine — Relation Cells, Inline Expansion, and Cross-Entity Navigation
+
+- Source issue: https://linear.app/fairlend/issue/ENG-276/view-engine-relation-cells-inline-expansion-and-cross-entity
+- Primary plan: https://www.notion.so/343fc1b4402481e7bf4ee591c48aa401
+- Supporting docs:
+  - https://www.notion.so/336fc1b4402481eba141c9c8cf17a600
+  - https://www.notion.so/341fc1b440248134b191da5114d9875b
+  - https://www.notion.so/341fc1b4402481599b9feebaa5801f61
+
+## Scope
+- Add a typed relation cell payload to the shared CRM view-engine row contract.
+- Hydrate relation-backed field values in backend table and kanban queries without changing calendar behavior.
+- Render relation chips for single and multi-relation cells in table and kanban surfaces with inline expansion for multi-value overflow.
+- Reuse shared sidebar/detail navigation with full-page fallback for relation chip clicks.
+- Render structured relation payloads meaningfully in generic detail sections instead of JSON-dumping them.
+- Add backend and frontend tests for relation hydration, single-open inline expansion, and navigation fallback behavior.
+
+## Constraints
+- Reuse the shared admin view surfaces from `ENG-275` and the shared detail surface from `ENG-279`; do not create route-local relation behavior.
+- Keep calendar views and calendar query contracts unchanged.
+- Only one relation cell expansion may be open per rendered surface in MVP.
+- No new `any` types.
+- `bun check`, `bun typecheck`, and `bunx convex codegen` are required quality gates.
+- GitNexus MCP/CLI is unavailable in this session, so pre-edit impact analysis uses direct caller/import sweeps as the fallback safety check.
+
+## Open questions
+- None blocking. For high-cardinality relation cells, cap the visible expanded list in MVP rather than attempting virtualization.

--- a/specs/ENG-276/tasks.md
+++ b/specs/ENG-276/tasks.md
@@ -1,0 +1,22 @@
+# Tasks: ENG-276 - View Engine — Relation Cells, Inline Expansion, and Cross-Entity Navigation
+
+## Phase 1: Backend Relation Contract
+- [ ] T-001: Add shared relation cell payload types to `convex/crm/types.ts` and update the row/cell model to carry typed relation values.
+- [ ] T-002: Reuse or extract linked-record label/object resolution helpers so relation-backed view fields can hydrate consistent `recordId` / `recordKind` / `objectDefId` / `label` items.
+- [ ] T-003: Update `convex/crm/viewQueries.ts` and any supporting helpers in `viewState.ts` / `recordQueries.ts` so table and kanban results emit cell-ready relation payloads while leaving calendar behavior unchanged.
+- [ ] T-004: Add backend test coverage in `convex/crm/__tests__/viewEngine.test.ts` for relation hydration on at least one dedicated entity and one fallback entity.
+
+## Phase 2: Shared Admin Relation UI
+- [ ] T-005: Update frontend admin view result types to consume typed row/cell payloads instead of only `UnifiedRecord.fields`.
+- [ ] T-006: Create a shared relation-cell component with collapsed truncation, inline expansion, and surface-owned single-open state.
+- [ ] T-007: Add a shared relation navigation helper that prefers sidebar stack navigation and falls back to the correct dedicated or generic full-page route.
+- [ ] T-008: Wire `AdminEntityTableView` and `AdminEntityKanbanView` to the new relation-cell rendering and navigation behavior without breaking row-click selection.
+- [ ] T-009: Update generic detail rendering (`FieldRenderer` and any related detail helpers) so relation payloads render as relation UI rather than raw JSON.
+
+## Phase 3: Validation And Regression Coverage
+- [ ] T-010: Add frontend component/unit coverage for inline expansion, one-open-at-a-time behavior, and relation navigation fallback.
+- [ ] T-011: Run `bun check`.
+- [ ] T-012: Run `bun typecheck`.
+- [ ] T-013: Run `bunx convex codegen`.
+- [ ] T-014: Run targeted tests for touched backend and admin-shell scope.
+- [ ] T-015: Reconcile the final change scope against the planned backend/frontend touchpoints using `git diff` plus the fallback caller sweep because GitNexus is unavailable.

--- a/src/components/admin/shell/AdminEntityKanbanView.tsx
+++ b/src/components/admin/shell/AdminEntityKanbanView.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Layers3 } from "lucide-react";
-import { type ReactNode, useState } from "react";
+import { type KeyboardEvent, type ReactNode, useState } from "react";
 import { Badge } from "#/components/ui/badge";
 import { useAdminRelationNavigation } from "#/hooks/useAdminRelationNavigation";
 import type { Doc } from "../../../../convex/_generated/dataModel";
@@ -50,7 +50,7 @@ export function AdminEntityKanbanView({
 		fields.map((field) => [field.name, field] as const)
 	);
 	const handleSelectableCardKeyDown = (
-		event: React.KeyboardEvent<HTMLDivElement>,
+		event: KeyboardEvent<HTMLDivElement>,
 		recordId: string
 	) => {
 		if (!onSelectRecord || event.target !== event.currentTarget) {

--- a/src/components/admin/shell/AdminEntityKanbanView.tsx
+++ b/src/components/admin/shell/AdminEntityKanbanView.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { Layers3 } from "lucide-react";
+import { type ReactNode, useState } from "react";
 import { Badge } from "#/components/ui/badge";
-import { Button } from "#/components/ui/button";
-import { cn } from "#/lib/utils";
+import { useAdminRelationNavigation } from "#/hooks/useAdminRelationNavigation";
 import type { Doc } from "../../../../convex/_generated/dataModel";
 import type {
 	EntityViewAdapterContract,
@@ -15,6 +15,7 @@ import {
 	renderAdminFieldValue,
 } from "./admin-view-rendering";
 import type { AdminKanbanGroup, AdminViewColumn } from "./admin-view-types";
+import { isRelationCellDisplayValue, RelationCell } from "./RelationCell";
 
 type ObjectDef = Pick<Doc<"objectDefs">, "nativeTable" | "singularLabel">;
 
@@ -35,6 +36,12 @@ export function AdminEntityKanbanView({
 	objectDef,
 	onSelectRecord,
 }: AdminEntityKanbanViewProps) {
+	const navigateRelation = useAdminRelationNavigation({
+		presentation: "sheet",
+	});
+	const [expandedRelationCellKey, setExpandedRelationCellKey] = useState<
+		string | null
+	>(null);
 	const previewColumns = columns
 		.filter((column) => column.isVisible)
 		.sort((left, right) => left.displayOrder - right.displayOrder)
@@ -42,6 +49,21 @@ export function AdminEntityKanbanView({
 	const fieldsByName = new Map(
 		fields.map((field) => [field.name, field] as const)
 	);
+	const handleSelectableCardKeyDown = (
+		event: React.KeyboardEvent<HTMLDivElement>,
+		recordId: string
+	) => {
+		if (!onSelectRecord || event.target !== event.currentTarget) {
+			return;
+		}
+
+		if (event.key !== "Enter" && event.key !== " ") {
+			return;
+		}
+
+		event.preventDefault();
+		onSelectRecord(recordId);
+	};
 
 	return (
 		<div className="overflow-x-auto pb-2">
@@ -71,64 +93,120 @@ export function AdminEntityKanbanView({
 								</div>
 							) : null}
 
-							{group.records.map((record) => (
-								<Button
-									className={cn(
-										"h-auto w-full flex-col items-start gap-3 rounded-2xl border border-border/70 bg-background/90 p-4 text-left text-foreground shadow-sm hover:bg-background"
-									)}
-									key={record._id}
-									onClick={() => onSelectRecord?.(record._id)}
-									variant="ghost"
-								>
-									<div className="flex w-full items-start justify-between gap-3">
-										<div className="space-y-1">
-											<p className="font-medium text-sm">
-												{getAdminRecordTitle({
-													adapterContract,
-													fields,
-													record,
-												})}
-											</p>
-											<p className="text-muted-foreground text-xs">
-												{getAdminRecordSupportingText(record, objectDef)}
-											</p>
+							{group.rows.map((row) => {
+								const cardBody = (
+									<>
+										<div className="flex w-full items-start justify-between gap-3">
+											<div className="space-y-1">
+												<p className="font-medium text-sm">
+													{getAdminRecordTitle({
+														adapterContract,
+														fields,
+														record: row.record,
+													})}
+												</p>
+												<p className="text-muted-foreground text-xs">
+													{getAdminRecordSupportingText(row.record, objectDef)}
+												</p>
+											</div>
+											<Badge
+												variant={
+													row.record._kind === "native"
+														? "secondary"
+														: "outline"
+												}
+											>
+												{row.record._kind === "native" ? "Native" : "EAV"}
+											</Badge>
 										</div>
-										<Badge
-											variant={
-												record._kind === "native" ? "secondary" : "outline"
-											}
-										>
-											{record._kind === "native" ? "Native" : "EAV"}
-										</Badge>
-									</div>
 
-									<div className="grid w-full gap-2">
-										{previewColumns.map((column) => {
-											const field = fieldsByName.get(column.name);
-											if (!field) {
-												return null;
-											}
+										<div className="grid w-full gap-2">
+											{previewColumns.map((column) => {
+												const field = fieldsByName.get(column.name);
+												const cell = row.cells.find(
+													(candidate) => candidate.fieldName === column.name
+												);
+												let cellContent: ReactNode;
 
-											return (
-												<div
-													className="flex items-center justify-between gap-3 rounded-xl border border-border/60 bg-muted/20 px-3 py-2"
-													key={`${group.groupId}-${record._id}-${column.fieldDefId}`}
-												>
-													<span className="text-muted-foreground text-xs">
-														{column.label}
-													</span>
-													<div className="max-w-[60%] truncate text-right text-sm">
-														{renderAdminFieldValue(
-															field,
-															record.fields[column.name]
-														)}
+												if (field && cell) {
+													const cellKey = `${row.record._id}:${column.name}`;
+													const relationDisplayValue =
+														isRelationCellDisplayValue(cell.displayValue)
+															? cell.displayValue
+															: null;
+
+													cellContent = relationDisplayValue ? (
+														<RelationCell
+															className="justify-end"
+															expanded={expandedRelationCellKey === cellKey}
+															onExpandedChange={(nextExpanded) => {
+																setExpandedRelationCellKey(
+																	nextExpanded ? cellKey : null
+																);
+															}}
+															onNavigate={navigateRelation}
+															value={relationDisplayValue}
+														/>
+													) : (
+														<div className="truncate">
+															{renderAdminFieldValue(
+																field,
+																cell.displayValue?.kind === "scalar"
+																	? cell.displayValue.value
+																	: cell.value
+															)}
+														</div>
+													);
+												} else {
+													cellContent = (
+														<span className="text-muted-foreground">—</span>
+													);
+												}
+
+												return (
+													<div
+														className="flex items-center justify-between gap-3 rounded-xl border border-border/60 bg-muted/20 px-3 py-2"
+														key={`${group.groupId}-${row.record._id}-${column.fieldDefId}`}
+													>
+														<span className="text-muted-foreground text-xs">
+															{column.label}
+														</span>
+														<div className="max-w-[60%] text-right text-sm">
+															{cellContent}
+														</div>
 													</div>
-												</div>
-											);
-										})}
+												);
+											})}
+										</div>
+									</>
+								);
+
+								if (!onSelectRecord) {
+									return (
+										<div
+											className="flex h-auto w-full flex-col items-start gap-3 rounded-2xl border border-border/70 bg-background/90 p-4 text-left text-foreground shadow-sm"
+											key={row.record._id}
+										>
+											{cardBody}
+										</div>
+									);
+								}
+
+								return (
+									<div
+										className="flex h-auto w-full cursor-pointer flex-col items-start gap-3 rounded-2xl border border-border/70 bg-background/90 p-4 text-left text-foreground shadow-sm hover:bg-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+										key={row.record._id}
+										onClick={() => onSelectRecord(row.record._id)}
+										onKeyDown={(event) =>
+											handleSelectableCardKeyDown(event, row.record._id)
+										}
+										role="button"
+										tabIndex={0}
+									>
+										{cardBody}
 									</div>
-								</Button>
-							))}
+								);
+							})}
 						</div>
 					</section>
 				))}

--- a/src/components/admin/shell/AdminEntityTableView.tsx
+++ b/src/components/admin/shell/AdminEntityTableView.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { type ReactNode, useState } from "react";
 import { Badge } from "#/components/ui/badge";
 import {
 	Table,
@@ -9,12 +10,13 @@ import {
 	TableHeader,
 	TableRow,
 } from "#/components/ui/table";
+import { useAdminRelationNavigation } from "#/hooks/useAdminRelationNavigation";
 import { cn } from "#/lib/utils";
 import type { Doc } from "../../../../convex/_generated/dataModel";
 import type {
 	EntityViewAdapterContract,
+	EntityViewRow,
 	NormalizedFieldDefinition,
-	UnifiedRecord,
 } from "../../../../convex/crm/types";
 import {
 	getAdminRecordSupportingText,
@@ -22,6 +24,7 @@ import {
 	renderAdminFieldValue,
 } from "./admin-view-rendering";
 import type { AdminViewColumn } from "./admin-view-types";
+import { isRelationCellDisplayValue, RelationCell } from "./RelationCell";
 
 type ObjectDef = Pick<Doc<"objectDefs">, "nativeTable" | "singularLabel">;
 
@@ -31,7 +34,7 @@ interface AdminEntityTableViewProps {
 	readonly fields: readonly NormalizedFieldDefinition[];
 	readonly objectDef: ObjectDef;
 	readonly onSelectRecord?: (recordId: string) => void;
-	readonly rows: readonly UnifiedRecord[];
+	readonly rows: readonly EntityViewRow[];
 }
 
 export function AdminEntityTableView({
@@ -42,6 +45,12 @@ export function AdminEntityTableView({
 	onSelectRecord,
 	rows,
 }: AdminEntityTableViewProps) {
+	const navigateRelation = useAdminRelationNavigation({
+		presentation: "sheet",
+	});
+	const [expandedRelationCellKey, setExpandedRelationCellKey] = useState<
+		string | null
+	>(null);
 	const visibleColumns = columns
 		.filter((column) => column.isVisible)
 		.sort((left, right) => left.displayOrder - right.displayOrder);
@@ -52,7 +61,7 @@ export function AdminEntityTableView({
 		event: React.KeyboardEvent<HTMLTableRowElement>,
 		recordId: string
 	) => {
-		if (!onSelectRecord) {
+		if (!onSelectRecord || event.target !== event.currentTarget) {
 			return;
 		}
 
@@ -76,16 +85,16 @@ export function AdminEntityTableView({
 					</TableRow>
 				</TableHeader>
 				<TableBody>
-					{rows.map((record) => (
+					{rows.map((row) => (
 						<TableRow
 							className={cn(
 								onSelectRecord &&
 									"cursor-pointer hover:bg-muted/40 focus-visible:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
 							)}
-							key={record._id}
-							onClick={() => onSelectRecord?.(record._id)}
+							key={row.record._id}
+							onClick={() => onSelectRecord?.(row.record._id)}
 							onKeyDown={(event) =>
-								handleSelectableRowKeyDown(event, record._id)
+								handleSelectableRowKeyDown(event, row.record._id)
 							}
 							role={onSelectRecord ? "button" : undefined}
 							tabIndex={onSelectRecord ? 0 : undefined}
@@ -97,38 +106,73 @@ export function AdminEntityTableView({
 											{getAdminRecordTitle({
 												adapterContract,
 												fields,
-												record,
+												record: row.record,
 											})}
 										</p>
 										<Badge
 											variant={
-												record._kind === "native" ? "secondary" : "outline"
+												row.record._kind === "native" ? "secondary" : "outline"
 											}
 										>
-											{record._kind === "native"
+											{row.record._kind === "native"
 												? "Native Adapter"
 												: "EAV Storage"}
 										</Badge>
 									</div>
 									<p className="text-muted-foreground text-xs">
-										{getAdminRecordSupportingText(record, objectDef)}
+										{getAdminRecordSupportingText(row.record, objectDef)}
 									</p>
 								</div>
 							</TableCell>
 							{visibleColumns.map((column) => {
 								const field = fieldsByName.get(column.name);
+								const cell = row.cells.find(
+									(candidate) => candidate.fieldName === column.name
+								);
+								const cellKey = `${row.record._id}:${column.name}`;
+								const relationDisplayValue = isRelationCellDisplayValue(
+									cell?.displayValue
+								)
+									? cell.displayValue
+									: null;
+								let cellContent: ReactNode;
+
+								if (!(field && cell)) {
+									cellContent = (
+										<span className="text-muted-foreground">—</span>
+									);
+								} else if (relationDisplayValue) {
+									cellContent = (
+										<RelationCell
+											expanded={expandedRelationCellKey === cellKey}
+											onExpandedChange={(nextExpanded) => {
+												setExpandedRelationCellKey(
+													nextExpanded ? cellKey : null
+												);
+											}}
+											onNavigate={navigateRelation}
+											value={relationDisplayValue}
+										/>
+									);
+								} else {
+									cellContent = (
+										<div className="truncate">
+											{renderAdminFieldValue(
+												field,
+												cell.displayValue?.kind === "scalar"
+													? cell.displayValue.value
+													: cell.value
+											)}
+										</div>
+									);
+								}
+
 								return (
 									<TableCell
 										className="align-top"
-										key={`${record._id}-${column.fieldDefId}`}
+										key={`${row.record._id}-${column.fieldDefId}`}
 									>
-										<div className="max-w-[220px] truncate text-sm">
-											{field ? (
-												renderAdminFieldValue(field, record.fields[column.name])
-											) : (
-												<span className="text-muted-foreground">—</span>
-											)}
-										</div>
+										<div className="max-w-[220px] text-sm">{cellContent}</div>
 									</TableCell>
 								);
 							})}

--- a/src/components/admin/shell/AdminEntityTableView.tsx
+++ b/src/components/admin/shell/AdminEntityTableView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { type ReactNode, useState } from "react";
+import { type KeyboardEvent, type ReactNode, useState } from "react";
 import { Badge } from "#/components/ui/badge";
 import {
 	Table,
@@ -58,7 +58,7 @@ export function AdminEntityTableView({
 		fields.map((field) => [field.name, field] as const)
 	);
 	const handleSelectableRowKeyDown = (
-		event: React.KeyboardEvent<HTMLTableRowElement>,
+		event: KeyboardEvent<HTMLTableRowElement>,
 		recordId: string
 	) => {
 		if (!onSelectRecord || event.target !== event.currentTarget) {

--- a/src/components/admin/shell/AdminEntityViewPage.tsx
+++ b/src/components/admin/shell/AdminEntityViewPage.tsx
@@ -478,8 +478,8 @@ export function AdminEntityViewPage({
 			: (tableResult?.totalCountExact ?? true);
 	const activeRows =
 		activeViewMode === "kanban"
-			? (kanbanResult?.groups.flatMap((group) => group.records) ?? [])
-			: (tableResult?.rows ?? []);
+			? (kanbanResult?.groups.flatMap((group) => group.rows) ?? [])
+			: (tableResult?.page.rows ?? []);
 	const activeCountLabel =
 		activeViewMode === "kanban"
 			? `${activeTotalCount}${activeCountExact ? "" : "+"} grouped records`
@@ -537,7 +537,7 @@ export function AdminEntityViewPage({
 						fields={schema.fields}
 						objectDef={objectDef}
 						onSelectRecord={(recordId) => open(recordId)}
-						rows={tableResult.rows}
+						rows={tableResult.page.rows}
 					/>
 					{tableResult.totalCount > RECORD_PAGE_SIZE ? (
 						<div className="flex flex-col gap-3 rounded-2xl border border-border/70 bg-muted/10 px-4 py-3 text-sm lg:flex-row lg:items-center lg:justify-between">
@@ -549,7 +549,7 @@ export function AdminEntityViewPage({
 									Showing records{" "}
 									{tablePagination.pageIndex * RECORD_PAGE_SIZE + 1}-
 									{tablePagination.pageIndex * RECORD_PAGE_SIZE +
-										tableResult.rows.length}{" "}
+										tableResult.page.rows.length}{" "}
 									of {tableResult.totalCount}
 									{tableResult.totalCountExact ? "." : "+."}
 								</p>

--- a/src/components/admin/shell/FieldRenderer.tsx
+++ b/src/components/admin/shell/FieldRenderer.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Badge } from "#/components/ui/badge";
+import type { AdminRelationNavigationTarget } from "#/lib/admin-relation-navigation";
 import { cn } from "#/lib/utils";
 import type { Doc } from "../../../../convex/_generated/dataModel";
 import type { NormalizedFieldDefinition } from "../../../../convex/crm/types";
@@ -12,6 +13,7 @@ import {
 	SelectCell,
 	TextCell,
 } from "./cell-renderers";
+import { isRelationCellDisplayValue, RelationCell } from "./RelationCell";
 
 type FieldType = Doc<"fieldDefs">["fieldType"];
 
@@ -20,6 +22,7 @@ export interface FieldRendererProps {
 	readonly field?: NormalizedFieldDefinition;
 	readonly fieldType?: FieldType;
 	readonly label?: string;
+	readonly onNavigateRelation?: (target: AdminRelationNavigationTarget) => void;
 	readonly value: unknown;
 }
 
@@ -28,6 +31,7 @@ export function FieldRenderer({
 	field,
 	fieldType,
 	label,
+	onNavigateRelation,
 	value,
 }: FieldRendererProps) {
 	const resolvedFieldType = field?.fieldType ?? fieldType;
@@ -47,7 +51,12 @@ export function FieldRenderer({
 				) : null}
 			</div>
 			<div className="min-h-6">
-				{renderFieldValue({ field, fieldType: resolvedFieldType, value })}
+				{renderFieldValue({
+					field,
+					fieldType: resolvedFieldType,
+					onNavigateRelation,
+					value,
+				})}
 			</div>
 			{field?.description ? (
 				<p className="text-muted-foreground text-xs">{field.description}</p>
@@ -104,8 +113,21 @@ function getArrayItemKey(item: unknown, seenKeys: Map<string, number>): string {
 function renderFieldValue(args: {
 	field: NormalizedFieldDefinition | undefined;
 	fieldType: FieldType | undefined;
+	onNavigateRelation?: (target: AdminRelationNavigationTarget) => void;
 	value: unknown;
 }) {
+	if (isRelationCellDisplayValue(args.value)) {
+		return (
+			<RelationCell
+				allowToggle={false}
+				expanded
+				onNavigate={args.onNavigateRelation}
+				value={args.value}
+				variant="detail"
+			/>
+		);
+	}
+
 	if (args.value === null || args.value === undefined || args.value === "") {
 		return <p className="text-muted-foreground text-sm">No value</p>;
 	}

--- a/src/components/admin/shell/LinkedRecordsPanel.tsx
+++ b/src/components/admin/shell/LinkedRecordsPanel.tsx
@@ -26,6 +26,7 @@ import {
 	CollapsibleContent,
 	CollapsibleTrigger,
 } from "#/components/ui/collapsible";
+import type { AdminRelationNavigationTarget } from "#/lib/admin-relation-navigation";
 import { cn } from "#/lib/utils";
 import { api } from "../../../../convex/_generated/api";
 import type { Id } from "../../../../convex/_generated/dataModel";
@@ -36,11 +37,7 @@ import { EntityIcon } from "./entity-icon";
 
 interface LinkedRecordsPanelProps {
 	objectDefId: Id<"objectDefs">;
-	onNavigate?: (
-		recordId: string,
-		recordKind: "record" | "native",
-		objectDefId: string
-	) => void;
+	onNavigate?: (target: AdminRelationNavigationTarget) => void;
 	recordId: string;
 	recordKind: "record" | "native";
 }
@@ -265,11 +262,7 @@ interface LinkGroupSectionProps {
 		}
 	>;
 	onAddLink: () => void;
-	onNavigate?: (
-		recordId: string,
-		recordKind: "record" | "native",
-		objectDefId: string
-	) => void;
+	onNavigate?: (target: AdminRelationNavigationTarget) => void;
 	onRemoveLink: (linkId: Id<"recordLinks">) => void;
 }
 
@@ -346,11 +339,7 @@ interface LinkedRecordItemProps {
 		singularLabel: string;
 	};
 	objectDefId: Id<"objectDefs">;
-	onNavigate?: (
-		recordId: string,
-		recordKind: "record" | "native",
-		objectDefId: string
-	) => void;
+	onNavigate?: (target: AdminRelationNavigationTarget) => void;
 	onRemove: (linkId: Id<"recordLinks">) => void;
 	recordId: string;
 	recordKind: "record" | "native";
@@ -371,7 +360,11 @@ function LinkedRecordItem({
 			<button
 				className="flex min-w-0 flex-1 items-center gap-2 text-left"
 				onClick={() =>
-					onNavigate?.(recordId, recordKind, objectDefId as string)
+					onNavigate?.({
+						objectDefId: String(objectDefId),
+						recordId,
+						recordKind,
+					})
 				}
 				type="button"
 			>

--- a/src/components/admin/shell/RecordSidebar.tsx
+++ b/src/components/admin/shell/RecordSidebar.tsx
@@ -16,11 +16,9 @@ import { Badge } from "#/components/ui/badge";
 import { Button } from "#/components/ui/button";
 import { Sheet, SheetContent, SheetHeader } from "#/components/ui/sheet";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "#/components/ui/tabs";
+import { useAdminRelationNavigation } from "#/hooks/useAdminRelationNavigation";
 import { EMPTY_ADMIN_DETAIL_SEARCH } from "#/lib/admin-detail-search";
-import {
-	getDedicatedAdminRecordRoute,
-	isDedicatedAdminEntityType,
-} from "#/lib/admin-entity-routes";
+import { resolveAdminRecordRouteTarget } from "#/lib/admin-relation-navigation";
 import { cn } from "#/lib/utils";
 import { api } from "../../../../convex/_generated/api";
 import type { Doc } from "../../../../convex/_generated/dataModel";
@@ -117,7 +115,6 @@ export function AdminRecordDetailSurface({
 	reference,
 	variant,
 }: RecordDetailSurfaceProps) {
-	const { push } = useRecordSidebar();
 	const objectDefs = useQuery(api.crm.objectDefs.listObjects);
 
 	const fallbackObjectDef = useMemo(
@@ -162,28 +159,19 @@ export function AdminRecordDetailSurface({
 			}),
 		[adapters, adapterContract?.detailSurfaceKey, objectDef, resolvedEntityType]
 	);
-	const fullPageTarget = useMemo(() => {
-		if (!resolvedEntityType) {
-			return null;
-		}
-
-		if (isDedicatedAdminEntityType(resolvedEntityType)) {
-			return {
-				to: getDedicatedAdminRecordRoute(resolvedEntityType),
-				params: {
-					recordid: reference.recordId,
-				},
-			} as const;
-		}
-
-		return {
-			to: "/admin/$entitytype/$recordid" as const,
-			params: {
-				entitytype: resolvedEntityType,
-				recordid: reference.recordId,
-			},
-		} as const;
-	}, [reference.recordId, resolvedEntityType]);
+	const fullPageTarget = useMemo(
+		() =>
+			resolvedEntityType
+				? resolveAdminRecordRouteTarget({
+						entityType: resolvedEntityType,
+						recordId: reference.recordId,
+					})
+				: null,
+		[reference.recordId, resolvedEntityType]
+	);
+	const navigateRelation = useAdminRelationNavigation({
+		presentation: variant === "sheet" ? "sheet" : "page",
+	});
 
 	const title =
 		adapter?.getRecordTitle?.({
@@ -320,6 +308,7 @@ export function AdminRecordDetailSurface({
 							fields={detailFields}
 							isLoading={shouldLoadLiveRecord && detailSurface === undefined}
 							objectDef={objectDef}
+							onNavigateRelation={navigateRelation}
 							record={record}
 							recordId={reference.recordId}
 						/>
@@ -329,21 +318,7 @@ export function AdminRecordDetailSurface({
 						{objectDef && record ? (
 							<LinkedRecordsPanel
 								objectDefId={objectDef._id}
-								onNavigate={(recordId, linkedRecordKind, linkedObjectDefId) => {
-									push({
-										entityType: objectDefs
-											? getAdminEntityForObjectDef(
-													objectDefs.find(
-														(candidate) =>
-															String(candidate._id) === linkedObjectDefId
-													) ?? {}
-												)?.entityType
-											: undefined,
-										objectDefId: linkedObjectDefId,
-										recordId,
-										recordKind: linkedRecordKind,
-									});
-								}}
+								onNavigate={navigateRelation}
 								recordId={record._id}
 								recordKind={record._kind}
 							/>
@@ -435,6 +410,7 @@ function DetailsTab({
 	entity,
 	fields,
 	isLoading,
+	onNavigateRelation,
 	objectDef,
 	record,
 	recordId,
@@ -444,6 +420,9 @@ function DetailsTab({
 	readonly entity: ReturnType<typeof getAdminEntityByType> | undefined;
 	readonly fields: readonly DetailField[] | undefined;
 	readonly isLoading: boolean;
+	readonly onNavigateRelation: Parameters<
+		typeof FieldRenderer
+	>[0]["onNavigateRelation"];
 	readonly objectDef: ObjectDef | undefined;
 	readonly record: RecordDetailRecord | undefined;
 	readonly recordId: string;
@@ -524,6 +503,7 @@ function DetailsTab({
 				<FieldRenderer
 					field={field}
 					key={field.name}
+					onNavigateRelation={onNavigateRelation}
 					value={record.fields[field.name]}
 				/>
 			))}

--- a/src/components/admin/shell/RecordSidebar.tsx
+++ b/src/components/admin/shell/RecordSidebar.tsx
@@ -551,7 +551,16 @@ function resolveObjectDef(
 	const entity = reference.entityType
 		? getAdminEntityByType(reference.entityType)
 		: undefined;
-	if (!entity) {
+	const entityCandidates = entity
+		? normalizeCandidateStrings([
+				entity.entityType,
+				entity.tableName,
+				entity.singularLabel,
+				entity.pluralLabel,
+			])
+		: normalizeCandidateStrings([reference.entityType]);
+
+	if (entityCandidates.length === 0) {
 		return undefined;
 	}
 
@@ -561,13 +570,6 @@ function resolveObjectDef(
 			objectDef.nativeTable,
 			objectDef.singularLabel,
 			objectDef.pluralLabel,
-		]);
-
-		const entityCandidates = normalizeCandidateStrings([
-			entity.entityType,
-			entity.tableName,
-			entity.singularLabel,
-			entity.pluralLabel,
 		]);
 
 		return entityCandidates.some((candidate) => candidates.includes(candidate));

--- a/src/components/admin/shell/RecordSidebarProvider.tsx
+++ b/src/components/admin/shell/RecordSidebarProvider.tsx
@@ -124,3 +124,7 @@ export function useRecordSidebar() {
 
 	return context;
 }
+
+export function useOptionalRecordSidebar() {
+	return useContext(RecordSidebarContext);
+}

--- a/src/components/admin/shell/RelationCell.tsx
+++ b/src/components/admin/shell/RelationCell.tsx
@@ -62,14 +62,18 @@ export function RelationCell({
 		);
 	}
 
-	const visibleItems = expanded
-		? value.items.slice(0, MAX_EXPANDED_ITEMS)
-		: value.items.slice(0, COLLAPSED_VISIBLE_ITEMS);
-	const hiddenItemCount = expanded
-		? Math.max(0, value.items.length - visibleItems.length)
-		: value.items.length - visibleItems.length;
 	const showToggle =
 		allowToggle && value.items.length > COLLAPSED_VISIBLE_ITEMS;
+	const visibleItems = showToggle
+		? expanded
+			? value.items.slice(0, MAX_EXPANDED_ITEMS)
+			: value.items.slice(0, COLLAPSED_VISIBLE_ITEMS)
+		: value.items;
+	const hiddenItemCount = showToggle
+		? expanded
+			? Math.max(0, value.items.length - visibleItems.length)
+			: value.items.length - visibleItems.length
+		: 0;
 
 	return (
 		<div
@@ -79,28 +83,48 @@ export function RelationCell({
 				className
 			)}
 		>
-			{visibleItems.map((item) => (
-				<button
-					className={cn(
-						"inline-flex max-w-full items-center gap-1 rounded-full border border-border/70 bg-muted/20 px-2.5 py-1 font-medium text-foreground text-xs transition-colors hover:border-primary/40 hover:bg-muted/50",
-						variant === "detail" && "px-3 py-1.5 text-sm"
-					)}
-					key={`${item.recordKind}:${item.recordId}`}
-					onClick={(event) => {
-						stopEvent(event);
-						onNavigate?.(toNavigationTarget(item));
-					}}
-					type="button"
-				>
-					<Link2
-						className={cn(
-							"size-3 text-muted-foreground",
-							variant === "detail" && "size-3.5"
-						)}
-					/>
-					<span className="truncate">{item.label}</span>
-				</button>
-			))}
+			{visibleItems.map((item) => {
+				const content = (
+					<>
+						<Link2
+							className={cn(
+								"size-3 text-muted-foreground",
+								variant === "detail" && "size-3.5"
+							)}
+						/>
+						<span className="truncate">{item.label}</span>
+					</>
+				);
+				const itemClassName = cn(
+					"inline-flex max-w-full items-center gap-1 rounded-full border border-border/70 bg-muted/20 px-2.5 py-1 font-medium text-foreground text-xs",
+					onNavigate &&
+						"transition-colors hover:border-primary/40 hover:bg-muted/50",
+					variant === "detail" && "px-3 py-1.5 text-sm"
+				);
+				const itemKey = `${item.objectDefId}:${item.recordKind}:${item.recordId}`;
+
+				if (!onNavigate) {
+					return (
+						<span className={itemClassName} key={itemKey}>
+							{content}
+						</span>
+					);
+				}
+
+				return (
+					<button
+						className={itemClassName}
+						key={itemKey}
+						onClick={(event) => {
+							stopEvent(event);
+							onNavigate(toNavigationTarget(item));
+						}}
+						type="button"
+					>
+						{content}
+					</button>
+				);
+			})}
 
 			{!expanded && hiddenItemCount > 0 ? (
 				<button

--- a/src/components/admin/shell/RelationCell.tsx
+++ b/src/components/admin/shell/RelationCell.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { ChevronDown, ChevronUp, Link2 } from "lucide-react";
+import type { MouseEvent } from "react";
+import type { AdminRelationNavigationTarget } from "#/lib/admin-relation-navigation";
+import { cn } from "#/lib/utils";
+import type { RelationCellDisplayValue } from "../../../../convex/crm/types";
+
+const COLLAPSED_VISIBLE_ITEMS = 1;
+const MAX_EXPANDED_ITEMS = 12;
+
+export interface RelationCellProps {
+	allowToggle?: boolean;
+	className?: string;
+	expanded?: boolean;
+	onExpandedChange?: (nextExpanded: boolean) => void;
+	onNavigate?: (target: AdminRelationNavigationTarget) => void;
+	value: RelationCellDisplayValue;
+	variant?: "compact" | "detail";
+}
+
+export function isRelationCellDisplayValue(
+	value: unknown
+): value is RelationCellDisplayValue {
+	if (!value || typeof value !== "object") {
+		return false;
+	}
+
+	const candidate = value as Partial<RelationCellDisplayValue>;
+	return candidate.kind === "relation" && Array.isArray(candidate.items);
+}
+
+function stopEvent(event: MouseEvent<HTMLElement>) {
+	event.preventDefault();
+	event.stopPropagation();
+}
+
+function toNavigationTarget(
+	item: RelationCellDisplayValue["items"][number]
+): AdminRelationNavigationTarget {
+	return {
+		objectDefId: String(item.objectDefId),
+		recordId: item.recordId,
+		recordKind: item.recordKind,
+	};
+}
+
+export function RelationCell({
+	allowToggle = true,
+	className,
+	expanded = false,
+	onExpandedChange,
+	onNavigate,
+	value,
+	variant = "compact",
+}: RelationCellProps) {
+	if (value.items.length === 0) {
+		return (
+			<span className="text-muted-foreground text-sm">
+				{variant === "detail" ? "No linked records" : "—"}
+			</span>
+		);
+	}
+
+	const visibleItems = expanded
+		? value.items.slice(0, MAX_EXPANDED_ITEMS)
+		: value.items.slice(0, COLLAPSED_VISIBLE_ITEMS);
+	const hiddenItemCount = expanded
+		? Math.max(0, value.items.length - visibleItems.length)
+		: value.items.length - visibleItems.length;
+	const showToggle =
+		allowToggle && value.items.length > COLLAPSED_VISIBLE_ITEMS;
+
+	return (
+		<div
+			className={cn(
+				"flex flex-wrap items-center gap-1.5",
+				variant === "detail" && "gap-2",
+				className
+			)}
+		>
+			{visibleItems.map((item) => (
+				<button
+					className={cn(
+						"inline-flex max-w-full items-center gap-1 rounded-full border border-border/70 bg-muted/20 px-2.5 py-1 font-medium text-foreground text-xs transition-colors hover:border-primary/40 hover:bg-muted/50",
+						variant === "detail" && "px-3 py-1.5 text-sm"
+					)}
+					key={`${item.recordKind}:${item.recordId}`}
+					onClick={(event) => {
+						stopEvent(event);
+						onNavigate?.(toNavigationTarget(item));
+					}}
+					type="button"
+				>
+					<Link2
+						className={cn(
+							"size-3 text-muted-foreground",
+							variant === "detail" && "size-3.5"
+						)}
+					/>
+					<span className="truncate">{item.label}</span>
+				</button>
+			))}
+
+			{!expanded && hiddenItemCount > 0 ? (
+				<button
+					className={cn(
+						"inline-flex items-center gap-1 rounded-full border border-border/70 border-dashed px-2.5 py-1 text-muted-foreground text-xs transition-colors hover:border-primary/40 hover:text-foreground",
+						variant === "detail" && "px-3 py-1.5 text-sm"
+					)}
+					onClick={(event) => {
+						stopEvent(event);
+						onExpandedChange?.(true);
+					}}
+					type="button"
+				>
+					<span>+{hiddenItemCount} more</span>
+					{showToggle ? (
+						<ChevronDown
+							className={cn("size-3", variant === "detail" && "size-3.5")}
+						/>
+					) : null}
+				</button>
+			) : null}
+
+			{expanded && showToggle ? (
+				<button
+					className={cn(
+						"inline-flex items-center gap-1 rounded-full border border-border/70 border-dashed px-2.5 py-1 text-muted-foreground text-xs transition-colors hover:border-primary/40 hover:text-foreground",
+						variant === "detail" && "px-3 py-1.5 text-sm"
+					)}
+					onClick={(event) => {
+						stopEvent(event);
+						onExpandedChange?.(false);
+					}}
+					type="button"
+				>
+					<span>Show less</span>
+					<ChevronUp
+						className={cn("size-3", variant === "detail" && "size-3.5")}
+					/>
+				</button>
+			) : null}
+
+			{expanded && hiddenItemCount > 0 ? (
+				<span className="text-muted-foreground text-xs">
+					+{hiddenItemCount} more hidden
+				</span>
+			) : null}
+		</div>
+	);
+}

--- a/src/components/admin/shell/admin-view-types.ts
+++ b/src/components/admin/shell/admin-view-types.ts
@@ -4,14 +4,16 @@ import type {
 	EditabilityMetadata,
 	EffectiveViewDefinition,
 	EntityViewAdapterContract,
+	EntityViewPageResult,
+	EntityViewRow,
 	FieldLayoutEligibility,
 	FieldRendererHint,
 	NormalizedFieldDefinition,
 	NormalizedFieldKind,
 	RelationMetadata,
 	SystemViewDefinition,
-	UnifiedRecord,
 	UserSavedViewDefinition,
+	ViewAggregateResult,
 	ViewLayout,
 } from "../../../../convex/crm/types";
 
@@ -51,11 +53,13 @@ export interface AdminViewSchemaResult {
 
 export interface AdminTableQueryResult {
 	adapterContract: EntityViewAdapterContract;
+	aggregates: ViewAggregateResult[];
 	columns: AdminViewColumn[];
 	cursor: string | null;
 	fields: NormalizedFieldDefinition[];
 	needsRepair: boolean;
-	rows: UnifiedRecord[];
+	page: EntityViewPageResult;
+	rows: EntityViewRow["record"][];
 	totalCount: number;
 	totalCountExact: boolean;
 	truncated: boolean;
@@ -69,11 +73,13 @@ export interface AdminKanbanGroup {
 	groupId: Id<"viewKanbanGroups">;
 	isCollapsed: boolean;
 	label: string;
-	records: UnifiedRecord[];
+	records: EntityViewRow["record"][];
+	rows: EntityViewRow[];
 }
 
 export interface AdminKanbanQueryResult {
 	adapterContract: EntityViewAdapterContract;
+	aggregates: ViewAggregateResult[];
 	columns: AdminViewColumn[];
 	fields: NormalizedFieldDefinition[];
 	groups: AdminKanbanGroup[];

--- a/src/components/admin/shell/entity-registry.ts
+++ b/src/components/admin/shell/entity-registry.ts
@@ -282,6 +282,25 @@ export function getAdminEntityForObjectDef(objectDef: {
 		);
 	});
 }
+
+export function resolveAdminEntityTypeForObjectDef(objectDef: {
+	name?: string;
+	nativeTable?: string;
+	pluralLabel?: string;
+	singularLabel?: string;
+}) {
+	const registeredEntity = getAdminEntityForObjectDef(objectDef);
+	if (registeredEntity) {
+		return registeredEntity.entityType;
+	}
+
+	return normalizeCandidateStrings([
+		objectDef.nativeTable,
+		objectDef.name,
+		objectDef.singularLabel,
+	])[0];
+}
+
 export function getAdminEntityByPathname(pathname: string) {
 	const segments = pathname.split("/").filter(Boolean);
 	if (segments[0] !== "admin") {

--- a/src/hooks/useAdminRelationNavigation.ts
+++ b/src/hooks/useAdminRelationNavigation.ts
@@ -21,16 +21,6 @@ function navigateToRoute(
 	navigate: ReturnType<typeof useNavigate>,
 	target: AdminRecordRouteTarget
 ) {
-	if ("entitytype" in target.params) {
-		void navigate({
-			params: target.params,
-			search: target.search,
-			to: target.to,
-			viewTransition: true,
-		});
-		return;
-	}
-
 	void navigate({
 		params: target.params,
 		search: target.search,
@@ -45,8 +35,9 @@ export function useAdminRelationNavigation(
 	const navigate = useNavigate();
 	const objectDefs = useQuery(api.crm.objectDefs.listObjects);
 	const sidebar = useOptionalRecordSidebar();
-
-	return useCallback(
+	const canNavigateWithoutMetadata =
+		options.presentation === "sheet" && Boolean(sidebar?.push);
+	const navigateRelation = useCallback(
 		(target: AdminRelationNavigationTarget) => {
 			navigateToAdminRelation({
 				navigate: (routeTarget) => navigateToRoute(navigate, routeTarget),
@@ -65,4 +56,8 @@ export function useAdminRelationNavigation(
 			sidebar,
 		]
 	);
+
+	return objectDefs !== undefined || canNavigateWithoutMetadata
+		? navigateRelation
+		: undefined;
 }

--- a/src/hooks/useAdminRelationNavigation.ts
+++ b/src/hooks/useAdminRelationNavigation.ts
@@ -1,0 +1,68 @@
+"use client";
+
+import { useNavigate } from "@tanstack/react-router";
+import { useQuery } from "convex/react";
+import { useCallback } from "react";
+import { useOptionalRecordSidebar } from "#/components/admin/shell/RecordSidebarProvider";
+import {
+	type AdminRecordRouteTarget,
+	type AdminRelationNavigationTarget,
+	type AdminRelationPresentation,
+	navigateToAdminRelation,
+} from "#/lib/admin-relation-navigation";
+import { api } from "../../convex/_generated/api";
+
+interface UseAdminRelationNavigationOptions {
+	onBeforePageNavigation?: () => void;
+	presentation: AdminRelationPresentation;
+}
+
+function navigateToRoute(
+	navigate: ReturnType<typeof useNavigate>,
+	target: AdminRecordRouteTarget
+) {
+	if ("entitytype" in target.params) {
+		void navigate({
+			params: target.params,
+			search: target.search,
+			to: target.to,
+			viewTransition: true,
+		});
+		return;
+	}
+
+	void navigate({
+		params: target.params,
+		search: target.search,
+		to: target.to,
+		viewTransition: true,
+	});
+}
+
+export function useAdminRelationNavigation(
+	options: UseAdminRelationNavigationOptions
+) {
+	const navigate = useNavigate();
+	const objectDefs = useQuery(api.crm.objectDefs.listObjects);
+	const sidebar = useOptionalRecordSidebar();
+
+	return useCallback(
+		(target: AdminRelationNavigationTarget) => {
+			navigateToAdminRelation({
+				navigate: (routeTarget) => navigateToRoute(navigate, routeTarget),
+				objectDefs,
+				onBeforePageNavigation: options.onBeforePageNavigation,
+				presentation: options.presentation,
+				pushToSidebar: sidebar?.push,
+				target,
+			});
+		},
+		[
+			navigate,
+			objectDefs,
+			options.onBeforePageNavigation,
+			options.presentation,
+			sidebar,
+		]
+	);
+}

--- a/src/lib/admin-detail-route-state.ts
+++ b/src/lib/admin-detail-route-state.ts
@@ -1,4 +1,5 @@
 import { getAdminEntityByPathname } from "#/components/admin/shell/entity-registry";
+import { isReservedAdminRouteSegment } from "#/lib/admin-entities";
 
 export interface AdminDetailRouteState {
 	readonly detailOpen: boolean;
@@ -22,7 +23,22 @@ function decodePathSegment(value: string | undefined): string | undefined {
 export function getAdminDetailRouteState(
 	pathname: string
 ): AdminDetailRouteState {
-	const entityType = getAdminEntityByPathname(pathname)?.entityType;
+	const segments = pathname.split("/").filter(Boolean);
+	if (segments[0] !== "admin") {
+		return {
+			detailOpen: false,
+			entityType: undefined,
+			recordId: undefined,
+		};
+	}
+
+	const routeEntityType = getAdminEntityByPathname(pathname)?.entityType;
+	const pathEntityType = decodePathSegment(segments[1]);
+	const entityType =
+		routeEntityType ??
+		(pathEntityType && !isReservedAdminRouteSegment(pathEntityType)
+			? pathEntityType
+			: undefined);
 
 	if (!entityType) {
 		return {
@@ -32,11 +48,8 @@ export function getAdminDetailRouteState(
 		};
 	}
 
-	const segments = pathname.split("/").filter(Boolean);
 	const recordId =
-		segments[0] === "admin" && segments[1] === entityType
-			? decodePathSegment(segments[2])
-			: undefined;
+		pathEntityType === entityType ? decodePathSegment(segments[2]) : undefined;
 
 	return {
 		detailOpen: recordId !== undefined,

--- a/src/lib/admin-entities.ts
+++ b/src/lib/admin-entities.ts
@@ -11,6 +11,12 @@ export const ADMIN_ENTITY_TYPES = [
 
 export type AdminEntityType = (typeof ADMIN_ENTITY_TYPES)[number];
 
+export const RESERVED_ADMIN_ROUTE_SEGMENTS = [
+	"financial-ledger",
+	"payment-operations",
+	"underwriting",
+] as const;
+
 export const ADMIN_ENTITY_LABELS: Record<AdminEntityType, string> = {
 	borrowers: "Borrowers",
 	brokers: "Brokers",
@@ -24,4 +30,10 @@ export const ADMIN_ENTITY_LABELS: Record<AdminEntityType, string> = {
 
 export function isAdminEntityType(value: string): value is AdminEntityType {
 	return ADMIN_ENTITY_TYPES.includes(value as AdminEntityType);
+}
+
+export function isReservedAdminRouteSegment(value: string): boolean {
+	return RESERVED_ADMIN_ROUTE_SEGMENTS.includes(
+		value as (typeof RESERVED_ADMIN_ROUTE_SEGMENTS)[number]
+	);
 }

--- a/src/lib/admin-relation-navigation.ts
+++ b/src/lib/admin-relation-navigation.ts
@@ -1,4 +1,4 @@
-import { getAdminEntityForObjectDef } from "#/components/admin/shell/entity-registry";
+import { resolveAdminEntityTypeForObjectDef } from "#/components/admin/shell/entity-registry";
 import type { SidebarRecordRef } from "#/components/admin/shell/RecordSidebarProvider";
 import { EMPTY_ADMIN_DETAIL_SEARCH } from "#/lib/admin-detail-search";
 import {
@@ -46,7 +46,7 @@ export function resolveAdminRelationReference(args: {
 		(candidate) => String(candidate._id) === args.target.objectDefId
 	);
 	const entityType = objectDef
-		? getAdminEntityForObjectDef(objectDef)?.entityType
+		? resolveAdminEntityTypeForObjectDef(objectDef)
 		: undefined;
 
 	return {

--- a/src/lib/admin-relation-navigation.ts
+++ b/src/lib/admin-relation-navigation.ts
@@ -60,24 +60,26 @@ export function resolveAdminRelationReference(args: {
 export function resolveAdminRecordRouteTarget(
 	reference: Pick<SidebarRecordRef, "entityType" | "recordId">
 ): AdminRecordRouteTarget | null {
-	if (!reference.entityType) {
+	const entityType = reference.entityType?.trim();
+	const recordId = reference.recordId.trim();
+	if (!(entityType && recordId)) {
 		return null;
 	}
 
-	if (isDedicatedAdminEntityType(reference.entityType)) {
+	if (isDedicatedAdminEntityType(entityType)) {
 		return {
 			params: {
-				recordid: reference.recordId,
+				recordid: recordId,
 			},
 			search: EMPTY_ADMIN_DETAIL_SEARCH,
-			to: getDedicatedAdminRecordRoute(reference.entityType),
+			to: getDedicatedAdminRecordRoute(entityType),
 		};
 	}
 
 	return {
 		params: {
-			entitytype: reference.entityType,
-			recordid: reference.recordId,
+			entitytype: entityType,
+			recordid: recordId,
 		},
 		search: EMPTY_ADMIN_DETAIL_SEARCH,
 		to: "/admin/$entitytype/$recordid",

--- a/src/lib/admin-relation-navigation.ts
+++ b/src/lib/admin-relation-navigation.ts
@@ -1,0 +1,112 @@
+import { getAdminEntityForObjectDef } from "#/components/admin/shell/entity-registry";
+import type { SidebarRecordRef } from "#/components/admin/shell/RecordSidebarProvider";
+import { EMPTY_ADMIN_DETAIL_SEARCH } from "#/lib/admin-detail-search";
+import {
+	type DedicatedAdminRecordRoute,
+	getDedicatedAdminRecordRoute,
+	isDedicatedAdminEntityType,
+} from "#/lib/admin-entity-routes";
+import type { Doc } from "../../convex/_generated/dataModel";
+
+type ObjectDefSummary = Pick<
+	Doc<"objectDefs">,
+	"_id" | "name" | "nativeTable" | "pluralLabel" | "singularLabel"
+>;
+
+export type AdminRelationPresentation = "page" | "sheet";
+
+export interface AdminRelationNavigationTarget {
+	objectDefId: string;
+	recordId: string;
+	recordKind: "record" | "native";
+}
+
+export type AdminRecordRouteTarget =
+	| {
+			params: {
+				recordid: string;
+			};
+			search: typeof EMPTY_ADMIN_DETAIL_SEARCH;
+			to: DedicatedAdminRecordRoute;
+	  }
+	| {
+			params: {
+				entitytype: string;
+				recordid: string;
+			};
+			search: typeof EMPTY_ADMIN_DETAIL_SEARCH;
+			to: "/admin/$entitytype/$recordid";
+	  };
+
+export function resolveAdminRelationReference(args: {
+	objectDefs?: readonly ObjectDefSummary[];
+	target: AdminRelationNavigationTarget;
+}): SidebarRecordRef {
+	const objectDef = args.objectDefs?.find(
+		(candidate) => String(candidate._id) === args.target.objectDefId
+	);
+	const entityType = objectDef
+		? getAdminEntityForObjectDef(objectDef)?.entityType
+		: undefined;
+
+	return {
+		entityType,
+		objectDefId: args.target.objectDefId,
+		recordId: args.target.recordId,
+		recordKind: args.target.recordKind,
+	};
+}
+
+export function resolveAdminRecordRouteTarget(
+	reference: Pick<SidebarRecordRef, "entityType" | "recordId">
+): AdminRecordRouteTarget | null {
+	if (!reference.entityType) {
+		return null;
+	}
+
+	if (isDedicatedAdminEntityType(reference.entityType)) {
+		return {
+			params: {
+				recordid: reference.recordId,
+			},
+			search: EMPTY_ADMIN_DETAIL_SEARCH,
+			to: getDedicatedAdminRecordRoute(reference.entityType),
+		};
+	}
+
+	return {
+		params: {
+			entitytype: reference.entityType,
+			recordid: reference.recordId,
+		},
+		search: EMPTY_ADMIN_DETAIL_SEARCH,
+		to: "/admin/$entitytype/$recordid",
+	};
+}
+
+export function navigateToAdminRelation(args: {
+	navigate: (target: AdminRecordRouteTarget) => void;
+	objectDefs?: readonly ObjectDefSummary[];
+	onBeforePageNavigation?: () => void;
+	presentation: AdminRelationPresentation;
+	pushToSidebar?: ((record: SidebarRecordRef) => void) | undefined;
+	target: AdminRelationNavigationTarget;
+}) {
+	const reference = resolveAdminRelationReference({
+		objectDefs: args.objectDefs,
+		target: args.target,
+	});
+
+	if (args.presentation === "sheet" && args.pushToSidebar) {
+		args.pushToSidebar(reference);
+		return;
+	}
+
+	const routeTarget = resolveAdminRecordRouteTarget(reference);
+	if (!routeTarget) {
+		return;
+	}
+
+	args.onBeforePageNavigation?.();
+	args.navigate(routeTarget);
+}

--- a/src/lib/admin-view-context.ts
+++ b/src/lib/admin-view-context.ts
@@ -52,7 +52,9 @@ export function resolveAdminObjectDef(
 	const normalizedEntityType = entityType.trim().toLowerCase();
 
 	return objectDefs.find((objectDef) => {
-		if (getAdminEntityForObjectDef(objectDef)?.entityType === entityType) {
+		if (
+			getAdminEntityForObjectDef(objectDef)?.entityType === normalizedEntityType
+		) {
 			return true;
 		}
 

--- a/src/lib/admin-view-context.ts
+++ b/src/lib/admin-view-context.ts
@@ -2,6 +2,7 @@ import {
 	type AdminEntity,
 	getAdminEntityByType,
 	getAdminEntityForObjectDef,
+	resolveAdminEntityTypeForObjectDef,
 } from "#/components/admin/shell/entity-registry";
 import type { Doc } from "../../convex/_generated/dataModel";
 import type { UserSavedViewDefinition } from "../../convex/crm/types";
@@ -48,10 +49,31 @@ export function resolveAdminObjectDef(
 	entityType: string,
 	objectDefs: readonly ObjectDef[]
 ): ObjectDef | undefined {
-	return objectDefs.find(
-		(objectDef) =>
-			getAdminEntityForObjectDef(objectDef)?.entityType === entityType
-	);
+	const normalizedEntityType = entityType.trim().toLowerCase();
+
+	return objectDefs.find((objectDef) => {
+		if (getAdminEntityForObjectDef(objectDef)?.entityType === entityType) {
+			return true;
+		}
+
+		const fallbackEntityType = resolveAdminEntityTypeForObjectDef(objectDef);
+		if (fallbackEntityType === normalizedEntityType) {
+			return true;
+		}
+
+		return [
+			objectDef.name,
+			objectDef.nativeTable,
+			objectDef.pluralLabel,
+			objectDef.singularLabel,
+		]
+			.flatMap((candidate) =>
+				typeof candidate === "string" && candidate.trim().length > 0
+					? [candidate.trim().toLowerCase()]
+					: []
+			)
+			.includes(normalizedEntityType);
+	});
 }
 
 export function findDefaultUserSavedView(

--- a/src/routes/admin/$entitytype.$recordid.tsx
+++ b/src/routes/admin/$entitytype.$recordid.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { AdminRecordDetailPage } from "#/components/admin/shell/AdminRecordDetailPage";
 import { AdminNotFoundState } from "#/components/admin/shell/AdminRouteStates";
-import { isAdminEntityType } from "#/lib/admin-entities";
+import { isReservedAdminRouteSegment } from "#/lib/admin-entities";
 
 export const Route = createFileRoute("/admin/$entitytype/$recordid")({
 	component: RouteComponent,
@@ -10,7 +10,7 @@ export const Route = createFileRoute("/admin/$entitytype/$recordid")({
 function RouteComponent() {
 	const { entitytype, recordid } = Route.useParams();
 
-	if (!isAdminEntityType(entitytype)) {
+	if (isReservedAdminRouteSegment(entitytype)) {
 		return <AdminNotFoundState entityType={entitytype} variant="entity" />;
 	}
 

--- a/src/routes/admin/$entitytype.tsx
+++ b/src/routes/admin/$entitytype.tsx
@@ -6,11 +6,11 @@ import {
 } from "@tanstack/react-router";
 import { AdminEntityViewPage } from "#/components/admin/shell/AdminEntityViewPage";
 import { EMPTY_ADMIN_DETAIL_SEARCH } from "#/lib/admin-detail-search";
-import { type AdminEntityType, isAdminEntityType } from "#/lib/admin-entities";
+import { isReservedAdminRouteSegment } from "#/lib/admin-entities";
 
 export const Route = createFileRoute("/admin/$entitytype")({
 	beforeLoad: ({ params }) => {
-		if (!isAdminEntityType(params.entitytype)) {
+		if (isReservedAdminRouteSegment(params.entitytype)) {
 			throw redirect({
 				to: "/admin",
 				search: EMPTY_ADMIN_DETAIL_SEARCH,
@@ -23,18 +23,10 @@ export const Route = createFileRoute("/admin/$entitytype")({
 function EntityList() {
 	const { entitytype } = Route.useParams();
 
-	if (!isAdminEntityType(entitytype)) {
-		return (
-			<div className="p-6 text-muted-foreground text-sm">
-				Unknown admin entity type: {entitytype}
-			</div>
-		);
-	}
-
 	return <TypedEntityList entityType={entitytype} />;
 }
 
-function TypedEntityList({ entityType }: { entityType: AdminEntityType }) {
+function TypedEntityList({ entityType }: { entityType: string }) {
 	const recordId = useMatch({
 		from: "/admin/$entitytype/$recordid",
 		select: (match) => match.params.recordid,

--- a/src/test/admin/admin-shell.test.ts
+++ b/src/test/admin/admin-shell.test.ts
@@ -5,7 +5,7 @@ import type {
 } from "../../../../convex/crm/types";
 import { isValidElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { FAIRLEND_STAFF_ORG_ID } from "../../../convex/constants";
 import {
 	buildAdminPreviewRecords,
@@ -16,6 +16,12 @@ import {
 	getAdminNavigationSections,
 	isAdminRouteActive,
 } from "#/components/admin/shell/entity-registry";
+import {
+	navigateToAdminRelation,
+	resolveAdminRecordRouteTarget,
+	resolveAdminRelationReference,
+} from "#/lib/admin-relation-navigation";
+import { EMPTY_ADMIN_DETAIL_SEARCH } from "#/lib/admin-detail-search";
 import { canAccessAdminPath } from "#/lib/auth";
 import { isAdminPathname } from "#/lib/admin-routes";
 
@@ -310,5 +316,90 @@ describe("admin shell helpers", () => {
 		expect(markup).toContain("Notes");
 		expect(markup.indexOf("Status")).toBeLessThan(markup.indexOf("IDV Status"));
 		expect(markup.indexOf("IDV Status")).toBeLessThan(markup.indexOf("Notes"));
+	});
+
+	it("resolves relation references from object metadata", () => {
+		const objectDef = buildBorrowerObjectDef();
+
+		expect(
+			resolveAdminRelationReference({
+				objectDefs: [objectDef],
+				target: {
+					objectDefId: String(objectDef._id),
+					recordId: "borrower_1",
+					recordKind: "native",
+				},
+			})
+		).toEqual({
+			entityType: "borrowers",
+			objectDefId: String(objectDef._id),
+			recordId: "borrower_1",
+			recordKind: "native",
+		});
+	});
+
+	it("builds dedicated admin detail routes for related records", () => {
+		expect(
+			resolveAdminRecordRouteTarget({
+				entityType: "borrowers",
+				recordId: "borrower_1",
+			})
+		).toEqual({
+			params: {
+				recordid: "borrower_1",
+			},
+			search: EMPTY_ADMIN_DETAIL_SEARCH,
+			to: "/admin/borrowers/$recordid",
+		});
+	});
+
+	it("prefers sidebar navigation for sheet-presented relation clicks", () => {
+		const navigate = vi.fn();
+		const pushToSidebar = vi.fn();
+		const objectDef = buildBorrowerObjectDef();
+
+		navigateToAdminRelation({
+			navigate,
+			objectDefs: [objectDef],
+			presentation: "sheet",
+			pushToSidebar,
+			target: {
+				objectDefId: String(objectDef._id),
+				recordId: "borrower_1",
+				recordKind: "native",
+			},
+		});
+
+		expect(pushToSidebar).toHaveBeenCalledWith({
+			entityType: "borrowers",
+			objectDefId: String(objectDef._id),
+			recordId: "borrower_1",
+			recordKind: "native",
+		});
+		expect(navigate).not.toHaveBeenCalled();
+	});
+
+	it("falls back to full-page navigation when sidebar state is unavailable", () => {
+		const navigate = vi.fn();
+		const objectDef = buildBorrowerObjectDef();
+
+		navigateToAdminRelation({
+			navigate,
+			objectDefs: [objectDef],
+			presentation: "sheet",
+			target: {
+				objectDefId: String(objectDef._id),
+				recordId: "borrower_1",
+				recordKind: "native",
+			},
+		});
+
+		expect(navigate).toHaveBeenCalledWith({
+			params: {
+				recordid: "borrower_1",
+			},
+			search: EMPTY_ADMIN_DETAIL_SEARCH,
+			to: "/admin/borrowers/$recordid",
+		});
 	});
 });

--- a/src/test/admin/admin-shell.test.ts
+++ b/src/test/admin/admin-shell.test.ts
@@ -101,6 +101,25 @@ function buildBorrowerRecord(): UnifiedRecord {
 	};
 }
 
+function buildLeadObjectDef(): Doc<"objectDefs"> {
+	return {
+		_id: "object_lead" as Id<"objectDefs">,
+		_creationTime: 0,
+		createdAt: 0,
+		createdBy: "user_test",
+		description: "Test lead object",
+		icon: "briefcase",
+		isActive: true,
+		isSystem: false,
+		name: "lead",
+		nativeTable: undefined,
+		orgId: "org_test",
+		pluralLabel: "Leads",
+		singularLabel: "Lead",
+		updatedAt: 0,
+	};
+}
+
 const FAIRLEND_ADMIN_CONTEXT = {
 	orgId: FAIRLEND_STAFF_ORG_ID,
 	permissions: ["admin:access"],
@@ -338,6 +357,26 @@ describe("admin shell helpers", () => {
 		});
 	});
 
+	it("resolves fallback relation references from object metadata", () => {
+		const objectDef = buildLeadObjectDef();
+
+		expect(
+			resolveAdminRelationReference({
+				objectDefs: [objectDef],
+				target: {
+					objectDefId: String(objectDef._id),
+					recordId: "lead_1",
+					recordKind: "record",
+				},
+			})
+		).toEqual({
+			entityType: "lead",
+			objectDefId: String(objectDef._id),
+			recordId: "lead_1",
+			recordKind: "record",
+		});
+	});
+
 	it("builds dedicated admin detail routes for related records", () => {
 		expect(
 			resolveAdminRecordRouteTarget({
@@ -350,6 +389,22 @@ describe("admin shell helpers", () => {
 			},
 			search: EMPTY_ADMIN_DETAIL_SEARCH,
 			to: "/admin/borrowers/$recordid",
+		});
+	});
+
+	it("builds generic admin detail routes for metadata-fallback related records", () => {
+		expect(
+			resolveAdminRecordRouteTarget({
+				entityType: "lead",
+				recordId: "lead_1",
+			})
+		).toEqual({
+			params: {
+				entitytype: "lead",
+				recordid: "lead_1",
+			},
+			search: EMPTY_ADMIN_DETAIL_SEARCH,
+			to: "/admin/$entitytype/$recordid",
 		});
 	});
 
@@ -400,6 +455,31 @@ describe("admin shell helpers", () => {
 			},
 			search: EMPTY_ADMIN_DETAIL_SEARCH,
 			to: "/admin/borrowers/$recordid",
+		});
+	});
+
+	it("falls back to generic full-page navigation for metadata-fallback relations", () => {
+		const navigate = vi.fn();
+		const objectDef = buildLeadObjectDef();
+
+		navigateToAdminRelation({
+			navigate,
+			objectDefs: [objectDef],
+			presentation: "sheet",
+			target: {
+				objectDefId: String(objectDef._id),
+				recordId: "lead_1",
+				recordKind: "record",
+			},
+		});
+
+		expect(navigate).toHaveBeenCalledWith({
+			params: {
+				entitytype: "lead",
+				recordid: "lead_1",
+			},
+			search: EMPTY_ADMIN_DETAIL_SEARCH,
+			to: "/admin/$entitytype/$recordid",
 		});
 	});
 });

--- a/src/test/admin/admin-shell.test.ts
+++ b/src/test/admin/admin-shell.test.ts
@@ -408,6 +408,15 @@ describe("admin shell helpers", () => {
 		});
 	});
 
+	it("returns null when the related record id is blank", () => {
+		expect(
+			resolveAdminRecordRouteTarget({
+				entityType: "borrowers",
+				recordId: "   ",
+			})
+		).toBeNull();
+	});
+
 	it("prefers sidebar navigation for sheet-presented relation clicks", () => {
 		const navigate = vi.fn();
 		const pushToSidebar = vi.fn();

--- a/src/test/admin/admin-view-context.test.ts
+++ b/src/test/admin/admin-view-context.test.ts
@@ -90,6 +90,7 @@ describe("admin view context helpers", () => {
 		});
 
 		expect(resolveAdminObjectDef("borrowers", [borrowers])).toEqual(borrowers);
+		expect(resolveAdminObjectDef("Borrowers", [borrowers])).toEqual(borrowers);
 	});
 
 	it("resolves metadata-fallback objects by fallback entity type", () => {

--- a/src/test/admin/admin-view-context.test.ts
+++ b/src/test/admin/admin-view-context.test.ts
@@ -92,6 +92,17 @@ describe("admin view context helpers", () => {
 		expect(resolveAdminObjectDef("borrowers", [borrowers])).toEqual(borrowers);
 	});
 
+	it("resolves metadata-fallback objects by fallback entity type", () => {
+		const leads = buildObjectDef({
+			name: "lead",
+			pluralLabel: "Leads",
+			singularLabel: "Lead",
+		});
+
+		expect(resolveAdminObjectDef("lead", [leads])).toEqual(leads);
+		expect(resolveAdminObjectDef("leads", [leads])).toEqual(leads);
+	});
+
 	it("prefers the default saved kanban view when one is active", () => {
 		const borrowers = buildObjectDef({
 			name: "borrower",

--- a/src/test/admin/field-renderer.test.tsx
+++ b/src/test/admin/field-renderer.test.tsx
@@ -1,5 +1,8 @@
 import type { Id } from "../../../convex/_generated/dataModel";
-import type { NormalizedFieldDefinition } from "../../../convex/crm/types";
+import type {
+	NormalizedFieldDefinition,
+	RelationCellDisplayValue,
+} from "../../../convex/crm/types";
 import { FieldRenderer } from "#/components/admin/shell/FieldRenderer";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
@@ -75,5 +78,40 @@ describe("FieldRenderer", () => {
 		expect(safeMarkup).toContain('href="https://fairlend.ca/"');
 		expect(unsafeMarkup).not.toContain("href=");
 		expect(unsafeMarkup).toContain("javascript:alert(&#x27;xss&#x27;)");
+	});
+
+	it("renders relation payloads as relation chips instead of raw json", () => {
+		const relationValue: RelationCellDisplayValue = {
+			cardinality: "many_to_many",
+			items: [
+				{
+					label: "12 Oak Street",
+					objectDefId: "object_property" as Id<"objectDefs">,
+					recordId: "property_1",
+					recordKind: "record",
+				},
+			],
+			kind: "relation",
+		};
+
+		const markup = renderToStaticMarkup(
+			<FieldRenderer
+				field={buildField({
+					fieldType: "text",
+					label: "Property",
+					name: "property",
+					relation: {
+						cardinality: "many_to_many",
+						targetObjectDefId: "object_property" as Id<"objectDefs">,
+					},
+					rendererHint: "relation",
+				})}
+				value={relationValue}
+			/>
+		);
+
+		expect(markup).toContain("12 Oak Street");
+		expect(markup).not.toContain("&quot;kind&quot;");
+		expect(markup).not.toContain("&quot;items&quot;");
 	});
 });

--- a/src/test/admin/relation-cell.test.tsx
+++ b/src/test/admin/relation-cell.test.tsx
@@ -84,4 +84,35 @@ describe("RelationCell", () => {
 		});
 		expect(onRowClick).not.toHaveBeenCalled();
 	});
+
+	it("renders all related records when toggling is disabled", () => {
+		render(
+			<RelationCell
+				allowToggle={false}
+				expanded
+				value={buildRelationValue(["Alpha", "Beta", "Gamma"])}
+				variant="detail"
+			/>
+		);
+
+		expect(screen.getByText("Alpha")).toBeTruthy();
+		expect(screen.getByText("Beta")).toBeTruthy();
+		expect(screen.getByText("Gamma")).toBeTruthy();
+		expect(screen.queryByText(/\+\d+ more/i)).toBeNull();
+		expect(screen.queryByText(/show less/i)).toBeNull();
+		expect(screen.queryByText(/\+\d+ more hidden/i)).toBeNull();
+	});
+
+	it("renders non-interactive chips when no navigation handler is provided", () => {
+		render(
+			<RelationCell
+				allowToggle={false}
+				value={buildRelationValue(["Alpha", "Beta"])}
+			/>
+		);
+
+		expect(screen.queryByRole("button", { name: /Alpha/i })).toBeNull();
+		expect(screen.getByText("Alpha")).toBeTruthy();
+		expect(screen.getByText("Beta")).toBeTruthy();
+	});
 });

--- a/src/test/admin/relation-cell.test.tsx
+++ b/src/test/admin/relation-cell.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import type { Id } from "../../../convex/_generated/dataModel";
+import type { RelationCellDisplayValue } from "../../../convex/crm/types";
+import { RelationCell } from "#/components/admin/shell/RelationCell";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+function buildRelationValue(labels: string[]): RelationCellDisplayValue {
+	return {
+		cardinality: "many_to_many",
+		items: labels.map((label, index) => ({
+			label,
+			objectDefId: `object_${String(index)}` as Id<"objectDefs">,
+			recordId: `record_${String(index)}`,
+			recordKind: "record" as const,
+		})),
+		kind: "relation",
+	};
+}
+
+afterEach(() => {
+	cleanup();
+});
+
+describe("RelationCell", () => {
+	it("supports single-open inline expansion within a shared surface", () => {
+		let expandedKey: string | null = null;
+		const renderHarness = () => (
+			<div>
+				<RelationCell
+					expanded={expandedKey === "first"}
+					onExpandedChange={(nextExpanded) => {
+						expandedKey = nextExpanded ? "first" : null;
+						view.rerender(renderHarness());
+					}}
+					value={buildRelationValue(["Alpha", "Beta", "Gamma"])}
+				/>
+				<RelationCell
+					expanded={expandedKey === "second"}
+					onExpandedChange={(nextExpanded) => {
+						expandedKey = nextExpanded ? "second" : null;
+						view.rerender(renderHarness());
+					}}
+					value={buildRelationValue(["Delta", "Epsilon"])}
+				/>
+			</div>
+		);
+		const view = render(renderHarness());
+
+		expect(screen.queryByText("Beta")).toBeNull();
+		fireEvent.click(screen.getByRole("button", { name: /\+2 more/i }));
+		expect(screen.getByText("Beta")).toBeTruthy();
+		expect(screen.getByText("Gamma")).toBeTruthy();
+
+		fireEvent.click(screen.getByRole("button", { name: /\+1 more/i }));
+		expect(screen.queryByText("Beta")).toBeNull();
+		expect(screen.getByText("Epsilon")).toBeTruthy();
+	});
+
+	it("stops chip clicks from bubbling to row handlers", () => {
+		const onNavigate = vi.fn();
+		const onRowClick = vi.fn();
+
+		const view = render(
+			<div onClick={onRowClick}>
+				<RelationCell
+					onNavigate={onNavigate}
+					value={buildRelationValue(["Alpha"])}
+				/>
+			</div>
+		);
+
+		fireEvent.click(
+			within(view.container).getByRole("button", { name: /Alpha/i })
+		);
+
+		expect(onNavigate).toHaveBeenCalledWith({
+			objectDefId: "object_0",
+			recordId: "record_0",
+			recordKind: "record",
+		});
+		expect(onRowClick).not.toHaveBeenCalled();
+	});
+});

--- a/src/test/admin/useAdminDetailSheet.test.ts
+++ b/src/test/admin/useAdminDetailSheet.test.ts
@@ -19,6 +19,14 @@ describe("getAdminDetailRouteState", () => {
 		});
 	});
 
+	it("parses metadata-fallback entity routes without the static admin registry", () => {
+		expect(getAdminDetailRouteState("/admin/lead/lead_123")).toEqual({
+			detailOpen: true,
+			entityType: "lead",
+			recordId: "lead_123",
+		});
+	});
+
 	it("keeps entity list routes closed", () => {
 		expect(getAdminDetailRouteState("/admin/listings")).toEqual({
 			detailOpen: false,
@@ -29,6 +37,11 @@ describe("getAdminDetailRouteState", () => {
 
 	it("ignores non-entity admin routes", () => {
 		expect(getAdminDetailRouteState("/admin/underwriting")).toEqual({
+			detailOpen: false,
+			entityType: undefined,
+			recordId: undefined,
+		});
+		expect(getAdminDetailRouteState("/admin/underwriting/request_1")).toEqual({
 			detailOpen: false,
 			entityType: undefined,
 			recordId: undefined,


### PR DESCRIPTION
Hydrate CRM relation cell payloads across table and detail views

fix(admin): support fallback relation routes

Align fallback entity resolution across relation navigation, generic admin routes, and detail route state so metadata-backed records can open on full detail pages when sidebar navigation is unavailable.

Add regression coverage for fallback route resolution and update the ENG-276 backend risk note with concrete impact and mitigation guidance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added rich relation field rendering across table, kanban, and detail views with typed cell payloads
  * Implemented inline multi-relation expansion with single-open-at-a-time behavior for space efficiency
  * Enabled cross-entity navigation from relation cells with sidebar and full-page routing support

* **Bug Fixes & Improvements**
  * Enhanced cell rendering to properly display scalar and relation field values without JSON serialization
  * Improved navigation fallback handling for related records across dedicated and generic entity types

* **Tests**
  * Added comprehensive backend tests for relation hydration coverage
  * Extended frontend test suite for expansion, navigation, and rendering behaviors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->